### PR TITLE
Add tests for the dot4add functions

### DIFF
--- a/test/Feature/HLSLLib/dot4add.test
+++ b/test/Feature/HLSLLib/dot4add.test
@@ -7,14 +7,16 @@ RWStructuredBuffer<uint32_t> Result : register(u2);
 [numthreads(1,1,1)]
 void main() {
   // dot4add({1, 1, 1, 1}, {1, 2, -128, -86}, 0) = -211 = 0xFF2D
-  Result[0] = dot4add_i8packed(X[0], Y[0], 0u);
+  uint32_t R0 = dot4add_i8packed(X[0], Y[0], 0u);
+  Result[0] = R0;
   // dot4add({2, 4, 8, -1}, {2, 2, 2, 1}, -211) = -184 = 0xFF48
-  Result[1] = dot4add_i8packed(X[1], Y[1], Result[0]);
+  Result[1] = dot4add_i8packed(X[1], Y[1], R0);
 
   // dot4add({1, 1, 1, 1}, {1, 2, 128, 170}, 0) = 301 = 0x012D
-  Result[2] = dot4add_u8packed(X[0], Y[0], 0u);
+  uint32_t R1 = dot4add_u8packed(X[0], Y[0], 0u);
+  Result[2] = R1;
   // dot4add({2, 4, 8, 255}, {2, 2, 2, 1}, 301) = 584 = 0x0248
-  Result[3] = dot4add_u8packed(X[1], Y[1], Result[2]);
+  Result[3] = dot4add_u8packed(X[1], Y[1], R1);
 }
 
 //--- pipeline.yaml

--- a/test/Feature/HLSLLib/dot4add.test
+++ b/test/Feature/HLSLLib/dot4add.test
@@ -74,6 +74,9 @@ DescriptorSets:
 ...
 #--- end
 
+# We don't yet support PackedVectorFormat4x8Bit
+# UNSUPPORTED: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot4add.test
+++ b/test/Feature/HLSLLib/dot4add.test
@@ -1,0 +1,77 @@
+#--- source.hlsl
+
+StructuredBuffer<uint32_t> X : register(t0);
+StructuredBuffer<uint32_t> Y : register(t1);
+RWStructuredBuffer<uint32_t> Result : register(u2);
+
+[numthreads(1,1,1)]
+void main() {
+  // dot4add({1, 1, 1, 1}, {1, 2, -128, -86}, 0) = -211 = 0xFF2D
+  Result[0] = dot4add_i8packed(X[0], Y[0], 0u);
+  // dot4add({2, 4, 8, -1}, {2, 2, 2, 1}, -211) = -184 = 0xFF48
+  Result[1] = dot4add_i8packed(X[1], Y[1], Result[0]);
+
+  // dot4add({1, 1, 1, 1}, {1, 2, 128, 170}, 0) = 301 = 0x012D
+  Result[2] = dot4add_u8packed(X[0], Y[0], 0u);
+  // dot4add({2, 4, 8, 255}, {2, 2, 2, 1}, 301) = 584 = 0x0248
+  Result[3] = dot4add_u8packed(X[1], Y[1], Result[2]);
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X
+    Format: Hex32
+    Stride: 4
+    Data: [ 0x01010101, 0x020408FF ]
+  - Name: Y
+    Format: Hex32
+    Stride: 4
+    Data: [ 0x010280AA, 0x02020201 ]
+  - Name: Result
+    Format: Hex32
+    Stride: 4
+    ZeroInitSize: 16
+  - Name: ExpectedResult
+    Format: Hex32
+    Stride: 4
+    Data: [ 0xFFFFFF2D, 0xFFFFFF48, 0x0000012D, 0x00000248 ]
+Results:
+  - Result: CheckResult
+    Rule: BufferExact
+    Actual: Result
+    Expected: ExpectedResult
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Result
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
We test `dot4add_i8packed` and `dot4add_u8packed` on the same inputs, showing the difference in signed vs unsigned results.

Fixes #123 and #149.