### PR TITLE
Add `dot` tests

### DIFF
--- a/test/Feature/HLSLLib/dot.32.test
+++ b/test/Feature/HLSLLib/dot.32.test
@@ -1,0 +1,195 @@
+#--- source.hlsl
+StructuredBuffer<float4> X0 : register(t0);
+StructuredBuffer<float4> Y0 : register(t1);
+StructuredBuffer<int4> X1 : register(t2);
+StructuredBuffer<int4> Y1 : register(t3);
+StructuredBuffer<uint4> X2 : register(t4);
+StructuredBuffer<uint4> Y2 : register(t5);
+
+RWStructuredBuffer<float> Out0 : register(u6);
+RWStructuredBuffer<int> Out1 : register(u7);
+RWStructuredBuffer<uint> Out2 : register(u8);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // float
+  Out0[0] = dot(X0[0].x, Y0[0].x);
+  Out0[1] = dot(float(1.125), float(7.29));
+
+  Out0[2] = dot(X0[0].xy, Y0[0].xy);
+  Out0[3] = dot(float2(1.125, -2.5), float2(7.29, 3.14));
+
+  Out0[4] = dot(X0[0].xyz, Y0[0].xyz);
+  Out0[5] = dot(float3(1.125, -2.5, -4.75), float3(7.29, 3.14, -1.1));
+  
+  Out0[6] = dot(X0[0], Y0[0]);
+  Out0[7] = dot(float4(1.125, -2.5, -4.75, 6.625), float4(7.29, 3.14, -1.1, -3.5));
+
+  // int
+  Out1[0] = dot(X1[0].x, Y1[0].x);
+  Out1[1] = dot(int(100), int(25));
+
+  Out1[2] = dot(X1[0].xy, Y1[0].xy);
+  Out1[3] = dot(int2(100, -52), int2(25, 43));
+
+  Out1[4] = dot(X1[0].xyz, Y1[0].xyz);
+  Out1[5] = dot(int3(100, -52, -210), int3(25, 43, -16));
+
+  Out1[6] = dot(X1[0], Y1[0]);
+  Out1[7] = dot(int4(100, -52, -210, 75), int4(25, 43, -16, -62));
+
+  // uint
+  Out2[0] = dot(X2[0].x, Y2[0].x);
+  Out2[1] = dot(uint(100), uint(25));
+
+  Out2[2] = dot(X2[0].xy, Y2[0].xy);
+  Out2[3] = dot(uint2(100, 52), uint2(25, 43));
+
+  Out2[4] = dot(X2[0].xyz, Y2[0].xyz);
+  Out2[5] = dot(uint3(100, 52, 210), uint3(25, 43, 16));
+
+  Out2[6] = dot(X2[0], Y2[0]);
+  Out2[7] = dot(uint4(100, 52, 210, 75), uint4(25, 43, 16, 62));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X0
+    Format: Float32
+    Stride: 16
+    Data: [ 1.125, -2.5, -4.75, 6.625 ]
+  - Name: Y0
+    Format: Float32
+    Stride: 16
+    Data: [ 7.29, 3.14, -1.1, -3.5 ]
+  - Name: X1
+    Format: Int32
+    Stride: 16
+    Data: [ 100, -52, -210, 75 ]
+  - Name: Y1
+    Format: Int32
+    Stride: 16
+    Data: [ 25, 43, -16, -62 ]
+  - Name: X2
+    Format: UInt32
+    Stride: 16
+    Data: [ 100, 52, 210, 75 ]
+  - Name: Y2
+    Format: UInt32
+    Stride: 16
+    Data: [ 25, 43, 16, 62 ]
+  - Name: Out0
+    Format: Float32
+    Stride: 4
+    ZeroInitSize: 32
+  - Name: ExpectedOut0
+    Format: Float32
+    Stride: 4
+    Data: [ 8.20125, 8.20125, 0.35125, 0.35125, 5.57625, 5.57625, -17.61125, -17.61125 ]
+  - Name: Out1
+    Format: Int32
+    Stride: 4
+    ZeroInitSize: 32
+  - Name: ExpectedOut1
+    Format: Int32
+    Stride: 4
+    Data: [ 2500, 2500, 264, 264, 3624, 3624, -1026, -1026 ]
+  - Name: Out2
+    Format: UInt32
+    Stride: 4
+    ZeroInitSize: 32
+  - Name: ExpectedOut2
+    Format: UInt32
+    Stride: 4
+    Data: [ 2500, 2500, 4736, 4736, 8096, 8096, 12746, 12746 ]
+Results:
+  - Result: Test0
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.008
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+  - Result: Test2
+    Rule: BufferExact
+    Actual: Out2
+    Expected: ExpectedOut2
+DescriptorSets:
+  - Resources:
+    - Name: X0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: X1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Y1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: X2
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: Y2
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 7
+        Space: 0
+      VulkanBinding:
+        Binding: 7
+    - Name: Out2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 8
+        Space: 0
+      VulkanBinding:
+        Binding: 8
+#--- end
+
+
+# RUN: split-file %s %t
+# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot.32.test
+++ b/test/Feature/HLSLLib/dot.32.test
@@ -189,6 +189,8 @@ DescriptorSets:
         Binding: 8
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/149561
+# XFAIL: Clang-Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/dot.fp16.test
+++ b/test/Feature/HLSLLib/dot.fp16.test
@@ -8,14 +8,16 @@ RWStructuredBuffer<half> Out : register(u2);
 [numthreads(1,1,1)]
 void main() {
   Out[0] = dot(X[0].x, Y[0].x);
-  Out[1] = dot(X[0].xy, Y[0].xy);
-  Out[2] = dot(X[0].xyz, Y[0].xyz);
-  Out[3] = dot(X[0], Y[0]);
+  Out[1] = dot(half(1.125), half(7.29));
 
-  Out[4] = dot(X[1].x, Y[1].x);
-  Out[5] = dot(X[1].xy, Y[1].xy);
-  Out[6] = dot(X[1].xyz, Y[1].xyz);
-  Out[7] = dot(X[1], Y[1]);
+  Out[2] = dot(X[0].xy, Y[0].xy);
+  Out[3] = dot(half2(1.125, -2.5), half2(7.29, 3.14));
+
+  Out[4] = dot(X[0].xyz, Y[0].xyz);
+  Out[5] = dot(half3(1.125, -2.5, -4.75), half3(7.29, 3.14, -1.1));
+  
+  Out[6] = dot(X[0], Y[0]);
+  Out[7] = dot(half4(1.125, -2.5, -4.75, 6.625), half4(7.29, 3.14, -1.1, -3.5));
 }
 //--- pipeline.yaml
 
