### PR TITLE
Enable structured buffer counter tests for Clang

### DIFF
--- a/test/Feature/StructuredBuffer/dec_counter.test
+++ b/test/Feature/StructuredBuffer/dec_counter.test
@@ -31,9 +31,13 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Vulkan
-# UNSUPPORTED: Metal
-# UNSUPPORTED: Clang
+# Offload tests are missing support for counters on Vulcan
+# https://github.com/llvm/offload-test-suite/issues/303
+# XFAIL: Vulkan
+
+# Offload tests are missing support for counters on Metal
+# https://github.com/llvm/offload-test-suite/issues/304
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/inc_counter.test
+++ b/test/Feature/StructuredBuffer/inc_counter.test
@@ -31,9 +31,13 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Vulkan
-# UNSUPPORTED: Metal
-# UNSUPPORTED: Clang
+# Offload tests are missing support for counters on Vulcan
+# https://github.com/llvm/offload-test-suite/issues/303
+# XFAIL: Vulkan
+
+# Offload tests are missing support for counters on Metal
+# https://github.com/llvm/offload-test-suite/issues/304
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
plus change `UNSUPPORTED:` to `XFAIL:` for Vulkan and Metal and add links to issues.