### PR TITLE
Implement tests for `countbits`

### DIFF
--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -1,0 +1,98 @@
+#--- source.hlsl
+
+StructuredBuffer<int16_t4> InInt : register(t0);
+StructuredBuffer<uint16_t4> InUInt : register(t1);
+
+RWStructuredBuffer<uint4> OutInt : register(u2);
+RWStructuredBuffer<uint4> OutUInt : register(u3);
+
+[numthreads(1,1,1)]
+void main() {
+  // Int
+  OutInt[0] = countbits(InInt[0]);
+  OutInt[1].xyz = countbits(InInt[0].xyz);
+  OutInt[1].w = countbits(InInt[0].w);
+  OutInt[2].xy = countbits(InInt[0].xy);
+
+  // UInt
+  OutUInt[0] = countbits(InUInt[0]);
+  OutUInt[1].xyz = countbits(InUInt[0].xyz);
+  OutUInt[1].w = countbits(InUInt[0].w);
+  OutUInt[2].xy = countbits(InUInt[0].xy);
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: InInt
+    Format: Int16
+    Stride: 8
+    Data: [42, 0, 3855, -1] # 0x2A, 0x0, 0x0f0f, 0xffff
+  - Name: InUInt
+    Format: UInt16
+    Stride: 8
+    Data: [42, 0, 3855, 65535] # 0x2A, 0x0, 0x0f0f, 0xffff
+  - Name: OutInt
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
+  - Name: OutUInt
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
+  - Name: ExpectedOut # The result we expect
+    Format: UInt32
+    Stride: 16
+    Data: [3, 0, 8, 16, 3, 0, 8, 16, 3, 0, 0, 0]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: OutInt
+    Expected: ExpectedOut
+  - Result: Test2
+    Rule: BufferExact
+    Actual: OutUInt
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: InInt
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: InInt
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+...
+#--- end
+
+# REQUIRES: Int16
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -125,7 +125,9 @@ DescriptorSets:
 # The rest all have inconsistent behaviours and require an HLK test
 # to ensure that they are behave as expected
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7499
-# UNSUPPORTED: *
+# UNSUPPORTED: Vulkan
+# UNSUPPORTED: Metal
+# UNSUPPORTED: Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -125,7 +125,7 @@ DescriptorSets:
 # The rest all have inconsistent behaviours and require an HLK test
 # to ensure that they are behave as expected
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7499
-# XFAIL: *
+# UNSUPPORTED: *
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -3,6 +3,10 @@
 StructuredBuffer<int16_t4> InInt : register(t0);
 StructuredBuffer<uint16_t4> InUInt : register(t1);
 
+// Explicitly using a size 3 buffer illustrates an error when using warp
+StructuredBuffer<int16_t3> InIntWarp : register(t4);
+StructuredBuffer<uint16_t3> InUIntWarp : register(t5);
+
 RWStructuredBuffer<uint4> OutInt : register(u2);
 RWStructuredBuffer<uint4> OutUInt : register(u3);
 
@@ -10,13 +14,13 @@ RWStructuredBuffer<uint4> OutUInt : register(u3);
 void main() {
   // Int
   OutInt[0] = countbits(InInt[0]);
-  uint4 OutOne = {countbits(InInt[0].xyz), countbits(InInt[0].w)};
+  uint4 OutOne = {countbits(InIntWarp[0]), countbits(InUInt[0].w)};
   OutInt[1] = OutOne;
   OutInt[2].xy = countbits(InInt[0].xy);
 
   // UInt
   OutUInt[0] = countbits(InUInt[0]);
-  uint4 OutUOne = {countbits(InUInt[0].xyz), countbits(InUInt[0].w)};
+  uint4 OutUOne = {countbits(InUIntWarp[0]), countbits(InUInt[0].w)};
   OutUInt[1] = OutUOne;
   OutUInt[2].xy = countbits(InUInt[0].xy);
 }
@@ -37,6 +41,14 @@ Buffers:
     Format: UInt16
     Stride: 8
     Data: [0x2A, 0, 0x0f0f, 0xffff]
+  - Name: InIntWarp
+    Format: Int16
+    Stride: 6
+    Data: [0, 0x0f0f, -1]
+  - Name: InUIntWarp
+    Format: UInt16
+    Stride: 6
+    Data: [0, 0x0f0f, 0xffff]
   - Name: OutInt
     Format: UInt32
     Stride: 16
@@ -74,6 +86,20 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 1
+    - Name: InIntWarp
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: InUIntWarp
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
     - Name: OutInt
       Kind: RWStructuredBuffer
       DirectXBinding:

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -92,6 +92,11 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: Int16
+
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7494
+# XFAIL: DXC-Vulkan
+
+# Failure to materializeAll for 16 bit
 # XFAIL: Metal
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -93,11 +93,13 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
+# Bug in DXC-Vulkan
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7494
-# XFAIL: DXC-Vulkan
 
-# Failure to materializeAll for 16 bit
-# XFAIL: Metal
+# The rest all have inconsistent behaviours and require an HLK test
+# to ensure that they are behave as expected
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7499
+# XFAIL: *
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -67,7 +67,7 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: InInt
+    - Name: InUInt
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -92,6 +92,7 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: Int16
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -32,11 +32,11 @@ Buffers:
   - Name: InInt
     Format: Int16
     Stride: 8
-    Data: [42, 0, 3855, -1] # 0x2A, 0x0, 0x0f0f, 0xffff
+    Data: [0x2A, 0, 0x0f0f, -1]
   - Name: InUInt
     Format: UInt16
     Stride: 8
-    Data: [42, 0, 3855, 65535] # 0x2A, 0x0, 0x0f0f, 0xffff
+    Data: [0x2A, 0, 0x0f0f, 0xffff]
   - Name: OutInt
     Format: UInt32
     Stride: 16

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -121,12 +121,11 @@ DescriptorSets:
 
 # Bug in DXC-Vulkan
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7494
-
-# The rest all have inconsistent behaviours and require an HLK test
-# to ensure that they are behave as expected
-# https://github.com/microsoft/DirectXShaderCompiler/issues/7499
-# UNSUPPORTED: Vulkan
-# UNSUPPORTED: Metal
+# Bug in Clang-Vulkan
+# https://github.com/llvm/llvm-project/issues/142677
+# However, the behaviour is also inconsistent and require an HLK test
+# so we will mark everything as UNSUPPORTED:
+# UNSUPPORTED: DXC
 # UNSUPPORTED: Clang
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -123,8 +123,10 @@ DescriptorSets:
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7494
 # Bug in Clang-Vulkan
 # https://github.com/llvm/llvm-project/issues/142677
-# However, the behaviour is also inconsistent and require an HLK test
-# so we will mark everything as UNSUPPORTED:
+# However, the behaviour is also inconsistent across GPUs when using directx
+# and requires an HLK test so we will mark everything as UNSUPPORTED.
+# For more context see here:
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7499
 # UNSUPPORTED: DXC
 # UNSUPPORTED: Clang
 

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -10,14 +10,14 @@ RWStructuredBuffer<uint4> OutUInt : register(u3);
 void main() {
   // Int
   OutInt[0] = countbits(InInt[0]);
-  OutInt[1].xyz = countbits(InInt[0].xyz);
-  OutInt[1].w = countbits(InInt[0].w);
+  uint4 OutOne = {countbits(InInt[0].xyz), countbits(InInt[0].w)};
+  OutInt[1] = OutOne;
   OutInt[2].xy = countbits(InInt[0].xy);
 
   // UInt
   OutUInt[0] = countbits(InUInt[0]);
-  OutUInt[1].xyz = countbits(InUInt[0].xyz);
-  OutUInt[1].w = countbits(InUInt[0].w);
+  uint4 OutUOne = {countbits(InUInt[0].xyz), countbits(InUInt[0].w)};
+  OutUInt[1] = OutUOne;
   OutUInt[2].xy = countbits(InUInt[0].xy);
 }
 

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -94,5 +94,5 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -1,0 +1,95 @@
+#--- source.hlsl
+
+StructuredBuffer<int4> InInt : register(t0);
+StructuredBuffer<uint4> InUInt : register(t1);
+RWStructuredBuffer<uint4> OutInt : register(u2);
+RWStructuredBuffer<uint4> OutUInt : register(u3);
+
+[numthreads(1,1,1)]
+void main() {
+  // Int
+  OutInt[0] = countbits(InInt[0]);
+  OutInt[1].xyz = countbits(InInt[0].xyz);
+  OutInt[1].w = countbits(InInt[0].w);
+  OutInt[2].xy = countbits(InInt[0].xy);
+
+  // UInt
+  OutUInt[0] = countbits(InUInt[0]);
+  OutUInt[1].xyz = countbits(InUInt[0].xyz);
+  OutUInt[1].w = countbits(InUInt[0].w);
+  OutUInt[2].xy = countbits(InUInt[0].xy);
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: InInt
+    Format: Int32
+    Stride: 16
+    Data: [42, 0, 252645135, -1] # 0x2A, 0x0, 0x0f ... 0f, 0xff ... ff
+  - Name: InUInt
+    Format: UInt32
+    Stride: 16
+    Data: [42, 0, 252645135, 4294967295] # 0x2A, 0x0, 0x0f ... 0f, 0xff ... ff
+  - Name: OutInt
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
+  - Name: OutUInt
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
+  - Name: ExpectedOut # The result we expect
+    Format: UInt32
+    Stride: 16
+    Data: [3, 0, 16, 32, 3, 0, 16, 32, 3, 0, 0, 0]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: OutInt
+    Expected: ExpectedOut
+  - Result: Test2
+    Rule: BufferExact
+    Actual: OutUInt
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: InInt
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: InInt
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -66,7 +66,7 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: InInt
+    - Name: InUInt
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -31,11 +31,11 @@ Buffers:
   - Name: InInt
     Format: Int32
     Stride: 16
-    Data: [42, 0, 252645135, -1] # 0x2A, 0x0, 0x0f ... 0f, 0xff ... ff
+    Data: [0x2A, 0, 0x0f0f0f0f, -1]
   - Name: InUInt
     Format: UInt32
     Stride: 16
-    Data: [42, 0, 252645135, 4294967295] # 0x2A, 0x0, 0x0f ... 0f, 0xff ... ff
+    Data: [0x2A, 0, 0x0f0f0f0f, 0xffffffff]
   - Name: OutInt
     Format: UInt32
     Stride: 16

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -9,14 +9,14 @@ RWStructuredBuffer<uint4> OutUInt : register(u3);
 void main() {
   // Int
   OutInt[0] = countbits(InInt[0]);
-  OutInt[1].xyz = countbits(InInt[0].xyz);
-  OutInt[1].w = countbits(InInt[0].w);
+  uint4 OutOne = {countbits(InInt[0].xyz), countbits(InInt[0].w)};
+  OutInt[1] = OutOne;
   OutInt[2].xy = countbits(InInt[0].xy);
 
   // UInt
   OutUInt[0] = countbits(InUInt[0]);
-  OutUInt[1].xyz = countbits(InUInt[0].xyz);
-  OutUInt[1].w = countbits(InUInt[0].w);
+  uint4 OutUOne = {countbits(InUInt[0].xyz), countbits(InUInt[0].w)};
+  OutUInt[1] = OutUOne;
   OutUInt[2].xy = countbits(InUInt[0].xy);
 }
 

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -32,11 +32,11 @@ Buffers:
   - Name: InInt
     Format: Int64
     Stride: 32
-    Data: [42, 0, 1085102592571150095, -1] # 0x2A, 0x0, 0x0f...0f, 0xff ... ff
+    Data: [0x2A, 0, 0x0f0f0f0f0f0f0f0f, -1]
   - Name: InUInt
     Format: UInt64
     Stride: 32
-    Data: [42, 0, 1085102592571150095, 1844674407370955161]  # 0x2A, 0x0, 0x0f ... 0f, 0xff ... ff
+    Data: [0x2A, 0, 0x0f0f0f0f0f0f0f0f, 0xffffffffffffffff]
   - Name: OutInt
     Format: UInt32
     Stride: 16

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -67,7 +67,7 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: InInt
+    - Name: InUInt
       Kind: StructuredBuffer
       DirectXBinding:
         Register: 1

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -1,0 +1,98 @@
+#--- source.hlsl
+
+StructuredBuffer<int64_t4> InInt : register(t0);
+StructuredBuffer<uint64_t4> InUInt : register(t1);
+
+RWStructuredBuffer<uint4> OutInt : register(u2);
+RWStructuredBuffer<uint4> OutUInt : register(u3);
+
+[numthreads(1,1,1)]
+void main() {
+  // Int
+  OutInt[0] = countbits(InInt[0]);
+  OutInt[1].xyz = countbits(InInt[0].xyz);
+  OutInt[1].w = countbits(InInt[0].w);
+  OutInt[2].xy = countbits(InInt[0].xy);
+
+  // UInt
+  OutUInt[0] = countbits(InUInt[0]);
+  OutUInt[1].xyz = countbits(InUInt[0].xyz);
+  OutUInt[1].w = countbits(InUInt[0].w);
+  OutUInt[2].xy = countbits(InUInt[0].xy);
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: InInt
+    Format: Int64
+    Stride: 32
+    Data: [42, 0, 1085102592571150095, -1] # 0x2A, 0x0, 0x0f...0f, 0xff ... ff
+  - Name: InUInt
+    Format: UInt64
+    Stride: 32
+    Data: [42, 0, 1085102592571150095, 1844674407370955161]  # 0x2A, 0x0, 0x0f ... 0f, 0xff ... ff
+  - Name: OutInt
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
+  - Name: OutUInt
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
+  - Name: ExpectedOut # The result we expect
+    Format: UInt32
+    Stride: 16
+    Data: [3, 0, 32, 64, 3, 0, 32, 64, 3, 0, 0, 0]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: OutInt
+    Expected: ExpectedOut
+  - Result: Test2
+    Rule: BufferExact
+    Actual: OutUInt
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: InInt
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: InInt
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutUInt
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+...
+#--- end
+
+# REQUIRES: Int64
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -93,6 +93,9 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7494
+# XFAIL: DXC-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -94,7 +94,8 @@ DescriptorSets:
 # REQUIRES: Int64
 
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7494
-# XFAIL: DXC-Vulkan
+# https://github.com/llvm/llvm-project/issues/142677
+# UNSUPPORTED: Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -10,14 +10,14 @@ RWStructuredBuffer<uint4> OutUInt : register(u3);
 void main() {
   // Int
   OutInt[0] = countbits(InInt[0]);
-  OutInt[1].xyz = countbits(InInt[0].xyz);
-  OutInt[1].w = countbits(InInt[0].w);
+  uint4 OutOne = {countbits(InInt[0].xyz), countbits(InInt[0].w)};
+  OutInt[1] = OutOne;
   OutInt[2].xy = countbits(InInt[0].xy);
 
   // UInt
   OutUInt[0] = countbits(InUInt[0]);
-  OutUInt[1].xyz = countbits(InUInt[0].xyz);
-  OutUInt[1].w = countbits(InUInt[0].w);
+  uint4 OutUOne = {countbits(InUInt[0].xyz), countbits(InUInt[0].w)};
+  OutUInt[1] = OutUOne;
   OutUInt[2].xy = countbits(InUInt[0].xy);
 }
 


### PR DESCRIPTION
Implement tests for `countbits` intrinsic with `uint16_t`, `int16_t`, `uint`, `uint32_t`, `int64_t` and `uint64_t`.

Resolves https://github.com/llvm/offload-test-suite/issues/140