### PR TITLE
Implement ULP Comparison for doubles

### DIFF
--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -13,15 +13,17 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
-template<typename T>
-static bool isDenorm(T F) { return std::fpclassify(F) == FP_SUBNORMAL; }
+template <typename T> static bool isDenorm(T F) {
+  return std::fpclassify(F) == FP_SUBNORMAL;
+}
 
 static bool isFloat16NAN(uint16_t Val) {
   return (Val & 0x7c00) == 0x7c00 && (Val & 0x03ff) != 0;
 }
 
 static bool compareDoubleULP(const double &FSrc, const double &FRef,
-			      unsigned ULPTolerance, offloadtest::DenormMode DM) {
+                             unsigned ULPTolerance,
+                             offloadtest::DenormMode DM) {
   if (FSrc == FRef)
     return true;
   if (std::isnan(FSrc) || std::isnan(FRef))
@@ -40,7 +42,7 @@ static bool compareDoubleULP(const double &FSrc, const double &FRef,
 }
 
 static bool compareFloatULP(const float &FSrc, const float &FRef,
-			     unsigned ULPTolerance, offloadtest::DenormMode DM) {
+                            unsigned ULPTolerance, offloadtest::DenormMode DM) {
   if (FSrc == FRef)
     return true;
   if (std::isnan(FSrc) || std::isnan(FRef))
@@ -59,7 +61,7 @@ static bool compareFloatULP(const float &FSrc, const float &FRef,
 }
 
 static bool compareFloat16ULP(const uint16_t &FSrc, const uint16_t &FRef,
-			       unsigned ULPTolerance) {
+                              unsigned ULPTolerance) {
   if (FSrc == FRef)
     return true;
   if (isFloat16NAN(FSrc) || isFloat16NAN(FRef))
@@ -81,8 +83,8 @@ static bool testBufferExact(offloadtest::Buffer *B1, offloadtest::Buffer *B2) {
 }
 
 template <typename T>
-static bool testAll(std::function<bool(const T&, const T&)> fn,
-		    llvm::ArrayRef<T> Arr1, llvm::ArrayRef<T> Arr2) {
+static bool testAll(std::function<bool(const T &, const T &)> fn,
+                    llvm::ArrayRef<T> Arr1, llvm::ArrayRef<T> Arr2) {
   if (Arr1.size() != Arr2.size())
     return false;
 
@@ -98,12 +100,13 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
   assert(B1->Format == B2->Format && "Buffer types must be the same");
   switch (B1->Format) {
   case offloadtest::DataFormat::Float64: {
-    const llvm::ArrayRef<double> Arr1(reinterpret_cast<double *>(B1->Data.get()),
-				      B1->Size / sizeof(double));
-    const llvm::ArrayRef<double> Arr2(reinterpret_cast<double *>(B2->Data.get()),
-				      B2->Size / sizeof(double));
+    const llvm::ArrayRef<double> Arr1(
+        reinterpret_cast<double *>(B1->Data.get()), B1->Size / sizeof(double));
+    const llvm::ArrayRef<double> Arr2(
+        reinterpret_cast<double *>(B2->Data.get()), B2->Size / sizeof(double));
     auto fn = [ULPT, DM](const double &FS, const double &FR) {
-      return compareDoubleULP(FS, FR, ULPT, DM); };
+      return compareDoubleULP(FS, FR, ULPT, DM);
+    };
     return testAll<double>(fn, Arr1, Arr2);
   }
   case offloadtest::DataFormat::Float32: {
@@ -112,7 +115,8 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
     const llvm::ArrayRef<float> Arr2(reinterpret_cast<float *>(B2->Data.get()),
                                      B2->Size / sizeof(float));
     auto fn = [ULPT, DM](const float &FS, const float &FR) {
-      return compareFloatULP(FS, FR, ULPT, DM); };
+      return compareFloatULP(FS, FR, ULPT, DM);
+    };
     return testAll<float>(fn, Arr1, Arr2);
   }
   case offloadtest::DataFormat::Float16: {
@@ -123,7 +127,8 @@ static bool testBufferFuzzy(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
         reinterpret_cast<uint16_t *>(B2->Data.get()),
         B2->Size / sizeof(uint16_t));
     auto fn = [ULPT](const uint16_t &FS, const uint16_t &FR) {
-      return compareFloat16ULP(FS, FR, ULPT); };
+      return compareFloat16ULP(FS, FR, ULPT);
+    };
     return testAll<uint16_t>(fn, Arr1, Arr2);
   }
   default:

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -14,7 +14,8 @@
 using namespace offloadtest;
 
 static bool isFloatingPointFormat(DataFormat Format) {
-  return Format == DataFormat::Float16 || Format == DataFormat::Float32;
+  return Format == DataFormat::Float16 || Format == DataFormat::Float32 ||
+    Format == DataFormat::Float64;
 }
 
 namespace llvm {
@@ -49,6 +50,8 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
         if (!isFloatingPointFormat(R.ActualPtr->Format) ||
             !isFloatingPointFormat(R.ExpectedPtr->Format))
           I.setError(Twine("BufferFuzzy only accepts Float buffers"));
+	if (R.ActualPtr->Format != R.ExpectedPtr->Format)
+	  I.setError(Twine("Buffers must have the same type"));
       }
     }
 

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -15,7 +15,7 @@ using namespace offloadtest;
 
 static bool isFloatingPointFormat(DataFormat Format) {
   return Format == DataFormat::Float16 || Format == DataFormat::Float32 ||
-    Format == DataFormat::Float64;
+         Format == DataFormat::Float64;
 }
 
 namespace llvm {
@@ -50,8 +50,8 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
         if (!isFloatingPointFormat(R.ActualPtr->Format) ||
             !isFloatingPointFormat(R.ExpectedPtr->Format))
           I.setError(Twine("BufferFuzzy only accepts Float buffers"));
-	if (R.ActualPtr->Format != R.ExpectedPtr->Format)
-	  I.setError(Twine("Buffers must have the same type"));
+        if (R.ActualPtr->Format != R.ExpectedPtr->Format)
+          I.setError(Twine("Buffers must have the same type"));
       }
     }
 

--- a/test/Tools/Offloader/BufferFuzzy-64bit.test
+++ b/test/Tools/Offloader/BufferFuzzy-64bit.test
@@ -1,0 +1,113 @@
+#--- source.hlsl
+
+RWStructuredBuffer<double> Out1 : register(u0);
+RWStructuredBuffer<double> Out2 : register(u1);
+RWStructuredBuffer<double> Out3 : register(u2);
+RWStructuredBuffer<double> Out4 : register(u3);
+
+[numthreads(1,1,1)]
+void main() {
+  Out1[0] = 0.0;
+  Out2[0] = 3.14159265;
+  Out3[0] = asdouble(0x00000000, 0x7FF80000); // Should be NaN
+  Out4[0] = 5.4;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Out1
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 8
+  - Name: Expected1
+    Format: Float64
+    Stride: 8
+    Data: [ 0x0.fffffffffffffp-1022 ] # isDenorm will return true for this value: 2.22507385850720104E-308
+  - Name: Out2
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 8
+  - Name: Expected2
+    Format: Float64
+    Stride: 8
+    Data: [ 3.14159265 ]
+  - Name: Out3
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 8
+  - Name: Expected3
+    Format: Float64
+    Stride: 8
+    Data: [ NaN ]
+  - Name: Out4
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 8
+  - Name: Expected4
+    Format: Float64
+    Stride: 8
+    Data: [ 5.399999999999999 ] # Should be 2 ulp away
+Results:
+  - Result: Test1 # Testing Expected is Denorm and Out is zero, and both have same sign bit
+    Rule: BufferFuzzy
+    ULPT: 1
+    DenormMode: Any
+    Actual: Out1
+    Expected: Expected1
+  - Result: Test2 # Test two values are exactly the same
+    Rule: BufferFuzzy
+    ULPT: 0 # ulp shouldn't matter for this test
+    Actual: Out2
+    Expected: Expected2
+  - Result: Test3 # Test both are NaN
+    Rule: BufferFuzzy
+    ULPT: 0 # ulp shouldn't matter for this test
+    Actual: Out3
+    Expected: Expected3
+  - Result: Test4 # Actual and Expected are not the same but they are within the ULPT
+    Rule: BufferFuzzy
+    ULPT: 2
+    Actual: Out4
+    Expected: Expected4
+DescriptorSets:
+  - Resources:
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out3
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Out4
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Tools/Offloader/BufferFuzzy-error-64bit.test
+++ b/test/Tools/Offloader/BufferFuzzy-error-64bit.test
@@ -1,0 +1,116 @@
+#--- source.hlsl
+
+RWStructuredBuffer<double> Out1 : register(u0);
+RWStructuredBuffer<double> Out2 : register(u1);
+
+[numthreads(1,1,1)]
+void main() {
+  Out1[0] = 20.3;
+  Out1[1] = 5.0;
+  Out2[0] = 0.0;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Out1
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 16
+  - Name: Expected1
+    Format: Float64
+    Stride: 8
+    Data: [ 1.5, 2.5 ]
+  - Name: Out2
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 8
+  - Name: Expected2
+    Format: Float64
+    Stride: 8
+    Data: [ 0x0.fffffffffffffp-1022 ] # isDenorm will return true for this value: 2.22507385850720104E-308
+Results:
+  - Result: Test1
+    Rule: BufferFuzzy
+    ULPT: 1
+    Actual: Out1
+    Expected: Expected1
+  - Result: Test2 # Denorm value but mode isn't Any
+    Rule: BufferFuzzy
+    ULPT: 1
+    DenormMode: Preserve # same to use FTZ
+    Actual: Out2
+    Expected: Expected2
+DescriptorSets:
+  - Resources:
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s
+
+# CHECK: Test failed: Test1
+# CHECK: Expected:
+# CHECK: ---
+# CHECK: Name:            Expected1
+# CHECK: Format:          Float64
+# CHECK: Stride:          8
+# CHECK: Data:            [ 1.5, 2.5 ]
+# CHECK: OutputProps:
+# CHECK: Height:          0
+# CHECK: Width:           0
+# CHECK: Depth:           0
+# CHECK:  ...
+# CHECK: Got:
+# CHECK: ---
+# CHECK: Name:            Out1
+# CHECK: Format:          Float64
+# CHECK: Stride:          8
+# CHECK: Data:            [ 20.3, 5 ]
+# CHECK: OutputProps:
+# CHECK: Height:          0
+# CHECK: Width:           0
+# CHECK: Depth:           0
+
+# CHECK: Test failed: Test2
+# CHECK: Expected:
+# CHECK: ---
+# CHECK: Name:            Expected2
+# CHECK: Format:          Float64
+# CHECK: Stride:          8
+# CHECK: Data:            [ 2.22507e-308 ]
+# CHECK: OutputProps:
+# CHECK: Height:          0
+# CHECK: Width:           0
+# CHECK: Depth:           0
+# CHECK:  ...
+# CHECK: Got:
+# CHECK: ---
+# CHECK: Name:            Out2
+# CHECK: Format:          Float64
+# CHECK: Stride:          8
+# CHECK: Data:            [ 0 ]
+# CHECK: OutputProps:
+# CHECK: Height:          0
+# CHECK: Width:           0
+# CHECK: Depth:           0


### PR DESCRIPTION
Implement ULP comparison support for doubles.
Abstracts BufferFuzzy code to be less repetitive. 
Adds Success and Failure tests for BufferFuzzy with Float64.
Closes #82 