### PR TITLE
[VK] Fix crash if validation layers are absent

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -766,7 +766,7 @@ public:
 
 class VKContext {
 private:
-  VkInstance Instance;
+  VkInstance Instance = VK_NULL_HANDLE;
   llvm::SmallVector<std::shared_ptr<VKDevice>> Devices;
 
   VKContext() = default;
@@ -798,7 +798,7 @@ public:
                                      "Cannot find a compatible Vulkan device");
     if (Res)
       return llvm::createStringError(std::errc::no_such_device,
-                                     "Unkown Vulkan initialization error");
+                                     "Unknown Vulkan initialization error");
 
     uint32_t DeviceCount = 0;
     if (vkEnumeratePhysicalDevices(Instance, &DeviceCount, nullptr))
@@ -814,6 +814,7 @@ public:
       AppInfo.apiVersion = TmpDev->getProps().apiVersion;
     }
     vkDestroyInstance(Instance, NULL);
+    Instance = VK_NULL_HANDLE;
 
 // TODO: This is a bit hacky but matches what I did in DX.
 #ifndef NDEBUG
@@ -828,7 +829,7 @@ public:
                                      "Cannot find a compatible Vulkan device");
     if (Res)
       return llvm::createStringError(std::errc::no_such_device,
-                                     "Unkown Vulkan initialization error");
+                                     "Unknown Vulkan initialization error");
 
     DeviceCount = 0;
     if (vkEnumeratePhysicalDevices(Instance, &DeviceCount, nullptr))


### PR DESCRIPTION
A first vkCreateInstance is called to enumerate devices and immediately destroyed. The resulting handle is not reset to VK_NULL_HANDLE. This means if the second vkCreateInstance fails (missing layer for ex), the dtor will call vkDestroyInstance with an already freed instance, causing a crash.