### PR TITLE
Enable most of the vulkan tests under clang

### DIFF
--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -39,7 +39,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -39,6 +39,9 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/140739
+# UNSUPPORTED: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -40,7 +40,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -E CSMain -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/idiv-edges.test
+++ b/test/Basic/idiv-edges.test
@@ -56,7 +56,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -41,7 +41,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/simple.hlsl
 # RUN: %offloader %t/simple.yaml %t.o | FileCheck %s

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -41,6 +41,9 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/140739
+# UNSUPPORTED: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/simple.hlsl
 # RUN: %offloader %t/simple.yaml %t.o | FileCheck %s

--- a/test/Feature/HLSLLib/length.test
+++ b/test/Feature/HLSLLib/length.test
@@ -46,7 +46,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/HLSLLib/saturate.test
+++ b/test/Feature/HLSLLib/saturate.test
@@ -46,7 +46,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/StructuredBuffer/layout.test
+++ b/test/Feature/StructuredBuffer/layout.test
@@ -87,6 +87,7 @@ DescriptorSets:
 ...
 #--- end
 
+# clang-dxc doesn't support the -fvk-use-scalar-layout flag yet
 # UNSUPPORTED: Clang-Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/StructuredBuffer/srv.test
+++ b/test/Feature/StructuredBuffer/srv.test
@@ -44,7 +44,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/StructuredBuffer/srv.test
+++ b/test/Feature/StructuredBuffer/srv.test
@@ -44,6 +44,9 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/140739
+# UNSUPPORTED: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/StructuredBuffer/stride.test
+++ b/test/Feature/StructuredBuffer/stride.test
@@ -6,7 +6,7 @@ struct S {
 StructuredBuffer<float4> In : register(t0);
 RWStructuredBuffer<S> Out : register(u1);
 
-[numthreads(1,1,2)]
+[numthreads(2,1,1)]
 void main(uint GI : SV_GroupIndex) {
   Out[GI].i = In[GI];
 }
@@ -43,8 +43,6 @@ DescriptorSets:
         Binding: 1
 ...
 #--- end
-
-# UNSUPPORTED: Clang-Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Tools/Offloader/BufferExact-error.test
+++ b/test/Tools/Offloader/BufferExact-error.test
@@ -43,7 +43,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s
@@ -70,4 +69,3 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
-

--- a/test/Tools/Offloader/BufferExact.test
+++ b/test/Tools/Offloader/BufferExact.test
@@ -65,7 +65,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Tools/Offloader/BufferFuzzy-error.test
+++ b/test/Tools/Offloader/BufferFuzzy-error.test
@@ -43,7 +43,7 @@ Results:
   - Result: Test2 # Denorm value but mode isn't Any
     Rule: BufferFuzzy
     ULPT: 1
-    DenormMode: Preserve # same to use FTZ 
+    DenormMode: Preserve # same to use FTZ
     Actual: Out2
     Expected: Expected2
 DescriptorSets:
@@ -65,7 +65,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s

--- a/test/Tools/Offloader/BufferFuzzy.test
+++ b/test/Tools/Offloader/BufferFuzzy.test
@@ -57,7 +57,7 @@ Results:
   - Result: Test1 # Testing Expected is Denorm and Out is zero, and both have same sign bit
     Rule: BufferFuzzy
     ULPT: 1
-    DenormMode: Any 
+    DenormMode: Any
     Actual: Out1
     Expected: Expected1
   - Result: Test2 # Test two values are exactly the same
@@ -108,7 +108,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/UseCase/particle-life.test
+++ b/test/UseCase/particle-life.test
@@ -350,6 +350,7 @@ DescriptorSets:
 ...
 #--- end
 
+# clang-dxc doesn't support the -fvk-use-scalar-layout flag yet
 # UNSUPPORTED: Clang-Vulkan
 
 # CBuffer bindings seem to be broken under metal

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -65,10 +65,9 @@ DescriptorSets:
 
 #--- end
 
-# UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
 # RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
-# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.1 -Fo %t.o %t/source.hlsl %}
+# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.2 -Fo %t.o %t/source.hlsl %}
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # The behavior of this operation is consistent on Metal, so the test verifies that behavior.


### PR DESCRIPTION
This removes `UNSUPPORTED: Clang-Vulkan` from most of then tests that had it. These tests pass with top-of-tree LLVM.

There are a couple of places we need to keep unsupported tests for now:
- Tests that use -fvk-use-scalar-layout flag
- Tests that use the vk::binding attribute