@@ -28,26 +30,26 @@ Buffers:
   - Name: X
     Format: Float16
     Stride: 8
-    Data: [ 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0xc900, 0x0000, 0x0000, 0x4900 ]
-    # [ 1, 1, 1, 1, -10, 0, 0, 10 ]
+    Data: [ 0x3c80, 0xc100, 0xc4c0, 0x46a0 ]
+    # [ 1.125, -2.5, -4.75, 6.625 ]
   - Name: Y
     Format: Float16
     Stride: 8
-    Data: [ 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0x4900, 0x0000, 0x0000, 0x4900 ]
-    # [ 1, 1, 1, 1, 10, 0, 0, 10 ]
+    Data: [ 0x474a, 0x4247, 0xbc66, 0xc300 ]
+    # [ 7.29, 3.14, -1.1, -3.5 ]
   - Name: Out
     Format: Float16
-    Stride: 8
+    Stride: 2
     ZeroInitSize: 16
   - Name: ExpectedOut
     Format: Float16
-    Stride: 8
-    Data: [ 0x3C00, 0x4000, 0x4200, 0x4400, 0xd640, 0xd640, 0xd640, 0x0000 ]
-    # [ 1, 2, 3, 4, -100, -100, -100, 0 ]
+    Stride: 2
+    Data: [ 0x481a, 0x481a, 0x359f, 0x359f, 0x4594, 0x4594, 0xcc67, 0xcc67 ]
+    # [ 8.20125, 8.20125, 0.35125, 0.35125, 5.57625, 5.57625, -17.61125, -17.61125 ]
 Results:
   - Result: Test1
     Rule: BufferFloatEpsilon
