### PR TITLE
[Metal] Enable Int64 tests on Metal.

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -74,6 +74,7 @@ def setDeviceFeatures(config, device, compiler):
     if device["API"] == "Metal":
         config.available_features.add("Int16")
         config.available_features.add("Half")
+        config.available_features.add("Int64")
 
     if device["API"] == "Vulkan":
         if device["Features"].get("shaderInt16", False):


### PR DESCRIPTION
Int64 support in Metal goes way back at least covering the full range of macOS hardware in active support.