### PR TITLE
Cleanup references to the original repo on my personal GitHub

### DIFF
--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -123,14 +123,14 @@ jobs:
       - name: Checkout OffloadTest
         uses: actions/checkout@v4
         with:
-          repository: llvm-beanz/offload-test-suite
+          repository: llvm/offload-test-suite
           ref: ${{ inputs.OffloadTest-branch }}
           path: OffloadTest
           fetch-depth: 1
       - name: Checkout Golden Images
         uses: actions/checkout@v4
         with:
-          repository: llvm-beanz/offload-golden-images
+          repository: llvm/offload-golden-images
           ref: main
           path: golden-images
           fetch-depth: 1

--- a/docs/WSL.md
+++ b/docs/WSL.md
@@ -10,7 +10,7 @@ These binaries, in addition to the WSL-specific headers and libraries made avail
 1. Install the DirectX-Headers package (usually named `directx-headers-dev`) from your preferred package manager.
 This is to obtain the libraries: DirectX-Guids (`libDirectX-Guids.a`) and d3dx12-format-properties (`libd3dx12-format-properties.a`)
 Alternatively, build and install the DirectX-Headers from the [original repo](https://github.com/microsoft/DirectX-Headers) or the git submodule of this repository: `third-party/DirectX-Headers`
-1. Install the rest of the [prerequisites](https://github.com/llvm-beanz/offload-test-suite/tree/main?tab=readme-ov-file#prerequisites) and follow the [instructions](https://github.com/llvm-beanz/offload-test-suite/tree/main?tab=readme-ov-file#adding-to-llvm-build) to add the experimental runtime test suite for HLSL to an LLVM build
+1. Install the rest of the [prerequisites](https://github.com/llvm/offload-test-suite/tree/main?tab=readme-ov-file#prerequisites) and follow the [instructions](https://github.com/llvm/offload-test-suite/tree/main?tab=readme-ov-file#adding-to-llvm-build) to add the experimental runtime test suite for HLSL to an LLVM build
 
 ## Known Issues
 

--- a/test/Feature/CBuffer/lit.local.cfg
+++ b/test/Feature/CBuffer/lit.local.cfg
@@ -2,6 +2,6 @@ if 'Clang' in config.available_features:
     config.unsupported = True
 
 # CBuffer bindings seem to be broken under metal
-# https://github.com/llvm-beanz/offload-test-suite/issues/55
+# https://github.com/llvm/offload-test-suite/issues/55
 if 'Metal' in config.available_features:
     config.unsupported = True

--- a/test/UseCase/particle-life.test
+++ b/test/UseCase/particle-life.test
@@ -354,7 +354,7 @@ DescriptorSets:
 # UNSUPPORTED: Clang-Vulkan
 
 # CBuffer bindings seem to be broken under metal
-# https://github.com/llvm-beanz/offload-test-suite/issues/55
+# https://github.com/llvm/offload-test-suite/issues/55
 # UNSUPPORTED: Metal
 
 # RUN: split-file %s %t


### PR DESCRIPTION
When moving to LLVM I clearly missed a few places where my personal repo was originally referenced. This gets the last of them.