### PR TITLE
Reduce intel builder schedule

### DIFF
--- a/.github/workflows/windows-intel-clang-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */2 * * *' # run every 2 hours
 
   pull_request:
     branches:

--- a/.github/workflows/windows-intel-clang-vk.yaml
+++ b/.github/workflows/windows-intel-clang-vk.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */2 * * *' # run every 2 hours
 
   pull_request:
     branches:

--- a/.github/workflows/windows-intel-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-clang-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */2 * * *' # run every 2 hours
 
   pull_request:
     branches:

--- a/.github/workflows/windows-intel-dxc-vk.yaml
+++ b/.github/workflows/windows-intel-dxc-vk.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */2 * * *' # run every 2 hours
 
   pull_request:
     branches:

--- a/.github/workflows/windows-intel-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-intel-dxc-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */2 * * *' # run every 2 hours
 
   pull_request:
     branches:


### PR DESCRIPTION
The intel builder is a single machine building 6 configurations... It just can't keep up. This reduces the scheduled builds to every 2 hours to help it stay on top of PRs.