### PR TITLE
Add windows-amd and windows-nvidia GitHub workflows for the two new machines

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-intel]
+        SKU: [windows-amd, windows-intel, windows-nvidia]
         TestTarget: [check-hlsl-d3d12, check-hlsl-warp-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-warp-d3d12, check-hlsl-clang-vk]
 
     uses: ./.github/workflows/build-and-test-callable.yaml

--- a/.github/workflows/windows-amd-clang-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12.yaml
@@ -1,0 +1,20 @@
+name: Windows D3D12 AMD Clang
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-D3D12-AMD-Clang:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      TestTarget: check-hlsl-clang-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-amd-clang-vk.yaml
+++ b/.github/workflows/windows-amd-clang-vk.yaml
@@ -1,0 +1,20 @@
+name: Windows Vulkan AMD Clang
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-VK-AMD-Clang:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      TestTarget: check-hlsl-clang-vk
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -1,0 +1,20 @@
+name: Windows D3D12 Warp Clang
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-D3D12-Warp-Clang:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      TestTarget: check-hlsl-clang-warp-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-amd-dxc-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-d3d12.yaml
@@ -1,0 +1,21 @@
+name: Windows D3D12 AMD DXC
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *' # run every 30 minutes
+
+jobs:
+  Windows-D3D12-AMD-DXC:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      BuildType: Debug
+      TestTarget: check-hlsl-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-dxc-vk.yaml
+++ b/.github/workflows/windows-amd-dxc-vk.yaml
@@ -1,0 +1,21 @@
+name: Windows Vulkan AMD DXC
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-VK-AMD-DXC:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      BuildType: Debug
+      TestTarget: check-hlsl-vk
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
@@ -1,0 +1,21 @@
+name: Windows D3D12 Warp DXC
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-D3D12-Warp-DXC:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-amd
+      BuildType: Debug
+      TestTarget: check-hlsl-warp-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-clang-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-d3d12.yaml
@@ -1,0 +1,20 @@
+name: Windows D3D12 NVIDIA Clang
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-D3D12-NVIDIA-Clang:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      TestTarget: check-hlsl-clang-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-nvidia-clang-vk.yaml
+++ b/.github/workflows/windows-nvidia-clang-vk.yaml
@@ -1,0 +1,20 @@
+name: Windows Vulkan NVIDIA Clang
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-VK-NVIDIA-Clang:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      TestTarget: check-hlsl-clang-vk
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-nvidia-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-clang-warp-d3d12.yaml
@@ -1,0 +1,20 @@
+name: Windows D3D12 Warp Clang
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-D3D12-Warp-Clang:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      TestTarget: check-hlsl-clang-warp-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=On

--- a/.github/workflows/windows-nvidia-dxc-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-dxc-d3d12.yaml
@@ -1,0 +1,21 @@
+name: Windows D3D12 NVIDIA DXC
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *' # run every 30 minutes
+
+jobs:
+  Windows-D3D12-NVIDIA-DXC:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      BuildType: Debug
+      TestTarget: check-hlsl-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-dxc-vk.yaml
+++ b/.github/workflows/windows-nvidia-dxc-vk.yaml
@@ -1,0 +1,21 @@
+name: Windows Vulkan NVIDIA DXC
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-VK-NVIDIA-DXC:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      BuildType: Debug
+      TestTarget: check-hlsl-vk
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl

--- a/.github/workflows/windows-nvidia-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-nvidia-dxc-warp-d3d12.yaml
@@ -1,0 +1,21 @@
+name: Windows D3D12 Warp DXC
+
+permissions:
+  contents: read
+  checks: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */2 * * *' # run every 2 hours
+
+jobs:
+  Windows-D3D12-Warp-DXC:
+    uses: ./.github/workflows/build-and-test-callable.yaml
+    with:
+      OS: windows
+      SKU: windows-nvidia
+      BuildType: Debug
+      TestTarget: check-hlsl-warp-d3d12
+      OffloadTest-branch: ${{ github.ref }}
+      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl


### PR DESCRIPTION
This PR duplicates the existing windows-intel github workflows to support the new windows-amd and windows-nvidia machines. 

windows-amd and windows-nvidia have also been added to the pr-matrix workflow SKUs for the Exec-Tests-Windows job.