-    Epsilon: 0.0008
+    Epsilon: 1
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/dot.fp16.test
+++ b/test/Feature/HLSLLib/dot.fp16.test
@@ -77,6 +77,9 @@ DescriptorSets:
         Binding: 2
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/149561
+# XFAIL: Clang-Vulkan
+
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/dot.fp16.test
+++ b/test/Feature/HLSLLib/dot.fp16.test
@@ -49,7 +49,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatEpsilon
-    Epsilon: 1
+    Epsilon: 0.008
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/dot.fp16.test
+++ b/test/Feature/HLSLLib/dot.fp16.test
@@ -1,0 +1,81 @@
+#--- source.hlsl
+StructuredBuffer<half4> X : register(t0);
+StructuredBuffer<half4> Y : register(t1);
+
+RWStructuredBuffer<half> Out : register(u2);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = dot(X[0].x, Y[0].x);
+  Out[1] = dot(X[0].xy, Y[0].xy);
+  Out[2] = dot(X[0].xyz, Y[0].xyz);
+  Out[3] = dot(X[0], Y[0]);
+
+  Out[4] = dot(X[1].x, Y[1].x);
+  Out[5] = dot(X[1].xy, Y[1].xy);
+  Out[6] = dot(X[1].xyz, Y[1].xyz);
+  Out[7] = dot(X[1], Y[1]);
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0xc900, 0x0000, 0x0000, 0x4900 ]
+    # [ 1, 1, 1, 1, -10, 0, 0, 10 ]
+  - Name: Y
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0x4900, 0x0000, 0x0000, 0x4900 ]
+    # [ 1, 1, 1, 1, 10, 0, 0, 10 ]
+  - Name: Out
+    Format: Float16
+    Stride: 8
+    ZeroInitSize: 16
+  - Name: ExpectedOut
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3C00, 0x4000, 0x4200, 0x4400, 0xd640, 0xd640, 0xd640, 0x0000 ]
+    # [ 1, 2, 3, 4, -100, -100, -100, 0 ]
+Results:
+  - Result: Test1
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.0008
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# REQUIRES: Half
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot.fp64.test
+++ b/test/Feature/HLSLLib/dot.fp64.test
@@ -1,22 +1,22 @@
 #--- source.hlsl
-StructuredBuffer<double4> X : register(t0);
-StructuredBuffer<double4> Y : register(t1);
+StructuredBuffer<double> X : register(t0);
+StructuredBuffer<double> Y : register(t1);
 
 RWStructuredBuffer<double> Out : register(u2);
 
 
 [numthreads(1,1,1)]
 void main() {
-  Out[0] = dot(X[0].x, Y[0].x);
+  Out[0] = dot(X[0], Y[0]);
   Out[1] = dot(double(1.125), double(7.29));
 
-  Out[2] = dot(X[0].y, Y[0].y);
+  Out[2] = dot(X[1], Y[1]);
   Out[3] = dot(double(-2.5), double(3.14));
 
-  Out[4] = dot(X[0].z, Y[0].z);
+  Out[4] = dot(X[2], Y[2]);
   Out[5] = dot(double(-4.75), double(-1.1));
   
-  Out[6] = dot(X[0].w, Y[0].w);
+  Out[6] = dot(X[3], Y[3]);
   Out[7] = dot(double(6.625), double(-3.5));
 }
 //--- pipeline.yaml
@@ -29,11 +29,11 @@ Shaders:
 Buffers:
   - Name: X
     Format: Float64
-    Stride: 32
+    Stride: 8
     Data: [ 1.125, -2.5, -4.75, 6.625 ]
   - Name: Y
     Format: Float64
-    Stride: 32
+    Stride: 8
     Data: [ 7.29, 3.14, -1.1, -3.5 ]
   - Name: Out
     Format: Float64

