### PR TITLE
Checking to see if exp16 is reliable at smaller values

### DIFF
--- a/test/Feature/HLSLLib/exp.16.test
+++ b/test/Feature/HLSLLib/exp.16.test
@@ -25,7 +25,7 @@ Buffers:
   - Name: In
     Format: Float16
     Stride: 8
-    Data: [ 0x7e00, 0xfc00, 0x8001, 0x8000, 0x0000, 0x0001, 0x7c00, 0xbc00, 0x4900, 0x7e00, 0x7e00, 0x7e00,]
+    Data: [ 0x7e00, 0xfc00, 0x8001, 0x8000, 0x0000, 0x0001, 0x7c00, 0xbc00, 0x4000, 0x7e00, 0x7e00, 0x7e00,]
     #  NaN, -Inf, -denorm, -0, 0, denorm, Inf, -1, 10,
   - Name: Out
     Format: Float16
@@ -34,7 +34,7 @@ Buffers:
   - Name: ExpectedOut # The result we expect
     Format: Float16
     Stride: 8
-    Data: [ 0x7e00, 0x0000, 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0x7c00, 0x35e3, 0x7561, 0x7e00, 0x7e00, 0x7e00,]
+    Data: [ 0x7e00, 0x0000, 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0x7c00, 0x35e3, 0x4764, 0x7e00, 0x7e00, 0x7e00,]
     #  NaN, 0, 1, 1, 1, 1, Inf, 0.367879441, 22026.46579,
 Results:
   - Result: Test1
@@ -61,11 +61,6 @@ DescriptorSets:
 ...
 #--- end
 
-# 16bit-hlk-issue-7570
-# https://github.com/microsoft/DirectXShaderCompiler/issues/7570
-# no hlk tests for 16 bit exp so unsure of correct driver behavior for 10
-# XFAIL: Clang
-# XFAIL: DXC
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
For fp16 exp(10) is a quite large number to represent in fp16, so it is possible (maybe even likely) that the precision loss is massively increased causing the problems resulting in the XFAILs. Trying this with a smaller value to see if it fixes the issue.