### PR TITLE
Fix handling of device features for DX

### DIFF
--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -66,6 +66,7 @@ DescriptorSets:
 # https://github.com/llvm/llvm-project/issues/110722
 # XFAIL: Clang
 
+# REQUIRES: Double, Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -79,10 +79,22 @@ devices = yaml.safe_load(query_string)
 
 for device in devices['Devices']:
   if device['API'] == "DirectX" and config.offloadtest_enable_d3d12:
+    if not config.offloadtest_test_warp:
+      # Don't add warps features if we're not using warp.
+      if "Microsoft Basic Render Driver" in device['Description']:
+        continue
+      if "Intel" in device['Description']:
+        config.available_features.add("DirectX-Intel")
+      if "NVIDIA" in device['Description']:
+        config.available_features.add("DirectX-NV")
+      if "AMD" in device['Description']:
+        config.available_features.add("DirectX-AMD")
+    else:
+      # Don't add native device features when targeting warp.
+      if "Microsoft Basic Render Driver" not in device['Description']:
+        continue
     config.available_features.add("DirectX")
     config.available_features.add(HLSLCompiler + "-DirectX")
-    if "Intel" in device['Description']:
-      config.available_features.add("DirectX-Intel")
 
     if device['Features'].get('Native16BitShaderOpsSupported', False):
       config.available_features.add("Int16")


### PR DESCRIPTION
Previously this code was creating a merged feature set for WARP and the available device. This instead only configures the features for the native device when not using WARP, and only configures WARPs features when you are using WARP.