### PR TITLE
Add `reversebits` tests

### DIFF
--- a/test/Feature/HLSLLib/reversebits.16.test
+++ b/test/Feature/HLSLLib/reversebits.16.test
@@ -57,6 +57,12 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7680
+# XFAIL: DXC-Vulkan
+
+# https://github.com/llvm/llvm-project/issues/152049
+# XFAIL: Clang-Vulkan
+
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/reversebits.16.test
+++ b/test/Feature/HLSLLib/reversebits.16.test
@@ -1,0 +1,64 @@
+#--- source.hlsl
+
+StructuredBuffer<uint16_t4> In : register(t0);
+RWStructuredBuffer<uint16_t4> Out : register(u1);
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = reversebits(In[0]);
+  uint16_t4 Tmp = {reversebits(In[1].xyz), reversebits(In[1].w)};
+  Out[1] = Tmp;
+  uint16_t4 Tmp2 = {reversebits(In[2].xy), reversebits(In[2].zw)};
+  Out[2] = Tmp2;
+  Out[3] = reversebits(uint16_t4(0, 1, 8, 32767));
+}
+
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: UInt16
+    Stride: 8
+    Data: [ 0, 1, 8, 256, 32767, 65535, 21845, 61680, 4680, 33825, 3976, 49155 ]
+  - Name: Out
+    Format: UInt16
+    Stride: 8
+    ZeroInitSize: 32
+  - Name: ExpectedOut # The result we expect
+    Format: UInt16
+    Stride: 8
+    Data: [ 0, 32768, 4096, 128, 65534, 65535, 43690, 3855, 4680, 33825, 4592, 49155, 0, 32768, 4096, 65534 ]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# REQUIRES: Int16
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.32.test
+++ b/test/Feature/HLSLLib/reversebits.32.test
@@ -1,14 +1,14 @@
 #--- source.hlsl
 
-StructuredBuffer<uint16_t4> In : register(t0);
-RWStructuredBuffer<uint16_t4> Out : register(u1);
+StructuredBuffer<uint32_t4> In : register(t0);
+RWStructuredBuffer<uint32_t4> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
   Out[0] = reversebits(In[0]);
-  uint16_t4 Tmp = {reversebits(In[1].xyz), reversebits(In[1].w)};
+  uint32_t4 Tmp = {reversebits(In[1].xyz), reversebits(In[1].w)};
   Out[1] = Tmp;
-  uint16_t4 Tmp2 = {reversebits(In[2].xy), reversebits(uint16_t2(0, 256))};
+  uint32_t4 Tmp2 = {reversebits(In[2].xy), reversebits(uint32_t2(0, 65536))};
   Out[2] = Tmp2;
 }
 
@@ -22,17 +22,17 @@ Shaders:
     DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
-    Format: UInt16
-    Stride: 8
-    Data: [ 0, 1, 8, 0x0100, 0x7FFF, 0xFFFF, 0x5555, 0xF0F0, 0x0F88, 0xC003, 0, 0 ] # Last two are filler
+    Format: UInt32
+    Stride: 16
+    Data: [ 0, 1, 8, 0x00010000, 0x7FFFFFFF, 0xFFFFFFFF, 0x55555555, 0xF0F0F0F0, 0x0F880F88, 0xC003C003, 0, 0 ] # Last two are filler
   - Name: Out
-    Format: UInt16
-    Stride: 8
-    ZeroInitSize: 24
+    Format: UInt32
+    Stride: 16
+    ZeroInitSize: 48
   - Name: ExpectedOut # The result we expect
-    Format: UInt16
-    Stride: 8
-    Data: [ 0, 32768, 4096, 0x0080, 0xFFFE, 0xFFFF, 0xAAAA, 0x0F0F, 0x11F0, 0xC003, 0, 128 ]    
+    Format: UInt32
+    Stride: 16
+    Data: [ 0, 2147483648, 268435456, 0x00008000, 0xFFFFFFFE, 0xFFFFFFFF, 0xAAAAAAAA, 0x0F0F0F0F, 0x11F011F0, 0xC003C003, 0, 32768 ]
 Results:
   - Result: Test1
     Rule: BufferExact
