### PR TITLE
Enable implicit binding tests for Clang-DXC

### DIFF
--- a/test/Feature/ImplicitBindings/all-implicit.test
+++ b/test/Feature/ImplicitBindings/all-implicit.test
@@ -72,7 +72,7 @@ DescriptorSets:
 # UNSUPPORTED: Clang-Vulkan
 
 # CBuffer bindings seem to be broken under metal
-# https://github.com/llvm-beanz/offload-test-suite/issues/55
+# https://github.com/llvm/offload-test-suite/issues/55
 # UNSUPPORTED: Metal
 
 # RUN: split-file %s %t

--- a/test/Feature/ImplicitBindings/all-implicit.test
+++ b/test/Feature/ImplicitBindings/all-implicit.test
@@ -68,7 +68,8 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
+# Clang's Vulcan implicit binding is not yet implemented.
+# UNSUPPORTED: Clang-Vulkan
 
 # CBuffer bindings seem to be broken under metal
 # https://github.com/llvm-beanz/offload-test-suite/issues/55

--- a/test/Feature/ImplicitBindings/all-implicit.test
+++ b/test/Feature/ImplicitBindings/all-implicit.test
@@ -68,7 +68,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Clang's Vulcan implicit binding is not yet implemented.
+# Clang's Vulkan implicit binding is not yet implemented.
 # UNSUPPORTED: Clang-Vulkan
 
 # CBuffer bindings seem to be broken under metal

--- a/test/Feature/ImplicitBindings/simple-resources.test
+++ b/test/Feature/ImplicitBindings/simple-resources.test
@@ -66,7 +66,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Clang's Vulcan implicit binding is not yet implemented.
+# Clang's Vulkan implicit binding is not yet implemented.
 # UNSUPPORTED: Clang-Vulkan
 
 # DXC's vulkan backend doesn't drop unused bindings, so it isn't possible to

--- a/test/Feature/ImplicitBindings/simple-resources.test
+++ b/test/Feature/ImplicitBindings/simple-resources.test
@@ -66,15 +66,15 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
+# Clang's Vulcan implicit binding is not yet implemented.
+# UNSUPPORTED: Clang-Vulkan
 
 # DXC's vulkan backend doesn't drop unused bindings, so it isn't possible to
 # specify descriptor sets that are valid for both DirectX and Vulkan there.
 # UNSUPPORTED: DXC-Vulkan
 
 # RUN: split-file %s %t
-# RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
-# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: Name: BufD

--- a/test/Feature/ImplicitBindings/simple-resources.test
+++ b/test/Feature/ImplicitBindings/simple-resources.test
@@ -73,6 +73,10 @@ DescriptorSets:
 # specify descriptor sets that are valid for both DirectX and Vulkan there.
 # UNSUPPORTED: DXC-Vulkan
 
+# CBuffer bindings seem to be broken under metal
+# https://github.com/llvm/offload-test-suite/issues/55
+# UNSUPPORTED: Metal
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s


### PR DESCRIPTION
Enables implicit resource binding tests for Clang-DXC.

Depends on llvm/llvm-project#142061.