--- a/test/Feature/HLSLLib/dot.fp64.test
+++ b/test/Feature/HLSLLib/dot.fp64.test
@@ -1,0 +1,80 @@
+#--- source.hlsl
+StructuredBuffer<double4> X : register(t0);
+StructuredBuffer<double4> Y : register(t1);
+
+RWStructuredBuffer<double> Out : register(u2);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = dot(X[0].x, Y[0].x);
+  Out[1] = dot(double(1.125), double(7.29));
+
+  Out[2] = dot(X[0].y, Y[0].y);
+  Out[3] = dot(double(-2.5), double(3.14));
+
+  Out[4] = dot(X[0].z, Y[0].z);
+  Out[5] = dot(double(-4.75), double(-1.1));
+  
+  Out[6] = dot(X[0].w, Y[0].w);
+  Out[7] = dot(double(6.625), double(-3.5));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X
+    Format: Float64
+    Stride: 32
+    Data: [ 1.125, -2.5, -4.75, 6.625 ]
+  - Name: Y
+    Format: Float64
+    Stride: 32
+    Data: [ 7.29, 3.14, -1.1, -3.5 ]
+  - Name: Out
+    Format: Float64
+    Stride: 8
+    ZeroInitSize: 64
+  - Name: ExpectedOut
+    Format: Float64
+    Stride: 32
+    Data: [ 8.20125, 8.20125, -7.85, -7.85, 5.225, 5.225, -23.1875, -23.1875 ]
+Results:
+  - Result: Test0
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.008
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# REQUIRES: Double
+# RUN: split-file %s %t
+# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot.fp64.test
+++ b/test/Feature/HLSLLib/dot.fp64.test
@@ -74,6 +74,9 @@ DescriptorSets:
         Binding: 2
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/149561
+# XFAIL: Clang-Vulkan
+
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/dot.fp64.test
+++ b/test/Feature/HLSLLib/dot.fp64.test
@@ -41,7 +41,7 @@ Buffers:
     ZeroInitSize: 64
   - Name: ExpectedOut
     Format: Float64
-    Stride: 32
+    Stride: 8
     Data: [ 8.20125, 8.20125, -7.85, -7.85, 5.225, 5.225, -23.1875, -23.1875 ]
 Results:
   - Result: Test0

