### PR TITLE
Un-XFAIL test now that llvm/llvm-project#144580 is resolved

### DIFF
--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -40,9 +40,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Tracking issue: https://github.com/llvm/llvm-project/issues/144580
-# XFAIL: Clang-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -E CSMain -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/TestPipeline.test
+++ b/test/Basic/TestPipeline.test
@@ -40,6 +40,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Tracking issue: https://github.com/llvm/llvm-project/issues/148270
+# XFAIL: Clang-Vulkan && Intel
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -E CSMain -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s


### PR DESCRIPTION
This test no longer fails because of the original issue, but still has issues
on intel drivers due to llvm/llvm-project#148270