### PR TITLE
Print the VK error code

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -866,7 +866,7 @@ public:
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");
-    if (Res) {
+    if (Res)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Unknown Vulkan initialization error %d",
                                      Res);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -870,7 +870,6 @@ public:
       return llvm::createStringError(std::errc::no_such_device,
                                      "Unknown Vulkan initialization error %d",
                                      Res);
-    }
 
     DeviceCount = 0;
     if (vkEnumeratePhysicalDevices(Instance, &DeviceCount, nullptr))

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -834,9 +834,11 @@ public:
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");
-    if (Res)
+    if (Res) {
       return llvm::createStringError(std::errc::no_such_device,
-                                     "Unknown Vulkan initialization error");
+                                     "Unknown Vulkan initialization error: %d",
+                                     Res);
+    }
 
     uint32_t DeviceCount = 0;
     if (vkEnumeratePhysicalDevices(Instance, &DeviceCount, nullptr))
@@ -865,9 +867,11 @@ public:
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");
-    if (Res)
+    if (Res) {
       return llvm::createStringError(std::errc::no_such_device,
-                                     "Unknown Vulkan initialization error");
+                                     "Unknown Vulkan initialization error %d",
+                                     Res);
+    }
 
     DeviceCount = 0;
     if (vkEnumeratePhysicalDevices(Instance, &DeviceCount, nullptr))

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -834,7 +834,7 @@ public:
     if (Res == VK_ERROR_INCOMPATIBLE_DRIVER)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Cannot find a compatible Vulkan device");
-    if (Res) {
+    if (Res)
       return llvm::createStringError(std::errc::no_such_device,
                                      "Unknown Vulkan initialization error: %d",
                                      Res);

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -838,7 +838,6 @@ public:
       return llvm::createStringError(std::errc::no_such_device,
                                      "Unknown Vulkan initialization error: %d",
                                      Res);
-    }
 
     uint32_t DeviceCount = 0;
     if (vkEnumeratePhysicalDevices(Instance, &DeviceCount, nullptr))


### PR DESCRIPTION
If the device fails to be created and the error is not recorginzied, the
error message impossible to act on. If we output the error number, then
the user can look it up, and see what needs to be done.
