### PR TITLE
Add comparison rule, tolerance if applicable, and hex64 view to test failure text output

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -77,7 +77,7 @@ struct Buffer {
   int Channels;
   int Stride;
   std::unique_ptr<char[]> Data;
-  std::unique_ptr<llvm::yaml::Hex64> HexData;
+  std::unique_ptr<std::string> HexData;
   size_t Size;
   size_t HexSize;
   OutputProperties OutputProps;

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -77,9 +77,7 @@ struct Buffer {
   int Channels;
   int Stride;
   std::unique_ptr<char[]> Data;
-  std::unique_ptr<std::string> HexData;
   size_t Size;
-  size_t HexSize;
   OutputProperties OutputProps;
   uint32_t Counter;
 

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -77,7 +77,9 @@ struct Buffer {
   int Channels;
   int Stride;
   std::unique_ptr<char[]> Data;
+  std::unique_ptr<llvm::yaml::Hex64> HexData;
   size_t Size;
+  size_t HexSize;
   OutputProperties OutputProps;
   uint32_t Counter;
 

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -297,6 +297,7 @@ static const std::string getBufferStr(offloadtest::Buffer *B,
     ret += " [ " + bitPatternAsHex64(Arr[0], ComparisonRule);                  \
     for (unsigned int i = 1; i < Arr.size(); i++)                              \
       ret += ", " + bitPatternAsHex64(Arr[i], ComparisonRule);                 \
+    ret += " ]";                                                               \
     break;                                                                     \
   }
     DATA_CASE(Hex8, llvm::yaml::Hex8)
@@ -319,33 +320,31 @@ static const std::string getBufferStr(offloadtest::Buffer *B,
 }
 
 llvm::Error verifyResult(offloadtest::Result R) {
-  llvm::SmallString<256> TestRuleStr;
-  llvm::raw_svector_ostream TestRuleOStr(TestRuleStr);
+  llvm::SmallString<256> Str;
+  llvm::raw_svector_ostream OS(Str);
+  OS << "Test failed: " << R.Name << "\n";
+
   switch (R.ComparisonRule) {
   case offloadtest::Rule::BufferExact: {
     if (testBufferExact(R.ActualPtr, R.ExpectedPtr))
       return llvm::Error::success();
-    TestRuleOStr << "Comparison Rule: BufferExact\n";
+    OS << "Comparison Rule: BufferExact\n";
     break;
   }
   case offloadtest::Rule::BufferFloatULP: {
     if (testBufferFloatULP(R.ActualPtr, R.ExpectedPtr, R.ULPT, R.DM))
       return llvm::Error::success();
-    TestRuleOStr << "Comparison Rule: BufferFloatULP\nULP: " << R.ULPT << "\n";
+    OS << "Comparison Rule: BufferFloatULP\nULP: " << R.ULPT << "\n";
     break;
   }
   case offloadtest::Rule::BufferFloatEpsilon: {
     if (testBufferFloatEpsilon(R.ActualPtr, R.ExpectedPtr, R.Epsilon, R.DM))
       return llvm::Error::success();
-    TestRuleOStr << "Comparison Rule: BufferFloatEpsilon\nEpsilon: "
-                 << R.Epsilon << "\n";
+    OS << "Comparison Rule: BufferFloatEpsilon\nEpsilon: " << R.Epsilon << "\n";
     break;
   }
   }
-  llvm::SmallString<256> Str;
-  llvm::raw_svector_ostream OS(Str);
-  OS << "Test failed: " << R.Name << "\n";
-  OS << TestRuleStr;
+
   OS << "Expected:\n";
   llvm::yaml::Output YAMLOS(OS);
   YAMLOS << *R.ExpectedPtr;

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -276,7 +276,7 @@ static std::string bitPatternAsHex64(const T &Val,
 
   std::ostringstream Oss;
   if (ComparisonRule == offloadtest::Rule::BufferExact)
-    Oss << std::hex << Val;
+    Oss << "0x" << std::hex << Val;
   else
     Oss << std::hexfloat << Val;
   return Oss.str();

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -268,26 +268,34 @@ static bool testBufferFloatULP(offloadtest::Buffer *B1, offloadtest::Buffer *B2,
 }
 
 llvm::Error verifyResult(offloadtest::Result R) {
+  llvm::SmallString<256> TestRuleStr;
+  llvm::raw_svector_ostream TestRuleOStr(TestRuleStr);
   switch (R.ComparisonRule) {
   case offloadtest::Rule::BufferExact: {
     if (testBufferExact(R.ActualPtr, R.ExpectedPtr))
       return llvm::Error::success();
+    TestRuleOStr << "Comparison Rule: BufferExact\n";
     break;
   }
   case offloadtest::Rule::BufferFloatULP: {
     if (testBufferFloatULP(R.ActualPtr, R.ExpectedPtr, R.ULPT, R.DM))
       return llvm::Error::success();
+    TestRuleOStr << "Comparison Rule: BufferFloatULP\nULP: " << R.ULPT << "\n";
     break;
   }
   case offloadtest::Rule::BufferFloatEpsilon: {
     if (testBufferFloatEpsilon(R.ActualPtr, R.ExpectedPtr, R.Epsilon, R.DM))
       return llvm::Error::success();
+    TestRuleOStr << "Comparison Rule: BufferFloatEpsilon\nEpsilon: "
+                 << R.Epsilon << "\n";
     break;
   }
   }
   llvm::SmallString<256> Str;
   llvm::raw_svector_ostream OS(Str);
-  OS << "Test failed: " << R.Name << "\nExpected:\n";
+  OS << "Test failed: " << R.Name << "\n";
+  OS << TestRuleStr;
+  OS << "Expected:\n";
   llvm::yaml::Output YAMLOS(OS);
   YAMLOS << *R.ExpectedPtr;
   OS << "Got:\n";

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -283,17 +283,17 @@ static std::string bitPatternAsHex64(const T &Val,
 }
 
 template <typename T>
-std::string formatBuffer(offloadtest::Buffer *B, offloadtest::Rule rule) {
-  llvm::MutableArrayRef<T> arr(reinterpret_cast<T *>(B->Data.get()),
+std::string formatBuffer(offloadtest::Buffer *B, offloadtest::Rule Rule) {
+  llvm::MutableArrayRef<T> Arr(reinterpret_cast<T *>(B->Data.get()),
                                B->Size / sizeof(T));
-  if (arr.empty())
+  if (Arr.empty())
     return "";
 
-  std::string result = "[ " + bitPatternAsHex64(arr[0], rule);
-  for (size_t i = 1; i < arr.size(); ++i)
-    result += ", " + bitPatternAsHex64(arr[i], rule);
-  result += " ]";
-  return result;
+  std::string Result = "[ " + bitPatternAsHex64(Arr[0], Rule);
+  for (size_t I = 1; I < Arr.size(); ++I)
+    Result += ", " + bitPatternAsHex64(Arr[I], Rule);
+  Result += " ]";
+  return Result;
 }
 
 static const std::string getBufferStr(offloadtest::Buffer *B,

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -277,16 +277,16 @@ template <typename T> static std::string bitPatternAsHex64(const T &Val) {
   return Oss.str();
 }
 
-std::string getBufferStr(offloadtest::Buffer *B) {
+static const std::string getBufferStr(offloadtest::Buffer *B) {
   std::string ret = "";
   switch (B->Format) {
 #define DATA_CASE(Enum, Type)                                                  \
   case offloadtest::DataFormat::Enum: {                                        \
-    llvm::MutableArrayRef<Type> Arr(reinterpret_cast<Type *>(B->Data.get()),   \
-                                    B->Size / sizeof(Type));                   \
+    const llvm::MutableArrayRef<Type> Arr(                                     \
+        reinterpret_cast<Type *>(B->Data.get()), B->Size / sizeof(Type));      \
     if (Arr.size() == 0)                                                       \
       return "";                                                               \
-    else if (Arr.size() == 1)                                                  \
+    if (Arr.size() == 1)                                                       \
       return "[ " + bitPatternAsHex64(Arr[0]) + " ]";                          \
     ret += " [ " + bitPatternAsHex64(Arr[0]);                                  \
     for (unsigned int i = 1; i < Arr.size(); i++)                              \
@@ -349,8 +349,8 @@ llvm::Error verifyResult(offloadtest::Result R) {
   // Now print exact hex64 representations of each element of the
   // actual and expected buffers.
 
-  std::string ExpectedBufferStr = getBufferStr(R.ExpectedPtr);
-  std::string ActualBufferStr = getBufferStr(R.ActualPtr);
+  const std::string ExpectedBufferStr = getBufferStr(R.ExpectedPtr);
+  const std::string ActualBufferStr = getBufferStr(R.ActualPtr);
 
   OS << "Full Hex 64bit representation of Expected Buffer Values:\n"
      << ExpectedBufferStr << "\n";

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -283,9 +283,10 @@ static std::string bitPatternAsHex64(const T &Val,
 }
 
 template <typename T>
-std::string formatBuffer(offloadtest::Buffer *B, offloadtest::Rule Rule) {
-  llvm::MutableArrayRef<T> Arr(reinterpret_cast<T *>(B->Data.get()),
-                               B->Size / sizeof(T));
+static std::string formatBuffer(offloadtest::Buffer *B,
+                                offloadtest::Rule Rule) {
+  const llvm::MutableArrayRef<T> Arr(reinterpret_cast<T *>(B->Data.get()),
+                                     B->Size / sizeof(T));
   if (Arr.empty())
     return "";
 

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -10,11 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "Support/Check.h"
+#include "Support/Pipeline.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
-#include "Support/Pipeline.h"
 #include <cmath>
 #include <sstream>
 
@@ -277,21 +277,20 @@ template <typename T> static std::string bitPatternAsHex64(const T &Val) {
   return Oss.str();
 }
 
-std::string getBufferStr(offloadtest::Buffer *B){
+std::string getBufferStr(offloadtest::Buffer *B) {
   std::string ret = "";
   switch (B->Format) {
 #define DATA_CASE(Enum, Type)                                                  \
   case offloadtest::DataFormat::Enum: {                                        \
-    llvm::MutableArrayRef<Type> Arr(reinterpret_cast<Type *>(B->Data.get()),             \
-                          B->Size / sizeof(Type));                             \
+    llvm::MutableArrayRef<Type> Arr(reinterpret_cast<Type *>(B->Data.get()),   \
+                                    B->Size / sizeof(Type));                   \
     if (Arr.size() == 0)                                                       \
       return "";                                                               \
     else if (Arr.size() == 1)                                                  \
       return "[ " + bitPatternAsHex64(Arr[0]) + " ]";                          \
     ret += " [ " + bitPatternAsHex64(Arr[0]);                                  \
-    for (unsigned int i = 1; i < Arr.size(); i++){                             \
-        ret += ", " + bitPatternAsHex64(Arr[i]);                               \
-    }                                                                          \
+    for (unsigned int i = 1; i < Arr.size(); i++)                              \
+      ret += ", " + bitPatternAsHex64(Arr[i]);                                 \
     break;                                                                     \
   }
     DATA_CASE(Hex8, llvm::yaml::Hex8)
@@ -307,7 +306,8 @@ std::string getBufferStr(offloadtest::Buffer *B){
     DATA_CASE(Float16, llvm::yaml::Hex16)
     DATA_CASE(Float32, float)
     DATA_CASE(Float64, double)
-    DATA_CASE(Bool, uint32_t) // Because sizeof(bool) is 1 but HLSL represents a bool using 4 bytes.
+    DATA_CASE(Bool, uint32_t) // Because sizeof(bool) is 1 but HLSL represents a
+                              // bool using 4 bytes.
   }
   return ret;
 }
@@ -352,8 +352,10 @@ llvm::Error verifyResult(offloadtest::Result R) {
   std::string ExpectedBufferStr = getBufferStr(R.ExpectedPtr);
   std::string ActualBufferStr = getBufferStr(R.ActualPtr);
 
-  OS << "Full Hex 64bit representation of Expected Buffer Values:\n" << ExpectedBufferStr << "\n";
-  OS << "Full Hex 64bit representation of Actual Buffer Values:\n" << ActualBufferStr << "\n";
+  OS << "Full Hex 64bit representation of Expected Buffer Values:\n"
+     << ExpectedBufferStr << "\n";
+  OS << "Full Hex 64bit representation of Actual Buffer Values:\n"
+     << ActualBufferStr << "\n";
 
   return llvm::createStringError(Str.c_str());
 }

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -297,39 +297,39 @@ std::string formatBuffer(offloadtest::Buffer *B, offloadtest::Rule rule) {
 }
 
 static const std::string getBufferStr(offloadtest::Buffer *B,
-                                      offloadtest::Rule rule) {
+                                      offloadtest::Rule Rule) {
   using DF = offloadtest::DataFormat;
   switch (B->Format) {
   case DF::Hex8:
-    return formatBuffer<llvm::yaml::Hex8>(B, rule);
+    return formatBuffer<llvm::yaml::Hex8>(B, Rule);
   case DF::Hex16:
-    return formatBuffer<llvm::yaml::Hex16>(B, rule);
+    return formatBuffer<llvm::yaml::Hex16>(B, Rule);
   case DF::Hex32:
-    return formatBuffer<llvm::yaml::Hex32>(B, rule);
+    return formatBuffer<llvm::yaml::Hex32>(B, Rule);
   case DF::Hex64:
-    return formatBuffer<llvm::yaml::Hex64>(B, rule);
+    return formatBuffer<llvm::yaml::Hex64>(B, Rule);
   case DF::UInt16:
-    return formatBuffer<uint16_t>(B, rule);
+    return formatBuffer<uint16_t>(B, Rule);
   case DF::UInt32:
-    return formatBuffer<uint32_t>(B, rule);
+    return formatBuffer<uint32_t>(B, Rule);
   case DF::UInt64:
-    return formatBuffer<uint64_t>(B, rule);
+    return formatBuffer<uint64_t>(B, Rule);
   case DF::Int16:
-    return formatBuffer<int16_t>(B, rule);
+    return formatBuffer<int16_t>(B, Rule);
   case DF::Int32:
-    return formatBuffer<int32_t>(B, rule);
+    return formatBuffer<int32_t>(B, Rule);
   case DF::Int64:
-    return formatBuffer<int64_t>(B, rule);
+    return formatBuffer<int64_t>(B, Rule);
   case DF::Float16:
     return formatBuffer<llvm::yaml::Hex16>(B,
-                                           rule); // assuming no native float16
+                                           Rule); // assuming no native float16
   case DF::Float32:
-    return formatBuffer<float>(B, rule);
+    return formatBuffer<float>(B, Rule);
   case DF::Float64:
-    return formatBuffer<double>(B, rule);
+    return formatBuffer<double>(B, Rule);
   case DF::Bool:
     return formatBuffer<uint32_t>(B,
-                                  rule); // Because sizeof(bool) is 1 but HLSL
+                                  Rule); // Because sizeof(bool) is 1 but HLSL
                                          // represents a bool using 4 bytes.
   }
 }

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -93,11 +93,11 @@ void MappingTraits<offloadtest::DescriptorSet>::mapping(
   I.mapRequired("Resources", D.Resources);
 }
 
-template <typename T> uint64_t bitPatternAsHex64(const T &val) {
+static template <typename T> uint64_t bitPatternAsHex64(const T &Val) {
   static_assert(sizeof(T) <= sizeof(uint64_t), "Type too large for Hex64");
-  uint64_t raw = 0;
-  memcpy(&raw, &val, sizeof(T));
-  return raw;
+  uint64_t Raw = 0;
+  memcpy(&Raw, &Val, sizeof(T));
+  return Raw;
 }
 
 void MappingTraits<offloadtest::Buffer>::mapping(IO &I,

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -93,6 +93,13 @@ void MappingTraits<offloadtest::DescriptorSet>::mapping(
   I.mapRequired("Resources", D.Resources);
 }
 
+template <typename T> uint64_t bitPatternAsHex64(const T &val) {
+  static_assert(sizeof(T) <= sizeof(uint64_t), "Type too large for Hex64");
+  uint64_t raw = 0;
+  memcpy(&raw, &val, sizeof(T));
+  return raw;
+}
+
 void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
                                                  offloadtest::Buffer &B) {
   I.mapRequired("Name", B.Name);
@@ -111,7 +118,7 @@ void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
       std::vector<llvm::yaml::Hex64> HexVec;                                   \
       HexVec.reserve(Arr.size());                                              \
       for (const auto &val : Arr)                                              \
-        HexVec.emplace_back(static_cast<uint64_t>(val));                       \
+        HexVec.emplace_back(bitPatternAsHex64(val));                           \
       llvm::MutableArrayRef<llvm::yaml::Hex64> HexArr(HexVec);                 \
       I.mapRequired("Data", Arr);                                              \
       I.mapRequired("HexData", HexArr);                                        \

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -105,6 +105,7 @@ template <typename Type> static void setData(IO &I, offloadtest::Buffer &B) {
       B.Size = ZeroInitSize;
       B.Data.reset(new char[B.Size]);
       memset(B.Data.get(), 0, B.Size);
+      I.mapOptional("OutputProps", B.OutputProps);
       return;
     }
     llvm::SmallVector<Type, 64> Arr;

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -97,21 +97,20 @@ void MappingTraits<offloadtest::DescriptorSet>::mapping(
 
 // Override yaml printer so that hex strings aren't printed like scalars,
 // but are printed inline as if they were elements of a vector
-template <>
-struct SequenceTraits<llvm::MutableArrayRef<std::string>> {
+template <> struct SequenceTraits<llvm::MutableArrayRef<std::string>> {
   static size_t size(IO &io, llvm::MutableArrayRef<std::string> &seq) {
     return seq.size();
   }
 
-  static std::string &element(IO &io, llvm::MutableArrayRef<std::string> &seq, size_t index) {    
+  static std::string &element(IO &io, llvm::MutableArrayRef<std::string> &seq,
+                              size_t index) {
     return seq[index];
   }
 
   static const bool flow = true;
 };
 
-template <typename T>
-static std::string bitPatternAsHex64(const T &Val) {
+template <typename T> static std::string bitPatternAsHex64(const T &Val) {
   static_assert(sizeof(T) <= sizeof(uint64_t), "Type too large for Hex64");
 
   std::ostringstream Oss;

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -93,7 +93,7 @@ void MappingTraits<offloadtest::DescriptorSet>::mapping(
   I.mapRequired("Resources", D.Resources);
 }
 
-static template <typename T> uint64_t bitPatternAsHex64(const T &Val) {
+template <typename T> static uint64_t bitPatternAsHex64(const T &Val) {
   static_assert(sizeof(T) <= sizeof(uint64_t), "Type too large for Hex64");
   uint64_t Raw = 0;
   memcpy(&Raw, &Val, sizeof(T));

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -108,7 +108,13 @@ void MappingTraits<offloadtest::Buffer>::mapping(IO &I,
     if (I.outputting()) {                                                      \
       llvm::MutableArrayRef<Type> Arr(reinterpret_cast<Type *>(B.Data.get()),  \
                                       B.Size / sizeof(Type));                  \
+      std::vector<llvm::yaml::Hex64> HexVec;                                   \
+      HexVec.reserve(Arr.size());                                              \
+      for (const auto &val : Arr)                                              \
+        HexVec.emplace_back(static_cast<uint64_t>(val));                       \
+      llvm::MutableArrayRef<llvm::yaml::Hex64> HexArr(HexVec);                 \
       I.mapRequired("Data", Arr);                                              \
+      I.mapRequired("HexData", HexArr);                                        \
     } else {                                                                   \
       int64_t ZeroInitSize;                                                    \
       I.mapOptional("ZeroInitSize", ZeroInitSize, 0);                          \

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -95,7 +95,7 @@ void MappingTraits<offloadtest::DescriptorSet>::mapping(
   I.mapRequired("Resources", D.Resources);
 }
 
-// override yaml printer so that hex strings aren't printed like scalars,
+// Override yaml printer so that hex strings aren't printed like scalars,
 // but are printed inline as if they were elements of a vector
 template <>
 struct SequenceTraits<llvm::MutableArrayRef<std::string>> {

--- a/test/Tools/Offloader/BufferExact-error.test
+++ b/test/Tools/Offloader/BufferExact-error.test
@@ -71,6 +71,6 @@ DescriptorSets:
 # CHECK: Width:           0
 # CHECK: Depth:           0
 # CHECK: Full Hex 64bit representation of Expected Buffer Values:
-# CHECK: [ 1, 2, 3, 4 ]
+# CHECK: [ 0x1, 0x2, 0x3, 0x4 ]
 # CHECK: Full Hex 64bit representation of Actual Buffer Values:
-# CHECK: [ 14, 1e, 28, 32 ]
+# CHECK: [ 0x14, 0x1e, 0x28, 0x32 ]

--- a/test/Tools/Offloader/BufferExact-error.test
+++ b/test/Tools/Offloader/BufferExact-error.test
@@ -48,6 +48,7 @@ DescriptorSets:
 # RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s
 
 # CHECK: Test failed: Test1
+# CHECK: Comparison Rule: BufferExact
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected1
@@ -69,3 +70,7 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK: [ 1, 2, 3, 4 ]
+# CHECK: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK: [ 14, 1e, 28, 32 ]

--- a/test/Tools/Offloader/BufferFloat-error-64bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-64bit.test
@@ -110,6 +110,8 @@ DescriptorSets:
 # RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s
 
 # CHECK: Test failed: Test1
+# CHECK: Comparison Rule: BufferFloatULP
+# CHECK: ULP: 1
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected1
@@ -131,8 +133,18 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK:  ...
+# CHECK-NEXT: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK-NEXT: [ 0x1.8000000000000p+0, 0x1.4000000000000p+1 ]
+# CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK-NEXT: [ 0x1.44cccc 
+# The rest is #ccccccdp+4, 0x1.4000000000000p+2 ], but some implementations
+# the remaining hex64 data. So, we resume checking from p+4
+# CHECK: p+4, 0x1.4000000000000p+2 ]
 
 # CHECK: Test failed: Test2
+# CHECK: Comparison Rule: BufferFloatULP
+# CHECK: ULP: 1
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected2
@@ -154,8 +166,15 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK:  ...
+# CHECK-NEXT: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK-NEXT: [ 0x0.fffffffffffffp-1022 ]
+# CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK-NEXT: [ 0x0.0000000000000p+0 ]
 
 # CHECK: Test failed: Test3
+# CHECK: Comparison Rule: BufferFloatULP
+# CHECK: ULP: 0
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected3
@@ -177,8 +196,15 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK:  ...
+# CHECK-NEXT: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK-NEXT: [ 0x0.0000000000000p+0 ]
+# CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK-NEXT: [ nan ]
 
 # CHECK: Test failed: Test4
+# CHECK: Comparison Rule: BufferFloatEpsilon
+# CHECK: Epsilon: 0.1
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected1
@@ -200,8 +226,18 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK:  ...
+# CHECK-NEXT: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK-NEXT: [ 0x1.8000000000000p+0, 0x1.4000000000000p+1 ]
+# CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK-NEXT: [ 0x1.44cccc 
+# The rest is #ccccccdp+4, 0x1.4000000000000p+2 ], but some implementations
+# the remaining hex64 data. So, we resume checking from p+4
+# CHECK: p+4, 0x1.4000000000000p+2 ]
 
 # CHECK: Test failed: Test5
+# CHECK: Comparison Rule: BufferFloatEpsilon
+# CHECK: Epsilon: 0
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected2
@@ -223,8 +259,15 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK:  ...
+# CHECK-NEXT: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK-NEXT: [ 0x0.fffffffffffffp-1022 ]
+# CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK-NEXT: [ 0x0.0000000000000p+0 ]
 
 # CHECK: Test failed: Test6
+# CHECK: Comparison Rule: BufferFloatEpsilon
+# CHECK: Epsilon: 0
 # CHECK: Expected:
 # CHECK: ---
 # CHECK: Name:            Expected3
@@ -246,3 +289,8 @@ DescriptorSets:
 # CHECK: Height:          0
 # CHECK: Width:           0
 # CHECK: Depth:           0
+# CHECK:  ...
+# CHECK-NEXT: Full Hex 64bit representation of Expected Buffer Values:
+# CHECK-NEXT: [ 0x0.0000000000000p+0 ]
+# CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
+# CHECK-NEXT: [ nan ]

--- a/test/Tools/Offloader/BufferFloat-error-64bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-64bit.test
@@ -139,7 +139,7 @@ DescriptorSets:
 # CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
 # CHECK-NEXT: [ 0x1.44cccc 
 # The rest is #ccccccdp+4, 0x1.4000000000000p+2 ], but some implementations
-# the remaining hex64 data. So, we resume checking from p+4
+# have trailing 0's for the remaining hex64 data. So, we resume checking from p+4
 # CHECK: p+4, 0x1.4000000000000p+2 ]
 
 # CHECK: Test failed: Test2
@@ -232,7 +232,7 @@ DescriptorSets:
 # CHECK-NEXT: Full Hex 64bit representation of Actual Buffer Values:
 # CHECK-NEXT: [ 0x1.44cccc 
 # The rest is #ccccccdp+4, 0x1.4000000000000p+2 ], but some implementations
-# the remaining hex64 data. So, we resume checking from p+4
+# have trailing 0's for the remaining hex64 data. So, we resume checking from p+4
 # CHECK: p+4, 0x1.4000000000000p+2 ]
 
 # CHECK: Test failed: Test5


### PR DESCRIPTION
This PR implements some extra quality of life to address confusion in seemingly identical actual and expected results.
Fixes https://github.com/llvm/offload-test-suite/issues/289

Here's some sample output of what I see when I force a test to fail, manually changing expected values.
<img width="1092" height="755" alt="image" src="https://github.com/user-attachments/assets/238cef2a-728b-4b9d-9b7c-d591c703761f" />

