### PR TITLE
Enable isinf.16.test with metal shader converter 3

### DIFF
--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -58,7 +58,10 @@ DescriptorSets:
 # llvm/llvm-project#141089
 # XFAIL: Clang-Vulkan
 # issue with 16 bit ops; no hlk tests
-# XFAIL: Clang-Metal
+
+# A bug in the Metal Shader Converter caused it to mis-translate this operation.
+# Version 3 fixes this issue.
+# UNSUPPORTED: Clang-Metal && !metal-shaderconverter-3.0.0-or-later
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -98,6 +98,16 @@ if config.offloadtest_enable_vulkan:
     ExtraCompilerArgs = ["-spirv", "-fspv-target-env=vulkan1.3"]
 if config.offloadtest_enable_metal:
     ExtraCompilerArgs = ["-metal"]
+    # metal-irconverter version: 3.0.0
+    MSCVersionOutput = subprocess.check_output(["metal-shaderconverter", "--version"]).decode("UTF-8")
+    VersionRegex = re.compile("metal-irconverter version: ([0-9]+)\.([0-9]+)\.([0-9]+)")
+    VersionMatch = VersionRegex.match(MSCVersionOutput)
+    if VersionMatch:
+        FullVersion = '.'.join(VersionMatch.groups()[0:3])
+        config.available_features.add("metal-shaderconverter-%s" % FullVersion)
+        MajorVersion = int(VersionMatch.group(1))
+        for I in range(1, MajorVersion+1):
+          config.available_features.add("metal-shaderconverter-%s.0.0-or-later" % I)
 
 HLSLCompiler = ""
 if config.offloadtest_test_clang:

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -99,15 +99,17 @@ if config.offloadtest_enable_vulkan:
 if config.offloadtest_enable_metal:
     ExtraCompilerArgs = ["-metal"]
     # metal-irconverter version: 3.0.0
-    MSCVersionOutput = subprocess.check_output(["metal-shaderconverter", "--version"]).decode("UTF-8")
+    MSCVersionOutput = subprocess.check_output(
+        ["metal-shaderconverter", "--version"]
+    ).decode("UTF-8")
     VersionRegex = re.compile("metal-irconverter version: ([0-9]+)\.([0-9]+)\.([0-9]+)")
     VersionMatch = VersionRegex.match(MSCVersionOutput)
     if VersionMatch:
-        FullVersion = '.'.join(VersionMatch.groups()[0:3])
+        FullVersion = ".".join(VersionMatch.groups()[0:3])
         config.available_features.add("metal-shaderconverter-%s" % FullVersion)
         MajorVersion = int(VersionMatch.group(1))
-        for I in range(1, MajorVersion+1):
-          config.available_features.add("metal-shaderconverter-%s.0.0-or-later" % I)
+        for I in range(1, MajorVersion + 1):
+            config.available_features.add("metal-shaderconverter-%s.0.0-or-later" % I)
 
 HLSLCompiler = ""
 if config.offloadtest_test_clang:


### PR DESCRIPTION
The Metal Shader Converter 3 beta released today fixes this test. This change marks it as unsupported on Metal with older versions of the shader converter.