### PR TITLE
Use `ComparisonRule` to prevent ambiguity between type and member variable name

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -116,7 +116,7 @@ struct Buffer {
 
 struct Result {
   std::string Name;
-  Rule TheRule;
+  Rule ComparisonRule;
   std::string Actual;
   std::string Expected;
   Buffer *ActualPtr = nullptr;

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -116,7 +116,7 @@ struct Buffer {
 
 struct Result {
   std::string Name;
-  Rule Rule;
+  Rule TheRule;
   std::string Actual;
   std::string Expected;
   Buffer *ActualPtr = nullptr;

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -268,7 +268,7 @@ static bool testBufferFloatULP(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
 }
 
 llvm::Error verifyResult(offloadtest::Result R) {
-  switch (R.TheRule) {
+  switch (R.ComparisonRule) {
   case offloadtest::Rule::BufferExact: {
     if (testBufferExact(R.ActualPtr, R.ExpectedPtr))
       return llvm::Error::success();

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -268,7 +268,7 @@ static bool testBufferFloatULP(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
 }
 
 llvm::Error verifyResult(offloadtest::Result R) {
-  switch (R.Rule) {
+  switch (R.TheRule) {
   case offloadtest::Rule::BufferExact: {
     if (testBufferExact(R.ActualPtr, R.ExpectedPtr))
       return llvm::Error::success();

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -46,8 +46,8 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
       R.ExpectedPtr = P.getBuffer(R.Expected);
       if (!R.ExpectedPtr)
         I.setError(Twine("Reference buffer ") + R.Expected + " not found!");
-      if (R.TheRule == Rule::BufferFloatULP ||
-          R.TheRule == Rule::BufferFloatEpsilon) {
+      if (R.ComparisonRule == Rule::BufferFloatULP ||
+          R.ComparisonRule == Rule::BufferFloatEpsilon) {
         if (!isFloatingPointFormat(R.ActualPtr->Format) ||
             !isFloatingPointFormat(R.ExpectedPtr->Format))
           I.setError(Twine("BufferFloat only accepts Float buffers"));
@@ -226,11 +226,11 @@ void MappingTraits<offloadtest::Shader>::mapping(IO &I,
 void MappingTraits<offloadtest::Result>::mapping(IO &I,
                                                  offloadtest::Result &R) {
   I.mapRequired("Result", R.Name);
-  I.mapRequired("Rule", R.TheRule);
+  I.mapRequired("Rule", R.ComparisonRule);
   I.mapRequired("Actual", R.Actual);
   I.mapRequired("Expected", R.Expected);
 
-  switch (R.TheRule) {
+  switch (R.ComparisonRule) {
   case Rule::BufferFloatULP: {
     I.mapRequired("ULPT", R.ULPT);
     I.mapOptional("DenormMode", R.DM);

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -46,8 +46,8 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
       R.ExpectedPtr = P.getBuffer(R.Expected);
       if (!R.ExpectedPtr)
         I.setError(Twine("Reference buffer ") + R.Expected + " not found!");
-      if (R.Rule == Rule::BufferFloatULP ||
-          R.Rule == Rule::BufferFloatEpsilon) {
+      if (R.TheRule == Rule::BufferFloatULP ||
+          R.TheRule == Rule::BufferFloatEpsilon) {
         if (!isFloatingPointFormat(R.ActualPtr->Format) ||
             !isFloatingPointFormat(R.ExpectedPtr->Format))
           I.setError(Twine("BufferFloat only accepts Float buffers"));
@@ -226,11 +226,11 @@ void MappingTraits<offloadtest::Shader>::mapping(IO &I,
 void MappingTraits<offloadtest::Result>::mapping(IO &I,
                                                  offloadtest::Result &R) {
   I.mapRequired("Result", R.Name);
-  I.mapRequired("Rule", R.Rule);
+  I.mapRequired("Rule", R.TheRule);
   I.mapRequired("Actual", R.Actual);
   I.mapRequired("Expected", R.Expected);
 
-  switch (R.Rule) {
+  switch (R.TheRule) {
   case Rule::BufferFloatULP: {
     I.mapRequired("ULPT", R.ULPT);
     I.mapOptional("DenormMode", R.DM);


### PR DESCRIPTION
This PR changes a member variable name to prevent compiler errors when compiling with g++-11.
Instead of using -fpermissive, this PR changes the conflicting member variable name.

Fixes https://github.com/llvm/offload-test-suite/issues/281