### PR TITLE
[WSL] Fix building under WSL

### DIFF
--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -10,11 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "Support/Check.h"
-
-#include <cmath>
-
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
+#include <cmath>
 
 static bool isDenorm(float F) { return std::fpclassify(F) == FP_SUBNORMAL; }
 

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -10,6 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "Support/Check.h"
+
+#include <cmath>
+
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 


### PR DESCRIPTION
`std::fpclassify`, `std::isnan`, and `std::signbit` were depended on in a previous PR. These are defined in `<cmath>` but it wasn't included.  By happenstance that is okay on windows but breaks the linux build.

My best guess is that `cmath` is included indirectly on the windows platform but not linux.