### PR TITLE
Add tests for resource arrays

### DIFF
--- a/test/Feature/ResourceArrays/array-local.test
+++ b/test/Feature/ResourceArrays/array-local.test
@@ -1,0 +1,90 @@
+#--- source.hlsl
+
+// This test verified handling of resource arrays used as a local
+// variable and function argument.
+
+RWBuffer<float> BufA : register(u0);
+RWBuffer<float> BufB : register(u1);
+RWBuffer<float> Out  : register(u2);
+
+float foo(RWBuffer<float> ArgArray[2], uint Index) {
+    return ArgArray[0][Index] + ArgArray[1][Index] * 10;
+}
+
+float bar(uint Index) {
+  RWBuffer<float> LocalArray[2];
+  LocalArray[0] = BufA;
+  LocalArray[1] = BufB;
+  return foo(LocalArray, Index);
+}
+
+[numthreads(4,2,1)]
+void main(uint GI : SV_GroupIndex) {
+  Out[GI] = bar(GI);
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufA
+    Format: Float32
+    Data: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+
+  - Name: BufB
+    Format: Float32
+    Data: [ 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08 ]
+
+  - Name: BufOut
+    Format: Float32
+    ZeroInitSize: 32
+
+  - Name: ExpectedOut
+    Format: Float32
+    Data: [ 0.1, 1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8 ]
+
+Results:
+  - Result: BufOut
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.0001
+    Actual: BufOut
+    Expected: ExpectedOut
+
+DescriptorSets:
+  - Resources:
+    - Name: BufA
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: BufB
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: BufOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# RUN: split-file %s %t
+# RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
+# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -1,22 +1,24 @@
 #--- source.hlsl
 
-// Another variation testing resource arrays used as a local
-// variable and function argument, making sure the array is
-// always a local copy.
+// Another variation testing resource arrays used as a local variable and
+// function argument. In this case the function SomeFn modifies the array B,
+// which should be a local copy of array A that is defined in main function.
+// The test verifies that this modification of local array B does not affect
+// array A.
 
 RWBuffer<int> X : register(u0);
 RWBuffer<int> Y : register(u1);
 
-void SomeFn(RWBuffer<int> Arr[2], uint Idx, int Val0) {
-  Arr[0] = Y;
-  Arr[0][Idx] = Val0;
+void SomeFn(RWBuffer<int> B[2], uint Idx, int Val0) {
+  B[0] = Y;
+  B[0][Idx] = Val0;
 }
 
 [numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
-  RWBuffer<int> Arr[2] = {X, Y};
-  SomeFn(Arr, GI, 1);
-  Arr[0][GI] = 2;
+  RWBuffer<int> A[2] = {X, Y};
+  SomeFn(A, GI, 1);
+  A[0][GI] = 2;
 }
 
 //--- pipeline.yaml
@@ -74,7 +76,8 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang
 
-# DXC-DirectX has a bug here
+# DXC-DirectX has a bug here because it does not create a local copy
+# of a function argument if the type is resource or resource array.
 https://github.com/microsoft/DirectXShaderCompiler/issues/7678
 # XFAIL: DXC-DirectX
 

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -74,9 +74,8 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang
 
-# DXC-DirectX has a bug here and produces wrong output:
-# BufX: [ 0, 0, 0, 0 ]
-# BufY: [ 2, 2, 2, 2 ]
+# DXC-DirectX has a bug here
+https://github.com/microsoft/DirectXShaderCompiler/issues/7678
 # XFAIL: DXC-DirectX
 
 # Resource arrays are not yet supported on Metal

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -1,0 +1,88 @@
+#--- source.hlsl
+
+// Another variation testing resource arrays used as a local
+// variable and function argument, making sure the array is
+// always a local copy.
+
+RWBuffer<int> X : register(u0);
+RWBuffer<int> Y : register(u1);
+
+void SomeFn(RWBuffer<int> Arr[2], uint Idx, int Val0) {
+  Arr[0] = Y;
+  Arr[0][Idx] = Val0;
+}
+
+[numthreads(4,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  RWBuffer<int> Arr[2] = {X, Y};
+  SomeFn(Arr, GI, 1);
+  Arr[0][GI] = 2;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufX
+    Format: Int32
+    ZeroInitSize: 16
+
+  - Name: BufY
+    Format: Int32
+    ZeroInitSize: 16
+
+  - Name: ExpectedX
+    Format: Int32
+    Data: [ 2, 2, 2, 2 ]
+
+  - Name: ExpectedY
+    Format: Int32
+    Data: [ 1, 1, 1, 1 ]
+
+Results:
+  - Result: BufX
+    Rule: BufferExact
+    Actual: BufX
+    Expected: ExpectedX
+
+  - Result: BufY
+    Rule: BufferExact
+    Actual: BufY
+    Expected: ExpectedY
+
+DescriptorSets:
+  - Resources:
+    - Name: BufX
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: BufY
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# DXC-DirectX has a bug here and produces wrong output:
+# BufX: [ 0, 0, 0, 0 ]
+# BufY: [ 2, 2, 2, 2 ]
+# XFAIL: DXC-DirectX
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# RUN: split-file %s %t
+# RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
+# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-array-global.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-global.test
@@ -5,7 +5,7 @@
 RWBuffer<int> In[2][3] : register(u0);
 RWBuffer<int> Out[2][3] : register(u6);
 
-[numthreads(4,2,1)]
+[numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 3; j++) {

--- a/test/Feature/ResourceArrays/multi-dim-array-global.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-global.test
@@ -1,0 +1,82 @@
+#--- source.hlsl
+
+// This test verified handling of global multi-dimensional resource arrays.
+
+RWBuffer<int> In[2][3] : register(u0);
+RWBuffer<int> Out[2][3] : register(u6);
+
+[numthreads(4,2,1)]
+void main(uint GI : SV_GroupIndex) {
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 3; j++) {
+      Out[i][j][GI] = In[i][j][GI] * 2;
+    }
+  }
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufIn
+    Format: Int32
+    ArraySize: 6
+    Data:
+      - [ 0, 1, 2, 3 ]
+      - [ 1, 2, 3, 4 ]
+      - [ 2, 3, 4, 5 ]
+      - [ 3, 4, 5, 6 ]
+      - [ 4, 5, 6, 7 ]
+      - [ 5, 6, 7, 8 ]
+
+  - Name: BufOut
+    Format: Int32
+    ArraySize: 6
+    ZeroInitSize: 16
+
+  - Name: ExpectedBufOut
+    Format: Int32
+    ArraySize: 6
+    Data:
+      - [ 0, 2, 4, 6 ]
+      - [ 2, 4, 6, 8 ]
+      - [ 4, 6, 8, 10 ]
+      - [ 6, 8, 10, 12 ]
+      - [ 8, 10, 12, 14 ]
+      - [ 10, 12, 14, 16 ]
+
+Results:
+  - Result: BufOut
+    Rule: BufferExact
+    Actual: BufOut
+    Expected: ExpectedBufOut
+
+DescriptorSets:
+  - Resources:
+    - Name: BufIn
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+    - Name: BufOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# Vulkan does not support multi-dimensional resource arrays
+# UNSUPPORTED: Vulkan
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-array-local.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-local.test
@@ -9,7 +9,7 @@ RWBuffer<float> Out  : register(u2);
 
 float foo(RWBuffer<float> A[2][3], uint Index) {
     return A[0][0][Index] + (A[0][1][Index] + 1) * 10 + (A[0][2][Index] + 2) * 100 +
-           A[1][0][Index] + (A[1][1][Index] + 1) / 10 + (A[1][2][Index] + 2) / 100;
+           A[1][0][Index] + (A[1][1][Index] + 0.1) / 10 + (A[1][2][Index] + 0.2) / 100;
 }
 
 float bar(uint Index) {
@@ -77,10 +77,6 @@ DescriptorSets:
 #--- end
 
 # UNSUPPORTED: Clang
-
-# DXC has a bug and produces wrong output:
-# [ 210.12, 321.231, 432.342, 543.453, 654.564, 765.675, 876.786, 987.897 ]
-# XFAIL: DXC
 
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan

--- a/test/Feature/ResourceArrays/multi-dim-array-local.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-local.test
@@ -1,0 +1,94 @@
+#--- source.hlsl
+
+// This test verified handling of multi-dimensional resource arrays
+// used as a local variable and function argument
+
+RWBuffer<float> BufA : register(u0);
+RWBuffer<float> BufB : register(u1);
+RWBuffer<float> Out  : register(u2);
+
+float foo(RWBuffer<float> A[2][3], uint Index) {
+    return A[0][0][Index] + (A[0][1][Index] + 1) * 10 + (A[0][2][Index] + 2) * 100 +
+           A[1][0][Index] + (A[1][1][Index] + 1) / 10 + (A[1][2][Index] + 2) / 100;
+}
+
+float bar(uint Index) {
+  RWBuffer<float> LocalArray[2][3];
+  for (int i = 0; i < 3; i++) {
+    LocalArray[0][i] = BufA;
+    LocalArray[1][i] = BufB;
+  }
+  return foo(LocalArray, Index);
+}
+
+[numthreads(4,2,1)]
+void main(uint GI : SV_GroupIndex) {
+  Out[GI] = bar(GI);
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufA
+    Format: Float32
+    Data: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+
+  - Name: BufB
+    Format: Float32
+    Data: [ 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7 ]
+
+  - Name: BufOut
+    Format: Float32
+    ZeroInitSize: 32
+
+  - Name: ExpectedOut
+    Format: Float32
+    Data: [ 210.012, 321.123, 432.234, 543.345, 654.456, 765.567,
+            876.678, 987.789 ]
+Results:
+  - Result: BufOut
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.001
+    Actual: BufOut
+    Expected: ExpectedOut
+
+DescriptorSets:
+  - Resources:
+    - Name: BufA
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+    - Name: BufB
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+    - Name: BufOut
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# DXC has a bug and produces wrong output:
+# [ 210.12, 321.231, 432.342, 543.453, 654.564, 765.675, 876.786, 987.897 ]
+# XFAIL: DXC
+
+# Vulkan does not support multi-dimensional resource arrays
+# UNSUPPORTED: Vulkan
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# RUN: split-file %s %t
+# RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
+# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -1,0 +1,101 @@
+#--- source.hlsl
+
+// This test verified handling of subsets of multi-dimensional resource
+// arrays used in a function argument.
+
+RWBuffer<float> In[4][2] : register(u0);
+RWBuffer<float> Out : register(u0, space1);
+RWBuffer<float> Out2 : register(u1, space1);
+
+float foo(RWBuffer<float> A[2], uint Index) {
+  return A[0][Index] + A[1][Index];
+}
+
+[numthreads(4,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  // the content of Out1 and Out2 should be identical
+  Out1[GI] = foo(In[GI], GI);
+  Out2[GI] = In[GI][0][GI] + In[GI][1][GI];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: BufIn
+    Format: Float32
+    ArraySize: 8
+    Data:
+      - [ 1.0, 2.0, 3.0, 4.0 ]
+      - [ 0.1, 0.2, 0.3, 0.4 ]
+      - [ 5.0, 6.0, 7.0, 8.0 ]
+      - [ 0.5, 0.6, 0.7, 0.8 ]
+      - [ 10.0, 11.0, 12.0, 13.0 ]
+      - [ 0.10, 0.11, 0.12, 0.13 ]
+      - [ 14.0, 15.0, 16.0, 17.0 ]
+      - [ 0.14, 0.15, 0.16, 0.17 ]
+
+  - Name: BufOut1
+    Format: Float32
+    ZeroInitSize: 16
+
+  - Name: BufOut2
+    Format: Float32
+    ZeroInitSize: 16
+
+  - Name: ExpectedOuts
+    Format: Float32
+    Data: [ 1.1, 6.6, 12.12, 17.17 ]
+
+Results:
+  - Result: BufOut1
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.00001
+    Actual: BufOut1
+    Expected: ExpectedOuts
+
+  - Result: BufOut2
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.00001
+    Actual: BufOut2
+    Expected: ExpectedOuts
+
+DescriptorSets:
+  - Resources:
+    - Name: BufIn
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+    - Name: BufOut1
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 1
+    - Name: BufOut2
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 1
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# DXC has a bug here and produces wrong output:
+# [ 2, 12, 13.2, 18.7 ]
+# XFAIL: DXC
+
+# Vulkan does not support multi-dimensional resource arrays
+# UNSUPPORTED: Vulkan
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# RUN: split-file %s %t
+# RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
+# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -12,7 +12,6 @@ float foo(RWBuffer<float> A[2], uint Index) {
 
 [numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
-  // the content of Out1 and Out2 should be identical
   Out[GI] = foo(In[GI], GI);
 }
 

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -5,7 +5,6 @@
 
 RWBuffer<float> In[4][2] : register(u0);
 RWBuffer<float> Out : register(u0, space1);
-RWBuffer<float> Out2 : register(u1, space1);
 
 float foo(RWBuffer<float> A[2], uint Index) {
   return A[0][Index] + A[1][Index];
@@ -14,8 +13,7 @@ float foo(RWBuffer<float> A[2], uint Index) {
 [numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
   // the content of Out1 and Out2 should be identical
-  Out1[GI] = foo(In[GI], GI);
-  Out2[GI] = In[GI][0][GI] + In[GI][1][GI];
+  Out[GI] = foo(In[GI], GI);
 }
 
 //--- pipeline.yaml
@@ -38,30 +36,20 @@ Buffers:
       - [ 14.0, 15.0, 16.0, 17.0 ]
       - [ 0.14, 0.15, 0.16, 0.17 ]
 
-  - Name: BufOut1
+  - Name: BufOut
     Format: Float32
     ZeroInitSize: 16
 
-  - Name: BufOut2
-    Format: Float32
-    ZeroInitSize: 16
-
-  - Name: ExpectedOuts
+  - Name: ExpectedOut
     Format: Float32
     Data: [ 1.1, 6.6, 12.12, 17.17 ]
 
 Results:
-  - Result: BufOut1
+  - Result: BufOut
     Rule: BufferFloatEpsilon
     Epsilon: 0.00001
-    Actual: BufOut1
-    Expected: ExpectedOuts
-
-  - Result: BufOut2
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.00001
-    Actual: BufOut2
-    Expected: ExpectedOuts
+    Actual: BufOut
+    Expected: ExpectedOut
 
 DescriptorSets:
   - Resources:
@@ -70,24 +58,15 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
-    - Name: BufOut1
+    - Name: BufOut
       Kind: RWBuffer
       DirectXBinding:
         Register: 0
-        Space: 1
-    - Name: BufOut2
-      Kind: RWBuffer
-      DirectXBinding:
-        Register: 1
         Space: 1
 ...
 #--- end
 
 # UNSUPPORTED: Clang
-
-# DXC has a bug here and produces wrong output:
-# [ 2, 12, 13.2, 18.7 ]
-# XFAIL: DXC
 
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan

--- a/test/Feature/ResourceArrays/multi-dim-unbounded-array.test
+++ b/test/Feature/ResourceArrays/multi-dim-unbounded-array.test
@@ -1,0 +1,73 @@
+#--- source.hlsl
+
+// This test verified handling of unbounded multi-dimensional resource array.
+
+RWBuffer<int> Buf[][2] : register(u0);
+
+[numthreads(4,2,1)]
+void main(uint3 GTI : SV_GroupThreadID, uint GI : SV_GroupIndex) {
+  for (int i = 0; i < 4; i++) {
+    Buf[GTI.x][GTI.y][i] = Buf[GTI.x][GTI.y][i] + 100 * GI;
+  } 
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Buf
+    Format: Int32
+    ArraySize: 8
+    Data:
+      - [ 0, 1, 2, 3 ]
+      - [ 1, 2, 3, 4 ]
+      - [ 2, 3, 4, 5 ]
+      - [ 3, 4, 5, 6 ]
+      - [ 4, 5, 6, 7 ]
+      - [ 5, 6, 7, 8 ]
+      - [ 6, 7, 8, 9 ]
+      - [ 7, 8, 9, 10 ]
+
+  - Name: ExpectedBuf
+    Format: Int32
+    ArraySize: 8
+    Data:
+      - [ 0, 1, 2, 3 ]
+      - [ 401, 402, 403, 404 ]
+      - [ 102, 103, 104, 105 ]
+      - [ 503, 504, 505, 506 ]
+      - [ 204, 205, 206, 207 ]
+      - [ 605, 606, 607, 608 ]
+      - [ 306, 307, 308, 309 ]
+      - [ 707, 708, 709, 710 ]
+
+Results:
+  - Result: Buf
+    Rule: BufferExact
+    Actual: Buf
+    Expected: ExpectedBuf
+
+DescriptorSets:
+  - Resources:
+    - Name: Buf
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# Vulkan does not support multi-dimensional resource arrays
+# UNSUPPORTED: Vulkan
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/unbounded-array.test
+++ b/test/Feature/ResourceArrays/unbounded-array.test
@@ -1,0 +1,74 @@
+#--- source.hlsl
+
+// This test verified handling of unbounded resource array.
+
+[[vk::binding(0)]]
+RWBuffer<int> Buf[] : register(u0);
+
+[numthreads(4,2,1)]
+void main(uint GI : SV_GroupIndex) {
+  for (int i = 0; i < 4; i++) {
+    Buf[GI][i] = GI * 100 + Buf[GI][i];
+  }
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Buf
+    Format: Int32
+    ArraySize: 8
+    Data:
+      - [ 0, 1, 2, 3 ]
+      - [ 1, 2, 3, 4 ]
+      - [ 2, 3, 4, 5 ]
+      - [ 3, 4, 5, 6 ]
+      - [ 4, 5, 6, 7 ]
+      - [ 5, 6, 7, 8 ]
+      - [ 6, 7, 8, 9 ]
+      - [ 7, 8, 9, 10 ]
+
+  - Name: ExpectedBuf
+    Format: Int32
+    ArraySize: 8
+    Data:
+      - [ 0, 1, 2, 3 ]
+      - [ 101, 102, 103, 104 ]
+      - [ 202, 203, 204, 205 ]
+      - [ 303, 304, 305, 306 ]
+      - [ 404, 405, 406, 407 ]
+      - [ 505, 506, 507, 508 ]
+      - [ 606, 607, 608, 609 ]
+      - [ 707, 708, 709, 710 ]
+
+Results:
+  - Result: Buf
+    Rule: BufferExact
+    Actual: Buf
+    Expected: ExpectedBuf
+
+DescriptorSets:
+  - Resources:
+    - Name: Buf
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# UNSUPPORTED: Clang
+
+# Resource arrays are not yet supported on Metal
+# UNSUPPORTED: Metal
+
+# RUN: split-file %s %t
+# RUN: %if !Vulkan %{ %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl %}
+# RUN: %if Vulkan %{ %dxc_target -T cs_6_0 -fspv-target-env=vulkan1.3 -fvk-use-scalar-layout -Fo %t.o %t/source.hlsl %}
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Add tests for arrays of resources to the offload test suite, including arrays declared locally or used as function arguments, multi-dimensional arrays, or subsets of multi-dimensional arrays. One test for global arrays was already added in #302 when support for resource arrays was added to the offload test suite.

Closes llvm/wg-hlsl#292