### PR TITLE
Fix the code-format workflow

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -16,7 +16,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.repository == 'llvm-beanz/offload-test-suite'
+    if: github.repository == 'llvm/offload-test-suite'
     steps:
       - name: Fetch Test Suite sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The workflow was pointed at my username because that's where the repo was originally, now it should point at LLVM.