### PR TITLE
[NFC] Apply clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+QualifierAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1
+ExcludeHeaderFilterRegex: ".*third-party.*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
 WarningsAsErrors: '*'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-use-anonymous-namespace,-misc-include-cleaner,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+WarningsAsErrors: '*'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase

--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -22,4 +22,4 @@ jobs:
       Test-Clang: On
       TestTarget: check-hlsl-clang-d3d12
       OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -22,4 +22,4 @@ jobs:
       Test-Clang: On
       TestTarget: check-hlsl-clang-vk
       OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-intel-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-warp-d3d12.yaml
@@ -22,4 +22,4 @@ jobs:
       Test-Clang: On
       TestTarget: check-hlsl-clang-warp-d3d12
       OffloadTest-branch: ${{ github.event.pull_request.head.sha || github.ref }}
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,37 @@ set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS_BUILDTREE_ONLY png_static)
 
 include(Warp)
 
+# This must be after the third-party targets are generated so that we only apply
+# it to code in the offload-test-suite.
+option(OFFLOADTEST_USE_CLANG_TIDY "Use clang-tidy on offload test codebase" Off)
+option(OFFLOADTEST_CLANG_TIDY_APPLY_FIX "Automatically apply clang-tidy fixes" Off)
+
+if (OFFLOADTEST_USE_CLANG_TIDY)
+  find_program(CLANG_TIDY clang-tidy)
+  if (NOT CLANG_TIDY)
+    message(
+      FATAL_ERROR
+        "Clang-tidy not found in PATH, please specify CLANG_TIDY to CMake.")
+  endif ()
+  if (APPLE)
+    if (CMAKE_OSX_SYSROOT)
+      set(CLANG_TIDY_ARGS --extra-arg=-isysroot${CMAKE_OSX_SYSROOT})
+    elseif(NOT CMAKE_CROSSCOMPILING)
+      # xcrun -sdk macosx --show-sdk-path
+      execute_process(COMMAND xcrun -sdk macosx --show-sdk-path
+        OUTPUT_VARIABLE SYSROOT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      set(CLANG_TIDY_ARGS --extra-arg=-isysroot${SYSROOT})
+    endif()
+  endif()
+  if (OFFLOADTEST_CLANG_TIDY_APPLY_FIX)
+    set(CLANG_TIDY_ARGS ${CLANG_TIDY_ARGS} --fix)
+  endif ()
+  set(CMAKE_C_CLANG_TIDY ${CLANG_TIDY} ${CLANG_TIDY_ARGS})
+  set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY} ${CLANG_TIDY_ARGS})
+endif ()
+
 add_subdirectory(lib)
 add_subdirectory(tools)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ compiler to use by passing:
 -DDXC_DIR=<path to folder containing dxc & dxv>
 ```
 
+## Enabling clang-tidy
+
+The offload test suite's code is clang-tidy clean for a limited ruleset.
+If you have clang-tidy installed locally you can enable clang-tidy by adding `-DOFFLOADTEST_USE_CLANG_TIDY=On` to your CMake invocation.
+You can also add `-DOFFLOADTEST_CLANG_TIDY_APPLY_FIX=On` to enable automatically applying the clang-tidy fix-its for any warnings that have automated fixes.
+
 # YAML Pipeline Format
 
 This framework provides a YAML representation for describing GPU pipelines and buffers. The format is implemented by the `API/Pipeline.{h|cpp}` sources. The following is an example pipeline YAML description:

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -20,10 +20,10 @@ Alternatively, build and install the DirectX-Headers from the [original repo](ht
   - Fix: Use a newer version of DXC that includes the validator binary `dxv`
 - `double free or corruption (!prev)` may occur when `api-query` and `offloader` exit, which then follows with an infinite stall instead of program termination
   - A workaround is implemented which avoids this issue on normal program exit (i.e., `return 0;` from main)
-  - This issue appears to occur whenever `DeviceContext::Devices` from `lib/API/Device.cpp` contains more than one device. 
-    When `api-query` or `offloader` exit, some memory resources are failing to automatically free themselves. 
-    Valgrind output suggests the core issue stems from the implementation of `Microsoft::WRL::ComPtr::InternalRelease` in WSL. 
+  - This issue appears to occur whenever `DeviceContext::Devices` from `lib/API/Device.cpp` contains more than one device.
+    When `api-query` or `offloader` exit, some memory resources are failing to automatically free themselves.
+    Valgrind output suggests the core issue stems from the implementation of `Microsoft::WRL::ComPtr::InternalRelease` in WSL.
     Manually clearing `DeviceContext::Devices` before a program exit appears to eliminate the issue for the exit
-  - An additional workaround that would cover all possible program exit points is to only select one `DXDevice` by editing `lib/API/DX/Device.cpp` to `break;` at the end of the first iteration of the for-loop in the function `InitializeDXDevices()`
+  - An additional workaround that would cover all possible program exit points is to only select one `DXDevice` by editing `lib/API/DX/Device.cpp` to `break;` at the end of the first iteration of the for-loop in the function `initializeDXDevices()`
     - Before implementing this workaround, you can run `api-query` to list all GPU devices available. Afterwards, edit the `AdapterIndex` of the for-loop to select the index of the desired GPU
 

--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -12,6 +12,8 @@
 #ifndef OFFLOADTEST_API_DEVICE_H
 #define OFFLOADTEST_API_DEVICE_H
 
+#include "Config.h"
+
 #include "API/API.h"
 #include "API/Capabilities.h"
 #include "llvm/ADT/StringRef.h"
@@ -54,6 +56,18 @@ public:
   static DeviceIterator begin();
   static DeviceIterator end();
   static inline DeviceRange devices() { return DeviceRange(begin(), end()); }
+
+#ifdef OFFLOADTEST_ENABLE_D3D12
+  static llvm::Error initializeDXDevices();
+#endif
+
+#ifdef OFFLOADTEST_ENABLE_VULKAN
+  static llvm::Error initializeVXDevices();
+#endif
+
+#ifdef OFFLOADTEST_ENABLE_METAL
+  static llvm::Error initializeMtlDevices();
+#endif
 };
 
 } // namespace offloadtest

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -322,7 +322,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createPSO(Pipeline &P, llvm::StringRef DXIL,
+  llvm::Error createPSO(llvm::StringRef DXIL,
                         InvocationState &State) {
     const D3D12_COMPUTE_PIPELINE_STATE_DESC Desc = {
         State.RootSig.Get(),
@@ -887,7 +887,7 @@ public:
       CopyBackResource(R);
   }
 
-  llvm::Error readBack(Pipeline &P, InvocationState &IS) {
+  llvm::Error readBack(InvocationState &IS) {
     auto MemCpyBack = [](ResourcePair &R) -> llvm::Error {
       if (!R.first->isReadWrite())
         return llvm::Error::success();
@@ -947,7 +947,7 @@ public:
     if (auto Err = createDescriptorHeap(P, State))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
-    if (auto Err = createPSO(P, P.Shaders[0].Shader->getBuffer(), State))
+    if (auto Err = createPSO(P.Shaders[0].Shader->getBuffer(), State))
       return Err;
     llvm::outs() << "PSO created.\n";
     if (auto Err = createCommandStructures(State))
@@ -964,7 +964,7 @@ public:
     if (auto Err = executeCommandList(State))
       return Err;
     llvm::outs() << "Compute commands executed.\n";
-    if (auto Err = readBack(P, State))
+    if (auto Err = readBack(State))
       return Err;
     llvm::outs() << "Read data back.\n";
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -972,7 +972,7 @@ public:
 };
 } // namespace
 
-llvm::Error InitializeDXDevices() {
+llvm::Error Device::initializeDXDevices() {
 #ifdef _WIN32
 #ifndef NDEBUG
   ComPtr<ID3D12Debug1> Debug1;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -322,8 +322,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createPSO(llvm::StringRef DXIL,
-                        InvocationState &State) {
+  llvm::Error createPSO(llvm::StringRef DXIL, InvocationState &State) {
     const D3D12_COMPUTE_PIPELINE_STATE_DESC Desc = {
         State.RootSig.Get(),
         {DXIL.data(), DXIL.size()},

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -10,22 +10,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "API/Device.h"
+
 #include "Config.h"
+
 #include "llvm/Support/Error.h"
 
+#include <memory>
+
 using namespace offloadtest;
-
-#ifdef OFFLOADTEST_ENABLE_D3D12
-llvm::Error InitializeDXDevices();
-#endif
-
-#ifdef OFFLOADTEST_ENABLE_VULKAN
-llvm::Error InitializeVXDevices();
-#endif
-
-#ifdef OFFLOADTEST_ENABLE_METAL
-llvm::Error InitializeMTLDevices();
-#endif
 
 namespace {
 class DeviceContext {
@@ -41,7 +33,7 @@ private:
   DeviceContext(const DeviceContext &) = delete;
 
 public:
-  static DeviceContext &Instance() {
+  static DeviceContext &instance() {
     static DeviceContext Ctx;
     return Ctx;
   }
@@ -58,31 +50,31 @@ public:
 Device::~Device() {}
 
 void Device::registerDevice(std::shared_ptr<Device> D) {
-  DeviceContext::Instance().registerDevice(D);
+  DeviceContext::instance().registerDevice(D);
 }
 
 llvm::Error Device::initialize() {
 #ifdef OFFLOADTEST_ENABLE_D3D12
-  if (auto Err = InitializeDXDevices())
+  if (auto Err = initializeDXDevices())
     return Err;
 #endif
 #ifdef OFFLOADTEST_ENABLE_VULKAN
-  if (auto Err = InitializeVXDevices())
+  if (auto Err = initializeVXDevices())
     return Err;
 #endif
 #ifdef OFFLOADTEST_ENABLE_METAL
-  if (auto Err = InitializeMTLDevices())
+  if (auto Err = initializeMtlDevices())
     return Err;
 #endif
   return llvm::Error::success();
 }
 
 void Device::uninitialize() {
-  DeviceContext::Instance().unregisterDevices();
+  DeviceContext::instance().unregisterDevices();
 }
 
 Device::DeviceIterator Device::begin() {
-  return DeviceContext::Instance().begin();
+  return DeviceContext::instance().begin();
 }
 
-Device::DeviceIterator Device::end() { return DeviceContext::Instance().end(); }
+Device::DeviceIterator Device::end() { return DeviceContext::instance().end(); }

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -69,9 +69,7 @@ llvm::Error Device::initialize() {
   return llvm::Error::success();
 }
 
-void Device::uninitialize() {
-  DeviceContext::instance().unregisterDevices();
-}
+void Device::uninitialize() { DeviceContext::instance().unregisterDevices(); }
 
 Device::DeviceIterator Device::begin() {
   return DeviceContext::instance().begin();

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -21,7 +21,7 @@ using namespace offloadtest;
 static llvm::Error toError(NS::Error *Err) {
   if (!Err)
     return llvm::Error::success();
-  std::error_code const EC =
+  const std::error_code EC =
       std::error_code(static_cast<int>(Err->code()), std::system_category());
   llvm::SmallString<256> ErrMsg;
   llvm::raw_svector_ostream OS(ErrMsg);
@@ -86,7 +86,7 @@ class MTLDevice : public offloadtest::Device {
 
   llvm::Error loadShaders(InvocationState &IS, const Shader &P) {
     NS::Error *Error = nullptr;
-    llvm::StringRef const Program = P.Shader->getBuffer();
+    const llvm::StringRef Program = P.Shader->getBuffer();
     dispatch_data_t Data = dispatch_data_create(Program.data(), Program.size(),
                                                 dispatch_get_main_queue(),
                                                 ^{
@@ -118,7 +118,7 @@ class MTLDevice : public offloadtest::Device {
       IRDescriptorTableSetBufferView(&TablePtr[HeapIdx], &View);
       IS.Buffers.push_back(Buf);
     } else {
-      uint64_t const Width = R.size() / R.getElementSize();
+      const uint64_t Width = R.size() / R.getElementSize();
       MTL::TextureUsage UsageFlags = MTL::ResourceUsageRead;
       if (R.isReadWrite())
         UsageFlags |= MTL::ResourceUsageWrite;
@@ -140,7 +140,7 @@ class MTLDevice : public offloadtest::Device {
   }
 
   llvm::Error createBuffers(Pipeline &P, InvocationState &IS) {
-    size_t const TableSize =
+    const size_t TableSize =
         sizeof(IRDescriptorTableEntry) * P.getDescriptorCount();
     IS.ArgBuffer =
         Device->newBuffer(TableSize, MTL::ResourceStorageModeManaged);
@@ -170,12 +170,12 @@ class MTLDevice : public offloadtest::Device {
       CmdEncoder->useResource(IS.Buffers[I],
                               MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
 
-    NS::UInteger const TGS = IS.PipelineState->maxTotalThreadsPerThreadgroup();
-    llvm::ArrayRef<int> const DispatchSize =
+    const NS::UInteger TGS = IS.PipelineState->maxTotalThreadsPerThreadgroup();
+    const llvm::ArrayRef<int> DispatchSize =
         llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
-    MTL::Size const GridSize =
+    const MTL::Size GridSize =
         MTL::Size(TGS * DispatchSize[0], DispatchSize[1], DispatchSize[2]);
-    MTL::Size const GroupSize(TGS, 1, 1);
+    const MTL::Size GroupSize(TGS, 1, 1);
 
     CmdEncoder->dispatchThreads(GridSize, GroupSize);
     CmdEncoder->memoryBarrier(MTL::BarrierScopeBuffers);
@@ -198,7 +198,7 @@ class MTLDevice : public offloadtest::Device {
             memcpy(R.BufferPtr->Data.get(),
                    IS.Buffers[BufferIndex++]->contents(), R.size());
           } else {
-            uint64_t const Width = R.size() / R.getElementSize();
+            const uint64_t Width = R.size() / R.getElementSize();
             IS.Textures[TextureIndex++]->getBytes(
                 R.BufferPtr->Data.get(), 0, MTL::Region(0, 0, Width, 1), 0);
           }

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -58,9 +58,9 @@ class MTLDevice : public offloadtest::Device {
   struct InvocationState {
     InvocationState() { Pool = NS::AutoreleasePool::alloc()->init(); }
     ~InvocationState() {
-      for (auto *T : Textures)
+      for (MTL::Texture *T : Textures)
         T->release();
-      for (auto *B : Buffers)
+      for (MTL::Buffer *B : Buffers)
         B->release();
       if (Fn)
         Fn->release();

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -851,4 +851,6 @@ public:
 };
 } // namespace
 
-llvm::Error InitializeVXDevices() { return VKContext::instance().initialize(); }
+llvm::Error Device::initializeVXDevices() {
+  return VKContext::instance().initialize();
+}

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -127,7 +127,7 @@ private:
 public:
   VKDevice(VkPhysicalDevice D) : Device(D) {
     vkGetPhysicalDeviceProperties(Device, &Props);
-    uint64_t StrSz =
+    const uint64_t StrSz =
         strnlen(Props.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
     Description = std::string(Props.deviceName, StrSz);
   }
@@ -227,7 +227,7 @@ public:
     // Find a queue that supports compute
     uint32_t QueueCount = 0;
     vkGetPhysicalDeviceQueueFamilyProperties(Device, &QueueCount, 0);
-    std::unique_ptr<VkQueueFamilyProperties[]> QueueFamilyProps =
+    const std::unique_ptr<VkQueueFamilyProperties[]> QueueFamilyProps =
         std::unique_ptr<VkQueueFamilyProperties[]>(
             new VkQueueFamilyProperties[QueueCount]);
     vkGetPhysicalDeviceQueueFamilyProperties(Device, &QueueCount,
@@ -241,7 +241,7 @@ public:
                                      "No compute queue found.");
 
     VkDeviceQueueCreateInfo QueueInfo = {};
-    float QueuePriority = 0.0f;
+    const float QueuePriority = 0.0f;
     QueueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
     QueueInfo.queueFamilyIndex = QueueIdx;
     QueueInfo.queueCount = 1;
@@ -533,17 +533,18 @@ public:
         const Resource &R = P.Sets[SetIdx].Resources[RIdx];
         // This is a hack... need a better way to do this.
         VkBufferViewCreateInfo ViewCreateInfo = {};
-        bool IsRawOrUniform = R.isRaw();
-        VkFormat Format = IsRawOrUniform ? VK_FORMAT_UNDEFINED
-                                         : getVKFormat(R.BufferPtr->Format,
-                                                       R.BufferPtr->Channels);
+        const bool IsRawOrUniform = R.isRaw();
+        const VkFormat Format =
+            IsRawOrUniform
+                ? VK_FORMAT_UNDEFINED
+                : getVKFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
         ViewCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
         ViewCreateInfo.buffer = IS.Buffers[BufIdx].Device.Buffer;
         ViewCreateInfo.format = Format;
         ViewCreateInfo.range = VK_WHOLE_SIZE;
         if (IsRawOrUniform) {
-          VkDescriptorBufferInfo BI = {IS.Buffers[BufIdx].Device.Buffer, 0,
-                                       VK_WHOLE_SIZE};
+          const VkDescriptorBufferInfo BI = {IS.Buffers[BufIdx].Device.Buffer,
+                                             0, VK_WHOLE_SIZE};
           RawBufferInfos.push_back(BI);
         } else {
           IS.BufferViews.push_back(VkBufferView{0});
@@ -630,7 +631,7 @@ public:
     vkCmdBindDescriptorSets(IS.CmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
                             IS.PipelineLayout, 0, IS.DescriptorSets.size(),
                             IS.DescriptorSets.data(), 0, 0);
-    llvm::ArrayRef<int> DispatchSize =
+    const llvm::ArrayRef<int> DispatchSize =
         llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
     vkCmdDispatch(IS.CmdBuffer, DispatchSize[0], DispatchSize[1],
                   DispatchSize[2]);
@@ -670,7 +671,7 @@ public:
     uint32_t BufIdx = 0;
     for (auto &S : P.Sets) {
       for (int I = 0, E = S.Resources.size(); I < E; ++I, ++BufIdx) {
-        Resource &R = S.Resources[I];
+        const Resource &R = S.Resources[I];
         if (!R.isReadWrite())
           continue;
         void *Mapped = nullptr;
@@ -793,11 +794,11 @@ public:
     CreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     CreateInfo.pApplicationInfo = &AppInfo;
 
-    VkResult Res = vkCreateInstance(&CreateInfo, NULL, &Instance);
+    const VkResult Res = vkCreateInstance(&CreateInfo, NULL, &Instance);
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");
-    else if (Res)
+    if (Res)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Unkown Vulkan initialization error");
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -351,8 +351,7 @@ public:
     return BufferRef{Buffer, Memory};
   }
 
-  llvm::Error createBuffer(Resource &R, InvocationState &IS,
-                           const uint32_t HeapIdx) {
+  llvm::Error createBuffer(Resource &R, InvocationState &IS) {
     auto ExHostBuf = createBuffer(
         IS, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, R.size(), R.BufferPtr->Data.get());
@@ -381,7 +380,7 @@ public:
     uint32_t HeapIndex = 0;
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
-        if (auto Err = createBuffer(R, IS, HeapIndex++))
+        if (auto Err = createBuffer(R, IS))
           return Err;
       }
     }
@@ -828,7 +827,7 @@ public:
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");
-    else if (Res)
+    if (Res)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Unkown Vulkan initialization error");
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -377,7 +377,7 @@ public:
   }
 
   llvm::Error createBuffers(Pipeline &P, InvocationState &IS) {
-    uint32_t HeapIndex = 0;
+    const uint32_t HeapIndex = 0;
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
         if (auto Err = createBuffer(R, IS))

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -794,7 +794,7 @@ public:
     CreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     CreateInfo.pApplicationInfo = &AppInfo;
 
-    const VkResult Res = vkCreateInstance(&CreateInfo, NULL, &Instance);
+    VkResult Res = vkCreateInstance(&CreateInfo, NULL, &Instance);
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");

--- a/lib/Image/Color.cpp
+++ b/lib/Image/Color.cpp
@@ -32,7 +32,7 @@ static Color clampColor(const Color C) {
                std::clamp(C.B, 0.0, 1.0), C.Space);
 }
 
-static Color rgbToXyz(const Color Old) {
+static Color convertRGBToXYZ(const Color Old) {
   // Matrix assumes D65 white point.
   // Source: http://brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
   double Mat[] = {0.4124564, 0.3575761, 0.1804375, 0.2126729, 0.7151522,
@@ -40,7 +40,7 @@ static Color rgbToXyz(const Color Old) {
   return multiply(Old, Mat, ColorSpace::XYZ);
 }
 
-static Color xyzToRgb(const Color Old) {
+static Color convertXYZToRGB(const Color Old) {
   // Matrix assumes D65 white point.
   // Source: http://brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
   double Mat[] = {3.2404542, -1.5371385, -0.4985314, -0.9692660, 1.8760108,
@@ -92,12 +92,12 @@ Color Color::translateSpaceImpl(ColorSpace NewCS) {
     return *this;
   Color Tmp = *this;
   if (Space == ColorSpace::RGB)
-    Tmp = rgbToXyz(*this);
+    Tmp = convertRGBToXYZ(*this);
   else if (Space == ColorSpace::LAB)
     Tmp = labToXyz(*this);
   // Tmp is now in XYZ space.
   if (NewCS == ColorSpace::RGB)
-    return xyzToRgb(Tmp);
+    return convertXYZToRGB(Tmp);
   if (NewCS == ColorSpace::LAB)
     return xyzToLab(Tmp);
   return Tmp;

--- a/lib/Image/Color.cpp
+++ b/lib/Image/Color.cpp
@@ -55,18 +55,18 @@ static double convertXYZ(double Val) {
 }
 
 static Color xyzToLab(const Color Old) {
-  double const X = convertXYZ(Old.R / D65WhitePoint.R);
-  double const Y = convertXYZ(Old.G / D65WhitePoint.G);
-  double const Z = convertXYZ(Old.B / D65WhitePoint.B);
+  const double X = convertXYZ(Old.R / D65WhitePoint.R);
+  const double Y = convertXYZ(Old.G / D65WhitePoint.G);
+  const double Z = convertXYZ(Old.B / D65WhitePoint.B);
 
-  double const L = fmax(0.0, 116.0 * Y - 16.0);
-  double const A = 500 * (X - Y);
-  double const B = 200 * (Y - Z);
+  const double L = fmax(0.0, 116.0 * Y - 16.0);
+  const double A = 500 * (X - Y);
+  const double B = 200 * (Y - Z);
   return Color(L, A, B, ColorSpace::LAB);
 }
 
 static double convertLAB(double Val) {
-  double const ValPow3 = pow(Val, 3.0);
+  const double ValPow3 = pow(Val, 3.0);
   if (ValPow3 > 0.008856)
     return ValPow3;
 

--- a/lib/Image/Color.cpp
+++ b/lib/Image/Color.cpp
@@ -54,7 +54,7 @@ static double convertXYZ(double Val) {
   return Val > E ? pow(Val, 1.0 / 3.0) : (K * Val + 16.0) / 116.0;
 }
 
-static Color xyzToLab(const Color Old) {
+static Color convertXYZToLAB(const Color Old) {
   const double X = convertXYZ(Old.R / D65WhitePoint.R);
   const double Y = convertXYZ(Old.G / D65WhitePoint.G);
   const double Z = convertXYZ(Old.B / D65WhitePoint.B);
@@ -75,7 +75,7 @@ static double convertLAB(double Val) {
   return (Val - V) / K;
 }
 
-static Color labToXyz(const Color Old) {
+static Color convertLABToXYZ(const Color Old) {
   double Y = (Old.R + 16) / 116;
   double X = Old.G / 500 + Y;
   double Z = Y - Old.B / 200;
@@ -94,11 +94,11 @@ Color Color::translateSpaceImpl(ColorSpace NewCS) {
   if (Space == ColorSpace::RGB)
     Tmp = convertRGBToXYZ(*this);
   else if (Space == ColorSpace::LAB)
-    Tmp = labToXyz(*this);
+    Tmp = convertLABToXYZ(*this);
   // Tmp is now in XYZ space.
   if (NewCS == ColorSpace::RGB)
     return convertXYZToRGB(Tmp);
   if (NewCS == ColorSpace::LAB)
-    return xyzToLab(Tmp);
+    return convertXYZToLAB(Tmp);
   return Tmp;
 }

--- a/lib/Image/Image.cpp
+++ b/lib/Image/Image.cpp
@@ -26,9 +26,10 @@
 using namespace offloadtest;
 
 template <typename DstType, typename SrcType>
-void TranslatePixelData(Image &Dst, ImageRef Src, bool ForWrite) {
-  uint64_t Pixels = Dst.getHeight() * Dst.getWidth();
-  uint32_t CopiedChannels = std::min(Dst.getChannels(), Src.getChannels());
+static void translatePixelData(Image &Dst, ImageRef Src, bool ForWrite) {
+  uint64_t const Pixels = Dst.getHeight() * Dst.getWidth();
+  uint32_t const CopiedChannels =
+      std::min(Dst.getChannels(), Src.getChannels());
   DstType *DstPtr = reinterpret_cast<DstType *>(Dst.data());
   const SrcType *SrcPtr = reinterpret_cast<const SrcType *>(Src.data());
   for (uint64_t I = 0; I < Pixels; ++I) {
@@ -53,35 +54,35 @@ void TranslatePixelData(Image &Dst, ImageRef Src, bool ForWrite) {
 }
 
 template <typename SrcType>
-void translatePixelSrc(Image &Dst, ImageRef Src, bool ForWrite) {
+static void translatePixelSrc(Image &Dst, ImageRef Src, bool ForWrite) {
 
   switch (Dst.getDepth()) {
   case 1:
     assert(!Dst.isFloat() && "No float8 support!");
-    TranslatePixelData<uint8_t, SrcType>(Dst, Src, ForWrite);
+    translatePixelData<uint8_t, SrcType>(Dst, Src, ForWrite);
     break;
   case 2:
     assert(!Dst.isFloat() && "No float16 support!");
-    TranslatePixelData<uint16_t, SrcType>(Dst, Src, ForWrite);
+    translatePixelData<uint16_t, SrcType>(Dst, Src, ForWrite);
     break;
   case 4:
     if (Dst.isFloat())
-      TranslatePixelData<float, SrcType>(Dst, Src, ForWrite);
+      translatePixelData<float, SrcType>(Dst, Src, ForWrite);
     else
-      TranslatePixelData<uint32_t, SrcType>(Dst, Src, ForWrite);
+      translatePixelData<uint32_t, SrcType>(Dst, Src, ForWrite);
     break;
   case 8:
     if (Dst.isFloat())
-      TranslatePixelData<double, SrcType>(Dst, Src, ForWrite);
+      translatePixelData<double, SrcType>(Dst, Src, ForWrite);
     else
-      TranslatePixelData<uint64_t, SrcType>(Dst, Src, ForWrite);
+      translatePixelData<uint64_t, SrcType>(Dst, Src, ForWrite);
     break;
   default:
     llvm_unreachable("Destination depth out of expected range.");
   }
 }
 
-void translatePixels(Image &Dst, ImageRef Src, bool ForWrite = false) {
+static void translatePixels(Image &Dst, ImageRef Src, bool ForWrite = false) {
   switch (Src.getDepth()) {
   case 1:
     assert(!Src.isFloat() && "No float8 support!");
@@ -116,7 +117,7 @@ Image Image::translateImage(ImageRef Src, uint8_t Depth, uint8_t Channels,
   return NewImage;
 }
 
-llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
+static llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
   png_structp PNG =
       png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
   if (!PNG)
@@ -136,7 +137,7 @@ llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
   F = fopen(OutputPath.data(), "wb");
   if (!F)
     return llvm::createStringError(std::errc::io_error, "Failed openiong file");
-  unsigned ImgFormat =
+  unsigned const ImgFormat =
       Img.getChannels() == 4 ? PNG_COLOR_TYPE_RGB_ALPHA : PNG_COLOR_TYPE_RGB;
   assert((Img.getChannels() == 3 || Img.getChannels() == 4) &&
          "Only support RGB and RGBA images.");
@@ -155,7 +156,7 @@ llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
 
   png_bytepp Rows =
       (png_bytepp)png_malloc(PNG, Img.getHeight() * sizeof(png_bytep));
-  uint64_t RowSize = Img.getWidth() * Img.getChannels() * Img.getDepth();
+  uint64_t const RowSize = Img.getWidth() * Img.getChannels() * Img.getDepth();
   // Step one row back from the end
   const uint8_t *Row = reinterpret_cast<const uint8_t *>(Img.data()) +
                        (RowSize * Img.getHeight()) - RowSize;
@@ -169,7 +170,7 @@ llvm::Error writePNGImpl(ImageRef Img, llvm::StringRef OutputPath) {
 }
 
 llvm::Error Image::writePNG(ImageRef Img, llvm::StringRef Path) {
-  uint32_t NewDepth = std::min(static_cast<uint32_t>(Img.getDepth()), 2u);
+  uint32_t const NewDepth = std::min(static_cast<uint32_t>(Img.getDepth()), 2u);
 
   // If the image depth is > 1, we need to translate it to get the right
   // endianness.
@@ -194,7 +195,7 @@ llvm::Expected<Image> Image::loadPNG(llvm::StringRef Path) {
   auto ScopeExit = llvm::make_scope_exit([&PNG]() { png_image_free(&PNG); });
 
   PNG.format = PNG_FORMAT_RGB;
-  size_t Size = PNG_IMAGE_SIZE(PNG);
+  size_t const Size = PNG_IMAGE_SIZE(PNG);
   std::unique_ptr<char[]> Buffer = std::make_unique<char[]>(Size);
 
   if (png_image_finish_read(&PNG, NULL /*background*/,
@@ -202,9 +203,9 @@ llvm::Expected<Image> Image::loadPNG(llvm::StringRef Path) {
                             0 /*row_stride*/, NULL /*colormap*/) == 0)
     return llvm::createStringError(std::errc::io_error,
                                    "Failed reading PNG data from file");
-  uint32_t BytesPerPixel =
+  uint32_t const BytesPerPixel =
       static_cast<uint32_t>(Size / (PNG.height * PNG.width));
-  uint32_t Channels = 3;
+  uint32_t const Channels = 3;
   Image Result =
       Image(PNG.height, PNG.width, /*Depth*/ BytesPerPixel / Channels, Channels,
             false, std::move(Buffer));
@@ -222,8 +223,8 @@ Image::compareImages(ImageRef LHS, ImageRef RHS,
          "Cannot operate on images with less than 3 channels.");
   assert(RHS.getChannels() >= 3 &&
          "Cannot operate on images with less than 3 channels.");
-  uint32_t CmpDepth = 4;
-  uint32_t CmpChannels = 3u;
+  uint32_t const CmpDepth = 4;
+  uint32_t const CmpChannels = 3u;
 
   Image L = Image::translateImage(LHS, CmpDepth, CmpChannels, true);
   Image R = Image::translateImage(RHS, CmpDepth, CmpChannels, true);
@@ -231,11 +232,11 @@ Image::compareImages(ImageRef LHS, ImageRef RHS,
   const float *LPtr = reinterpret_cast<const float *>(L.data());
   const float *RPtr = reinterpret_cast<const float *>(R.data());
 
-  uint64_t PixelCt = static_cast<uint64_t>(LHS.getHeight()) *
-                     static_cast<uint64_t>(LHS.getWidth());
+  uint64_t const PixelCt = static_cast<uint64_t>(LHS.getHeight()) *
+                           static_cast<uint64_t>(LHS.getWidth());
   for (uint64_t I = 0; I < PixelCt; ++I, LPtr += 3, RPtr += 3) {
-    Color L = Color(LPtr[0], LPtr[1], LPtr[2]);
-    Color R = Color(RPtr[0], RPtr[1], RPtr[2]);
+    Color const L = Color(LPtr[0], LPtr[1], LPtr[2]);
+    Color const R = Color(RPtr[0], RPtr[1], RPtr[2]);
     for (auto &Cmp : Comparators)
       Cmp.processPixel(L, R);
   }

--- a/lib/Image/ImageComparators.cpp
+++ b/lib/Image/ImageComparators.cpp
@@ -46,8 +46,8 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
     }
     return true;
   case CompareCheck::PixelPercent: {
-    double const DiffPercent = (static_cast<double>(VisibleDiffs) /
-                          static_cast<double>(Count) * 100.0);
+    const double DiffPercent = (static_cast<double>(VisibleDiffs) /
+                                static_cast<double>(Count) * 100.0);
     if (DiffPercent > C.Val) {
       Err << "PixelPercent check failed. Difference percent " << DiffPercent
           << " above threshold " << C.Val;
@@ -56,7 +56,7 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
     return true;
   }
   case CompareCheck::Intervals: {
-    double const DblCount = static_cast<double>(Count);
+    const double DblCount = static_cast<double>(Count);
     for (uint32_t I = 0; I < 10; ++I) {
       if (I >= C.Vals.size()) {
         if (Histogram[I] == 0)
@@ -66,7 +66,7 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
         return false;
       }
 
-      double const DiffPercent =
+      const double DiffPercent =
           (static_cast<double>(Histogram[I]) / DblCount * 100.0);
       if (DiffPercent > C.Vals[I]) {
         Err << "Interval[" << I << "]: Out of range. Maximum: " << C.Vals[I]

--- a/lib/Image/ImageComparators.cpp
+++ b/lib/Image/ImageComparators.cpp
@@ -46,7 +46,7 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
     }
     return true;
   case CompareCheck::PixelPercent: {
-    double DiffPercent = (static_cast<double>(VisibleDiffs) /
+    double const DiffPercent = (static_cast<double>(VisibleDiffs) /
                           static_cast<double>(Count) * 100.0);
     if (DiffPercent > C.Val) {
       Err << "PixelPercent check failed. Difference percent " << DiffPercent
@@ -56,7 +56,7 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
     return true;
   }
   case CompareCheck::Intervals: {
-    double DblCount = static_cast<double>(Count);
+    double const DblCount = static_cast<double>(Count);
     for (uint32_t I = 0; I < 10; ++I) {
       if (I >= C.Vals.size()) {
         if (Histogram[I] == 0)
@@ -66,7 +66,7 @@ bool ImageComparatorDistance::evaluateCheck(const CompareCheck &C,
         return false;
       }
 
-      double DiffPercent =
+      double const DiffPercent =
           (static_cast<double>(Histogram[I]) / DblCount * 100.0);
       if (DiffPercent > C.Vals[I]) {
         Err << "Interval[" << I << "]: Out of range. Maximum: " << C.Vals[I]

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -33,8 +33,8 @@ static bool compareFloatULP(const float &FSrc, const float &FRef,
   }
   // For FTZ or Preserve mode, we should get the expected number within
   // ULPTolerance for any operations.
-  int const Diff = *((const uint32_t *)&FSrc) - *((const uint32_t *)&FRef);
-  unsigned int const AbsDiff = Diff < 0 ? -Diff : Diff;
+  const int Diff = *((const uint32_t *)&FSrc) - *((const uint32_t *)&FRef);
+  const unsigned int AbsDiff = Diff < 0 ? -Diff : Diff;
   return AbsDiff <= ULPTolerance;
 }
 
@@ -45,8 +45,8 @@ static bool compareFloat16ULP(const uint16_t &FSrc, const uint16_t &FRef,
   if (isFloat16NAN(FSrc) || isFloat16NAN(FRef))
     return isFloat16NAN(FRef) && isFloat16NAN(FSrc);
   // 16-bit floating point numbers must preserve denorms
-  int const Diff = FSrc - FRef;
-  unsigned int const AbsDiff = Diff < 0 ? -Diff : Diff;
+  const int Diff = FSrc - FRef;
+  const unsigned int AbsDiff = Diff < 0 ? -Diff : Diff;
   return AbsDiff <= ULPTolerance;
 }
 
@@ -66,12 +66,12 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
   case offloadtest::DataFormat::Float32: {
     if (B1->Size != B2->Size)
       return false;
-    llvm::ArrayRef<float> const Arr1(reinterpret_cast<float *>(B1->Data.get()),
-                               B1->Size / sizeof(float));
+    const llvm::ArrayRef<float> Arr1(reinterpret_cast<float *>(B1->Data.get()),
+                                     B1->Size / sizeof(float));
     assert(B2->Format == offloadtest::DataFormat::Float32 &&
            "Buffer types must be the same");
-    llvm::ArrayRef<float> const Arr2(reinterpret_cast<float *>(B2->Data.get()),
-                               B2->Size / sizeof(float));
+    const llvm::ArrayRef<float> Arr2(reinterpret_cast<float *>(B2->Data.get()),
+                                     B2->Size / sizeof(float));
     for (unsigned I = 0, E = Arr1.size(); I < E; ++I) {
       if (!compareFloatULP(Arr1[I], Arr2[I], ULPT, DM))
         return false;
@@ -81,12 +81,14 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
   case offloadtest::DataFormat::Float16: {
     if (B1->Size != B2->Size)
       return false;
-    llvm::ArrayRef<uint16_t> const Arr1(reinterpret_cast<uint16_t *>(B1->Data.get()),
-                                  B1->Size / sizeof(uint16_t));
+    const llvm::ArrayRef<uint16_t> Arr1(
+        reinterpret_cast<uint16_t *>(B1->Data.get()),
+        B1->Size / sizeof(uint16_t));
     assert(B2->Format == offloadtest::DataFormat::Float16 &&
            "Buffer types must be the same");
-    llvm::ArrayRef<uint16_t> const Arr2(reinterpret_cast<uint16_t *>(B2->Data.get()),
-                                  B2->Size / sizeof(uint16_t));
+    const llvm::ArrayRef<uint16_t> Arr2(
+        reinterpret_cast<uint16_t *>(B2->Data.get()),
+        B2->Size / sizeof(uint16_t));
     for (unsigned I = 0, E = Arr1.size(); I < E; ++I) {
       if (!compareFloat16ULP(Arr1[I], Arr2[I], ULPT))
         return false;

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -33,8 +33,8 @@ static bool compareFloatULP(const float &FSrc, const float &FRef,
   }
   // For FTZ or Preserve mode, we should get the expected number within
   // ULPTolerance for any operations.
-  int Diff = *((const uint32_t *)&FSrc) - *((const uint32_t *)&FRef);
-  unsigned int AbsDiff = Diff < 0 ? -Diff : Diff;
+  int const Diff = *((const uint32_t *)&FSrc) - *((const uint32_t *)&FRef);
+  unsigned int const AbsDiff = Diff < 0 ? -Diff : Diff;
   return AbsDiff <= ULPTolerance;
 }
 
@@ -45,8 +45,8 @@ static bool compareFloat16ULP(const uint16_t &FSrc, const uint16_t &FRef,
   if (isFloat16NAN(FSrc) || isFloat16NAN(FRef))
     return isFloat16NAN(FRef) && isFloat16NAN(FSrc);
   // 16-bit floating point numbers must preserve denorms
-  int Diff = FSrc - FRef;
-  unsigned int AbsDiff = Diff < 0 ? -Diff : Diff;
+  int const Diff = FSrc - FRef;
+  unsigned int const AbsDiff = Diff < 0 ? -Diff : Diff;
   return AbsDiff <= ULPTolerance;
 }
 
@@ -66,11 +66,11 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
   case offloadtest::DataFormat::Float32: {
     if (B1->Size != B2->Size)
       return false;
-    llvm::ArrayRef<float> Arr1(reinterpret_cast<float *>(B1->Data.get()),
+    llvm::ArrayRef<float> const Arr1(reinterpret_cast<float *>(B1->Data.get()),
                                B1->Size / sizeof(float));
     assert(B2->Format == offloadtest::DataFormat::Float32 &&
            "Buffer types must be the same");
-    llvm::ArrayRef<float> Arr2(reinterpret_cast<float *>(B2->Data.get()),
+    llvm::ArrayRef<float> const Arr2(reinterpret_cast<float *>(B2->Data.get()),
                                B2->Size / sizeof(float));
     for (unsigned I = 0, E = Arr1.size(); I < E; ++I) {
       if (!compareFloatULP(Arr1[I], Arr2[I], ULPT, DM))
@@ -81,11 +81,11 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
   case offloadtest::DataFormat::Float16: {
     if (B1->Size != B2->Size)
       return false;
-    llvm::ArrayRef<uint16_t> Arr1(reinterpret_cast<uint16_t *>(B1->Data.get()),
+    llvm::ArrayRef<uint16_t> const Arr1(reinterpret_cast<uint16_t *>(B1->Data.get()),
                                   B1->Size / sizeof(uint16_t));
     assert(B2->Format == offloadtest::DataFormat::Float16 &&
            "Buffer types must be the same");
-    llvm::ArrayRef<uint16_t> Arr2(reinterpret_cast<uint16_t *>(B2->Data.get()),
+    llvm::ArrayRef<uint16_t> const Arr2(reinterpret_cast<uint16_t *>(B2->Data.get()),
                                   B2->Size / sizeof(uint16_t));
     for (unsigned I = 0, E = Arr1.size(); I < E; ++I) {
       if (!compareFloat16ULP(Arr1[I], Arr2[I], ULPT))

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -13,7 +13,7 @@
 
 using namespace offloadtest;
 
-bool isFloatingPointFormat(DataFormat Format) {
+static bool isFloatingPointFormat(DataFormat Format) {
   return Format == DataFormat::Float16 || Format == DataFormat::Float32;
 }
 

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -21,10 +21,10 @@ using namespace llvm;
 using namespace offloadtest;
 
 int main(int ArgC, char **ArgV) {
-  InitLLVM const X(ArgC, ArgV);
+  const InitLLVM X(ArgC, ArgV);
   cl::ParseCommandLineOptions(ArgC, ArgV, "GPU API Query Tool");
 
-  ExitOnError const ExitOnErr("api-query: error: ");
+  const ExitOnError ExitOnErr("api-query: error: ");
 
   if (auto Err = Device::initialize())
     logAllUnhandledErrors(std::move(Err), errs(), "api-query: error: ");

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -21,10 +21,10 @@ using namespace llvm;
 using namespace offloadtest;
 
 int main(int ArgC, char **ArgV) {
-  InitLLVM X(ArgC, ArgV);
+  InitLLVM const X(ArgC, ArgV);
   cl::ParseCommandLineOptions(ArgC, ArgV, "GPU API Query Tool");
 
-  ExitOnError ExitOnErr("api-query: error: ");
+  ExitOnError const ExitOnErr("api-query: error: ");
 
   if (auto Err = Device::initialize())
     logAllUnhandledErrors(std::move(Err), errs(), "api-query: error: ");

--- a/tools/imgdiff/imgdiff.cpp
+++ b/tools/imgdiff/imgdiff.cpp
@@ -46,9 +46,9 @@ static cl::opt<std::string> RulesFilename("rules", cl::desc("Rules filename"),
                                           cl::value_desc("filename"));
 
 int main(int ArgC, char **ArgV) {
-  InitLLVM const X(ArgC, ArgV);
+  const InitLLVM X(ArgC, ArgV);
   cl::ParseCommandLineOptions(ArgC, ArgV, "Image Comparison Tool");
-  ExitOnError const ExitOnErr("imgdiff: error: ");
+  const ExitOnError ExitOnErr("imgdiff: error: ");
 
   Image ExpectedImage = ExitOnErr(Image::loadPNG(ExpectedPath));
   Image ActualImage = ExitOnErr(Image::loadPNG(ActualPath));

--- a/tools/imgdiff/imgdiff.cpp
+++ b/tools/imgdiff/imgdiff.cpp
@@ -46,9 +46,9 @@ static cl::opt<std::string> RulesFilename("rules", cl::desc("Rules filename"),
                                           cl::value_desc("filename"));
 
 int main(int ArgC, char **ArgV) {
-  InitLLVM X(ArgC, ArgV);
+  InitLLVM const X(ArgC, ArgV);
   cl::ParseCommandLineOptions(ArgC, ArgV, "Image Comparison Tool");
-  ExitOnError ExitOnErr("imgdiff: error: ");
+  ExitOnError const ExitOnErr("imgdiff: error: ");
 
   Image ExpectedImage = ExitOnErr(Image::loadPNG(ExpectedPath));
   Image ActualImage = ExitOnErr(Image::loadPNG(ActualPath));

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -99,17 +99,16 @@ int run() {
         PipelineDesc.Shaders.size(), InputShader.size()));
 
   // Try to guess the API by reading the shader binary.
+  StringRef Binary = PipelineDesc.Shaders[0].Shader->getBuffer();
   if (APIToUse == GPUAPI::Unknown) {
-    if (PipelineDesc.Shaders[0].Shader->getBuffer().starts_with("DXBC")) {
+    if (Binary.starts_with("DXBC")) {
       APIToUse = GPUAPI::DirectX;
       outs() << "Using DirectX API\n";
-    } else if (*reinterpret_cast<const uint32_t *>(
-                   PipelineDesc.Shaders[0].Shader->getBuffer().data()) ==
+    } else if (*reinterpret_cast<const uint32_t *>(Binary.data()) ==
                0x07230203) {
       APIToUse = GPUAPI::Vulkan;
       outs() << "Using Vulkan API\n";
-    } else if (PipelineDesc.Shaders[0].Shader->getBuffer().starts_with(
-                   "MTLB")) {
+    } else if (Binary.starts_with("MTLB")) {
       APIToUse = GPUAPI::Metal;
       outs() << "Using Metal API\n";
     }

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -82,7 +82,7 @@ int run() {
   const ExitOnError ExitOnErr("gpu-exec: error: ");
   ExitOnErr(Device::initialize());
 
-  std::unique_ptr<MemoryBuffer> PipelineBuf = readFile(InputPipeline);
+  const std::unique_ptr<MemoryBuffer> PipelineBuf = readFile(InputPipeline);
   Pipeline PipelineDesc;
   yaml::Input YIn(PipelineBuf->getBuffer());
   YIn >> PipelineDesc;
@@ -104,10 +104,12 @@ int run() {
       APIToUse = GPUAPI::DirectX;
       outs() << "Using DirectX API\n";
     } else if (*reinterpret_cast<const uint32_t *>(
-                   PipelineDesc.Shaders[0].Shader->getBuffer().data()) == 0x07230203) {
+                   PipelineDesc.Shaders[0].Shader->getBuffer().data()) ==
+               0x07230203) {
       APIToUse = GPUAPI::Vulkan;
       outs() << "Using Vulkan API\n";
-    } else if (PipelineDesc.Shaders[0].Shader->getBuffer().starts_with("MTLB")) {
+    } else if (PipelineDesc.Shaders[0].Shader->getBuffer().starts_with(
+                   "MTLB")) {
       APIToUse = GPUAPI::Metal;
       outs() << "Using Metal API\n";
     }

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -58,7 +58,7 @@ static cl::opt<bool>
 static cl::opt<bool> UseWarp("warp", cl::desc("Use warp"));
 
 static std::unique_ptr<MemoryBuffer> readFile(const std::string &Path) {
-  ExitOnError const ExitOnErr("gpu-exec: error: ");
+  const ExitOnError ExitOnErr("gpu-exec: error: ");
   ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
       MemoryBuffer::getFileOrSTDIN(Path);
   ExitOnErr(errorCodeToError(FileOrErr.getError()));
@@ -69,7 +69,7 @@ static std::unique_ptr<MemoryBuffer> readFile(const std::string &Path) {
 static int run();
 
 int main(int ArgC, char **ArgV) {
-  InitLLVM const X(ArgC, ArgV);
+  const InitLLVM X(ArgC, ArgV);
   cl::ParseCommandLineOptions(ArgC, ArgV, "GPU Execution Tool");
 
   if (run())
@@ -79,7 +79,7 @@ int main(int ArgC, char **ArgV) {
 }
 
 int run() {
-  ExitOnError const ExitOnErr("gpu-exec: error: ");
+  const ExitOnError ExitOnErr("gpu-exec: error: ");
   ExitOnErr(Device::initialize());
 
   std::unique_ptr<MemoryBuffer> PipelineBuf = readFile(InputPipeline);
@@ -162,7 +162,7 @@ int run() {
     }
     for (const auto &B : PipelineDesc.Buffers) {
       if (B.Name == ImageOutput) {
-        ImageRef const Img = ImageRef(B);
+        const ImageRef Img = ImageRef(B);
         ExitOnErr(Image::writePNG(Img, OutputFilename));
         return 0;
       }

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -99,7 +99,7 @@ int run() {
         PipelineDesc.Shaders.size(), InputShader.size()));
 
   // Try to guess the API by reading the shader binary.
-  StringRef Binary = PipelineDesc.Shaders[0].Shader->getBuffer();
+  StringRef const Binary = PipelineDesc.Shaders[0].Shader->getBuffer();
   if (APIToUse == GPUAPI::Unknown) {
     if (Binary.starts_with("DXBC")) {
       APIToUse = GPUAPI::DirectX;

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -99,7 +99,7 @@ int run() {
         PipelineDesc.Shaders.size(), InputShader.size()));
 
   // Try to guess the API by reading the shader binary.
-  StringRef const Binary = PipelineDesc.Shaders[0].Shader->getBuffer();
+  const StringRef Binary = PipelineDesc.Shaders[0].Shader->getBuffer();
   if (APIToUse == GPUAPI::Unknown) {
     if (Binary.starts_with("DXBC")) {
       APIToUse = GPUAPI::DirectX;

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -57,8 +57,8 @@ static cl::opt<bool>
 
 static cl::opt<bool> UseWarp("warp", cl::desc("Use warp"));
 
-std::unique_ptr<MemoryBuffer> readFile(const std::string &Path) {
-  ExitOnError ExitOnErr("gpu-exec: error: ");
+static std::unique_ptr<MemoryBuffer> readFile(const std::string &Path) {
+  ExitOnError const ExitOnErr("gpu-exec: error: ");
   ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
       MemoryBuffer::getFileOrSTDIN(Path);
   ExitOnErr(errorCodeToError(FileOrErr.getError()));
@@ -66,10 +66,10 @@ std::unique_ptr<MemoryBuffer> readFile(const std::string &Path) {
   return std::move(FileOrErr.get());
 }
 
-int run();
+static int run();
 
 int main(int ArgC, char **ArgV) {
-  InitLLVM X(ArgC, ArgV);
+  InitLLVM const X(ArgC, ArgV);
   cl::ParseCommandLineOptions(ArgC, ArgV, "GPU Execution Tool");
 
   if (run())
@@ -79,7 +79,7 @@ int main(int ArgC, char **ArgV) {
 }
 
 int run() {
-  ExitOnError ExitOnErr("gpu-exec: error: ");
+  ExitOnError const ExitOnErr("gpu-exec: error: ");
   ExitOnErr(Device::initialize());
 
   std::unique_ptr<MemoryBuffer> PipelineBuf = readFile(InputPipeline);
@@ -162,7 +162,7 @@ int run() {
     }
     for (const auto &B : PipelineDesc.Buffers) {
       if (B.Name == ImageOutput) {
-        ImageRef Img = ImageRef(B);
+        ImageRef const Img = ImageRef(B);
         ExitOnErr(Image::writePNG(Img, OutputFilename));
         return 0;
       }

--- a/unittests/Image/ColorTests.cpp
+++ b/unittests/Image/ColorTests.cpp
@@ -11,11 +11,9 @@
 
 #include "Image/Color.h"
 
-#include "llvm/Support/raw_ostream.h"
-
 #include "gtest/gtest.h"
 
-#include <algorithm>
+#include <cstdint>
 
 using namespace offloadtest;
 


### PR DESCRIPTION
This PR configures clang-tidy to enforce a swath of rules that comply with and enforce LLVM's coding standards.

Two new CMake options are added:
* `OFFLOADTEST_USE_CLANG_TIDY` - When set to `On` this runs clang-tidy on non-third-party sources in the offload-test-suite as part of the build process.
* `OFFLOADTEST_CLANG_TIDY_APPLY_FIX` - When set to `On` passes `--fix` to `clang-tidy` to automatically apply fix-its for any issues that have fixes available (Requires `OFFLOADTEST_USE_CLANG_TIDY=On`).

The enabled warning set is:

`clang-diagnostic-*` - Clang compiler diagnostics.
`llvm-*` - LLVM coding standards
`misc-*` - All miscellaneous rules except:
* [misc-use-anonymous-namespace](https://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html), which violates LLVM coding standards which [prefers `static` for functions](https://llvm.org/docs/CodingStandards.html#restrict-visibility).
* [misc-include-cleaner](https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html), which did some unholy things to a few source files and caused them to fail to compile.
*[misc-non-private-member-variables-in-classes](https://clang.llvm.org/extra/clang-tidy/checks/misc/non-private-member-variables-in-classes.html), which conflicts with common patterns in LLVM code.

`readability-identifier-naming` - Apply [LLVM naming conventions](https://llvm.org/docs/CodingStandards.html#name-types-functions-variables-and-enumerators-properly)

Additionally this PR adds the `QualifierAlignment: Left` option to the `.clang-format` configuration because the clang-tidy [misc-const-correctness](https://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html) rule adds const to the right of the type which is less common in every codebase ever (Thank's Clang!).