--- a/test/Feature/HLSLLib/dot.int16.test
+++ b/test/Feature/HLSLLib/dot.int16.test
@@ -1,0 +1,137 @@
+#--- source.hlsl
+StructuredBuffer<int16_t4> X0 : register(t0);
+StructuredBuffer<int16_t4> Y0 : register(t1);
+StructuredBuffer<uint16_t4> X1 : register(t2);
+StructuredBuffer<uint16_t4> Y1 : register(t3);
+
+RWStructuredBuffer<int16_t> Out0 : register(u4);
+RWStructuredBuffer<uint16_t> Out1 : register(u5);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // int16_t
+  Out0[0] = dot(X0[0].x, Y0[0].x);
+  Out0[1] = dot(int16_t(100), int16_t(25));
+
+  Out0[2] = dot(X0[0].xy, Y0[0].xy);
+  Out0[3] = dot(int16_t2(100, -52), int16_t2(25, 43));
+
+  Out0[4] = dot(X0[0].xyz, Y0[0].xyz);
+  Out0[5] = dot(int16_t3(100, -52, -210), int16_t3(25, 43, -16));
+
+  Out0[6] = dot(X0[0], Y0[0]);
+  Out0[7] = dot(int16_t4(100, -52, -210, 75), int16_t4(25, 43, -16, -62));
+
+  // uint16_t
+  Out1[0] = dot(X1[0].x, Y1[0].x);
+  Out1[1] = dot(uint16_t(100), uint16_t(25));
+
+  Out1[2] = dot(X1[0].xy, Y1[0].xy);
+  Out1[3] = dot(uint16_t2(100, 52), uint16_t2(25, 43));
+
+  Out1[4] = dot(X1[0].xyz, Y1[0].xyz);
+  Out1[5] = dot(uint16_t3(100, 52, 210), uint16_t3(25, 43, 16));
+
+  Out1[6] = dot(X1[0], Y1[0]);
+  Out1[7] = dot(uint16_t4(100, 52, 210, 75), uint16_t4(25, 43, 16, 62));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X0
+    Format: Int16
+    Stride: 8
+    Data: [ 100, -52, -210, 75 ]
+  - Name: Y0
+    Format: Int16
+    Stride: 8
+    Data: [ 25, 43, -16, -62 ]
+  - Name: X1
+    Format: UInt16
+    Stride: 8
+    Data: [ 100, 52, 210, 75 ]
+  - Name: Y1
+    Format: UInt16
+    Stride: 8
+    Data: [ 25, 43, 16, 62 ]
+  - Name: Out0
+    Format: Int16
+    Stride: 2
+    ZeroInitSize: 16
+  - Name: ExpectedOut0
+    Format: Int16
+    Stride: 2
+    Data: [ 2500, 2500, 264, 264, 3624, 3624, -1026, -1026 ]
+  - Name: Out1
+    Format: UInt16
+    Stride: 2
+    ZeroInitSize: 16
+  - Name: ExpectedOut1
+    Format: UInt16
+    Stride: 2
+    Data: [ 2500, 2500, 4736, 4736, 8096, 8096, 12746, 12746 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+DescriptorSets:
+  - Resources:
+    - Name: X0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: X1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Y1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+#--- end
+
+# REQUIRES: Int16
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot.int64.test
+++ b/test/Feature/HLSLLib/dot.int64.test
@@ -1,0 +1,137 @@
+#--- source.hlsl
+StructuredBuffer<int64_t4> X0 : register(t0);
+StructuredBuffer<int64_t4> Y0 : register(t1);
+StructuredBuffer<uint64_t4> X1 : register(t2);
+StructuredBuffer<uint64_t4> Y1 : register(t3);
+
+RWStructuredBuffer<int64_t> Out0 : register(u4);
+RWStructuredBuffer<uint64_t> Out1 : register(u5);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // int64_t
+  Out0[0] = dot(X0[0].x, Y0[0].x);
+  Out0[1] = dot(int64_t(100), int64_t(25));
+
+  Out0[2] = dot(X0[0].xy, Y0[0].xy);
+  Out0[3] = dot(int64_t2(100, -52), int64_t2(25, 43));
+
+  Out0[4] = dot(X0[0].xyz, Y0[0].xyz);
+  Out0[5] = dot(int64_t3(100, -52, -210), int64_t3(25, 43, -16));
+
+  Out0[6] = dot(X0[0], Y0[0]);
+  Out0[7] = dot(int64_t4(100, -52, -210, 75), int64_t4(25, 43, -16, -62));
+
+  // uint64_t
+  Out1[0] = dot(X1[0].x, Y1[0].x);
+  Out1[1] = dot(uint64_t(100), uint64_t(25));
+
+  Out1[2] = dot(X1[0].xy, Y1[0].xy);
+  Out1[3] = dot(uint64_t2(100, 52), uint64_t2(25, 43));
+
+  Out1[4] = dot(X1[0].xyz, Y1[0].xyz);
+  Out1[5] = dot(uint64_t3(100, 52, 210), uint64_t3(25, 43, 16));
+
+  Out1[6] = dot(X1[0], Y1[0]);
+  Out1[7] = dot(uint64_t4(100, 52, 210, 75), uint64_t4(25, 43, 16, 62));
+  }
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X0
+    Format: Int64
+    Stride: 32
+    Data: [ 100, -52, -210, 75 ]
+  - Name: Y0
+    Format: Int64
+    Stride: 32
+    Data: [ 25, 43, -16, -62 ]
+  - Name: X1
+    Format: UInt64
+    Stride: 32
+    Data: [ 100, 52, 210, 75 ]
+  - Name: Y1
+    Format: UInt64
+    Stride: 32
+    Data: [ 25, 43, 16, 62 ]
+  - Name: Out0
+    Format: Int64
+    Stride: 8
+    ZeroInitSize: 64
+  - Name: ExpectedOut0
+    Format: Int64
+    Stride: 8
+    Data: [ 2500, 2500, 264, 264, 3624, 3624, -1026, -1026 ]
+  - Name: Out1
+    Format: UInt64
+    Stride: 8
+    ZeroInitSize: 64
+  - Name: ExpectedOut1
+    Format: UInt64
+    Stride: 8
+    Data: [ 2500, 2500, 4736, 4736, 8096, 8096, 12746, 12746 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+DescriptorSets:
+  - Resources:
+    - Name: X0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: X1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Y1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+#--- end
+
+# REQUIRES: Int64
+# RUN: split-file %s %t
+# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #124.

Adds tests for `dot` testing 16 bit int types, half, 32 bit types, 64 bit int types, and double (only supports scalar double not vector). Didn't use the [HLK test inputs](https://github.com/microsoft/DirectXShaderCompiler/blob/57177f77a4dc6996400ac97a0d618799c82374e8/tools/clang/unittests/HLSLExec/ShaderOpArithTable.xml#L4766) because it was testing 9 inputs for each of vector sizes 2-4, and the tests were mostly for nans, infs, and denorms.