### PR TITLE
Enable most of the cbuffer tests for clang

### DIFF
--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -59,8 +59,8 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
-# https://github.com/llvm/llvm-project/issues/110722
-# XFAIL: Clang
+# https://github.com/llvm/llvm-project/issues/138996
+# UNSUPPORTED: Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/lit.local.cfg
+++ b/test/Feature/CBuffer/lit.local.cfg
@@ -1,4 +1,4 @@
-if 'Clang' in config.available_features:
+if 'Clang-Vulkan' in config.available_features:
     config.unsupported = True
 
 # CBuffer bindings seem to be broken under metal

--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -97,6 +97,10 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
++# Clang trips on 2-element vectors in structs:
++# https://github.com/llvm/llvm-project/issues/123968
++# UNSUPPORTED: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -63,6 +63,10 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
+# Clang trips on 3-element vectors in structs:
+# https://github.com/llvm/llvm-project/issues/123968
+# UNSUPPORTED: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -63,6 +63,10 @@ DescriptorSets:
 # DXC's vulkan support does not layout cbuffers compatibly with DXIL
 # UNSUPPORTED: Vulkan
 
+# Clang trips on 3-element vectors in structs:
+# https://github.com/llvm/llvm-project/issues/123968
+# UNSUPPORTED: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s


### PR DESCRIPTION
These have been working for some time but we never enabled the tests.