### PR TITLE
[CMake] Fix generation of lit subdirectory targets

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,6 +129,7 @@ function(add_offloadtest_lit_suite suite)
 
   add_lit_testsuites(hlsl-${suite} ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${OFFLOADTEST_DEPS}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${suite}/
     FOLDER "HLSL tests/Suites/${suite}"
   )
 endfunction()


### PR DESCRIPTION
This fixes generation of the sub-directory targets for the generated nested lit executions.