### PR TITLE
Add test for asuint

### DIFF
--- a/test/Feature/HLSLLib/asuint.32.test
+++ b/test/Feature/HLSLLib/asuint.32.test
@@ -1,0 +1,137 @@
+#--- source.hlsl
+StructuredBuffer<uint4> In0 : register(t0);
+StructuredBuffer<int4> In1 : register(t1);
+StructuredBuffer<float4> In2 : register(t2);
+
+RWStructuredBuffer<uint4> Out0 : register(u3);
+RWStructuredBuffer<uint4> Out1 : register(u4);
+RWStructuredBuffer<uint4> Out2 : register(u5);
+
+
+[numthreads(1,1,1)]
+void main() {
+
+Out0[0] = asuint(In0[0]);
+Out0[1] = uint4(asuint(In0[1].xyz), asuint(In0[1].w));
+Out0[2] = uint4(asuint(In0[2].xy), asuint(In0[2].zw));
+Out0[3] = asuint(uint4(100, 0, 4294967295, 75757575));
+
+Out1[0] = asuint(In1[0]);
+Out1[1] = uint4(asuint(In1[1].xyz), asuint(In1[1].w));
+Out1[2] = uint4(asuint(In1[2].xy), asuint(In1[2].zw));
+Out1[3] = asuint(int4(-1, 0, 2147483647, -2147483648));
+
+Out2[0] = asuint(In2[0]);
+Out2[1] = uint4(asuint(In2[1].xyz), asuint(In2[1].w));
+Out2[2] = uint4(asuint(In2[2].xy), asuint(In2[2].zw));
+Out2[3] = asuint(float4(10, 0, 5.57, 111.111));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In0
+    Format: UInt32
+    Stride: 16
+    Data: [100, 0, 4294967295, 75757575, 10, 20, 30, 40 , 50, 60, 70, 80]
+  - Name: In1
+    Format: Int32
+    Stride: 16
+    Data: [-1, 0, 2147483647, -2147483648, -10, -20, -30, -40, -50, 60, 70, 80]
+  - Name: In2
+    Format: Float32
+    Stride: 16
+    Data: [10, 0, 5.57, 111.111, 20.5, 30.6, 40.7, 50.8, -60.9, -0.000001, -0.0002, -888.888]
+  - Name: Out0
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedOut0
+    Format: UInt32
+    Stride: 16
+    Data: [100, 0, 4294967295, 75757575, 10, 20, 30, 40 , 50, 60, 70, 80, 100, 0, 4294967295, 75757575]
+  - Name: Out1
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedOut1
+    Format: UInt32
+    Stride: 16
+    Data: [ 4294967295, 0, 2147483647, 2147483648, 4294967286, 4294967276, 4294967266, 4294967256, 4294967246, 60, 70, 80, 4294967295, 0, 2147483647, 2147483648]
+  - Name: Out2
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedOut2
+    Format: UInt32
+    Stride: 16
+    Data:  [ 1092616192, 0, 1085422961, 1121859797, 1101266944, 1106562253, 1109576909, 1112224563, 3262355866, 3045472189, 3109140247, 3294509269, 1092616192, 0, 1085422961, 1121859797 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+  - Result: Test2
+    Rule: BufferExact
+    Actual: Out2
+    Expected: ExpectedOut2
+DescriptorSets:
+  - Resources:
+    - Name: In0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: In1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: In2
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: Out2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+#--- end
+
+# https://github.com/llvm/llvm-project/issues/146942
+# XFAIL: Clang-Vulkan
+
+# RUN: split-file %s %t
+# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/asuint.64.test
+++ b/test/Feature/HLSLLib/asuint.64.test
@@ -1,0 +1,94 @@
+#--- source.hlsl
+StructuredBuffer<double4> In0 : register(t0);
+
+RWStructuredBuffer<uint4> Lows : register(u1);
+RWStructuredBuffer<uint4> Highs : register(u2);
+
+[numthreads(1,1,1)]
+void main() {
+
+asuint(In0[0], Lows[0], Highs[0]);
+uint4 Tmp0;
+uint4 Tmp1;
+asuint(In0[1].xyz, Tmp0.xyz, Tmp1.xyz);
+asuint(In0[1].w, Tmp0.w, Tmp1.w);
+Lows[1] = Tmp0;
+Highs[1]= Tmp1;
+asuint(In0[2].xy, Tmp0.xy, Tmp1.xy);
+asuint(In0[2].zw, Tmp0.zw, Tmp1.zw);
+Lows[2] = Tmp0;
+Highs[2] = Tmp1;
+asuint(double4(10, 0, 5.57, 111.111), Lows[3], Highs[3]);
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In0
+    Format: Float64
+    Stride: 32
+    Data: [10, 0, 5.57, 111.111, 20.5, 30.6, 40.7, 50.8, -60.9, -0.000001, -0.0002, -888.888]
+  - Name: Lows
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedLows
+    Format: UInt32
+    Stride: 16
+    Data: [ 0, 0, 343597384, 2680059593, 0, 2576980378, 2576980378, 1717986918, 858993459, 2696277389, 3944497965, 2680059593, 0, 0, 343597384, 2680059593 ] # 536870912, 2684354560 ]
+  - Name: Highs
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedHighs
+    Format: UInt32
+    Stride: 16
+    Data: [ 1076101120, 0, 1075201966, 1079756570, 1077182464, 1077844377, 1078221209, 1078552166, 3226366771, 3199256311, 3207214818, 3230385946, 1076101120, 0, 1075201966, 1079756570 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Lows
+    Expected: ExpectedLows
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Highs
+    Expected: ExpectedHighs
+DescriptorSets:
+  - Resources:
+    - Name: In0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Lows
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Highs
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7666
+# XFAIL: DXC-Vulkan
+
+# https://github.com/llvm/llvm-project/issues/146942
+# XFAIL: Clang-Vulkan
+
+# REQUIRES: Double
+# RUN: split-file %s %t
+# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/asuint.64.test
+++ b/test/Feature/HLSLLib/asuint.64.test
@@ -39,7 +39,7 @@ Buffers:
   - Name: ExpectedLows
     Format: UInt32
     Stride: 16
-    Data: [ 0, 0, 343597384, 2680059593, 0, 2576980378, 2576980378, 1717986918, 858993459, 2696277389, 3944497965, 2680059593, 0, 0, 343597384, 2680059593 ] # 536870912, 2684354560 ]
+    Data: [ 0, 0, 343597384, 2680059593, 0, 2576980378, 2576980378, 1717986918, 858993459, 2696277389, 3944497965, 2680059593, 0, 0, 536870912, 2684354560 ]
   - Name: Highs
     Format: UInt32
     Stride: 16
@@ -90,5 +90,5 @@ DescriptorSets:
 
 # REQUIRES: Double
 # RUN: split-file %s %t
-# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target  -T cs_6_5 -HV 202x -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds a test for 32 bit version of asuint, which does a bit cast
Adds a test for splitdouble version of asuint.
Closes #174