@@ -57,7 +57,6 @@ DescriptorSets:
 ...
 #--- end
 
-# REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.32.test
+++ b/test/Feature/HLSLLib/reversebits.32.test
@@ -58,5 +58,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.32.test
+++ b/test/Feature/HLSLLib/reversebits.32.test
@@ -57,6 +57,9 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/152049
+# XFAIL: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -59,5 +59,5 @@ DescriptorSets:
 
 # REQUIRES: Int64
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -1,14 +1,14 @@
 #--- source.hlsl
 
-StructuredBuffer<uint16_t4> In : register(t0);
-RWStructuredBuffer<uint16_t4> Out : register(u1);
+StructuredBuffer<uint64_t4> In : register(t0);
+RWStructuredBuffer<uint64_t4> Out : register(u1);
 
 [numthreads(1,1,1)]
 void main() {
   Out[0] = reversebits(In[0]);
-  uint16_t4 Tmp = {reversebits(In[1].xyz), reversebits(In[1].w)};
+  uint64_t4 Tmp = {reversebits(In[1].xyz), reversebits(In[1].w)};
   Out[1] = Tmp;
-  uint16_t4 Tmp2 = {reversebits(In[2].xy), reversebits(uint16_t2(0, 256))};
+  uint64_t4 Tmp2 = {reversebits(In[2].xy), reversebits(uint64_t2(0, 4294967296))};
   Out[2] = Tmp2;
 }
 
@@ -22,17 +22,17 @@ Shaders:
     DispatchSize: [1, 1, 1]
 Buffers:
   - Name: In
-    Format: UInt16
-    Stride: 8
-    Data: [ 0, 1, 8, 0x0100, 0x7FFF, 0xFFFF, 0x5555, 0xF0F0, 0x0F88, 0xC003, 0, 0 ] # Last two are filler
+    Format: UInt64
+    Stride: 32
+    Data: [ 0, 1, 8, 0x0000000100000000, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0x5555555555555555, 0xF0F0F0F0F0F0F0F0, 0x0F880F880F880F88, 0xC003C003C003C003, 0, 0 ] # Last two are filler
   - Name: Out
-    Format: UInt16
-    Stride: 8
-    ZeroInitSize: 24
+    Format: UInt64
+    Stride: 32
+    ZeroInitSize: 96
   - Name: ExpectedOut # The result we expect
-    Format: UInt16
-    Stride: 8
-    Data: [ 0, 32768, 4096, 0x0080, 0xFFFE, 0xFFFF, 0xAAAA, 0x0F0F, 0x11F0, 0xC003, 0, 128 ]    
+    Format: UInt64
+    Stride: 32
+    Data: [ 0, 9223372036854775808, 1152921504606846976, 0x0000000080000000, 0xFFFFFFFFFFFFFFFE, 0xFFFFFFFFFFFFFFFF, 0xAAAAAAAAAAAAAAAA, 0x0F0F0F0F0F0F0F0F, 0x11F011F011F011F0, 0xC003C003C003C003, 0, 2147483648 ]
 Results:
   - Result: Test1
     Rule: BufferExact
@@ -57,7 +57,7 @@ DescriptorSets:
 ...
 #--- end
 
-# REQUIRES: Int16
+# REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/reversebits.64.test
+++ b/test/Feature/HLSLLib/reversebits.64.test
@@ -57,6 +57,12 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/microsoft/DirectXShaderCompiler/issues/7680
+# XFAIL: DXC-Vulkan
+
+# https://github.com/llvm/llvm-project/issues/152049
+# XFAIL: Clang-Vulkan
+
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Closes #135.

Adds tests for `reversebits` testing `UInt16`, `UInt32`, `UInt64` types. Some values for 16 bit and 32 bit pulled from [HLK tests](https://github.com/microsoft/DirectXShaderCompiler/blob/57177f77a4dc6996400ac97a0d618799c82374e8/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml#L2647), but those tested signed ints so ended up not really being the same. No HLK test for 64 bit.
Need to remove XFAILs after [#7680](https://github.com/microsoft/DirectXShaderCompiler/issues/7680) and [#152049](https://github.com/llvm/llvm-project/issues/152049) are fixed.