### PR TITLE
Adjust hyperbolic trig functions to use ULP rules

### DIFF
--- a/test/Feature/HLSLLib/cosh.32.test
+++ b/test/Feature/HLSLLib/cosh.32.test
@@ -38,8 +38,8 @@ Buffers:
     #  NaN, Inf, 1.0, 1.0, 1.0, 1.0, Inf, 1.543081, 1.543081,
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.0008
+    Rule: BufferFloatULP
+    ULPT: 2
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/cosh.32.test
+++ b/test/Feature/HLSLLib/cosh.32.test
@@ -39,7 +39,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 2
+    ULPT: 4
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/sinh.16.test
+++ b/test/Feature/HLSLLib/sinh.16.test
@@ -38,8 +38,8 @@ Buffers:
     #  NaN, -Inf, 0.0, 0.0, 0.0, 0.0, Inf, 1.175201, -1.175201,
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.0008
+    Rule: BufferFloatULP
+    ULPT: 2
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/sinh.32.test
+++ b/test/Feature/HLSLLib/sinh.32.test
@@ -38,8 +38,8 @@ Buffers:
     #  NaN, -Inf, 0.0, 0.0, 0.0, 0.0, Inf, 1.175201, -1.175201,
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.0008
+    Rule: BufferFloatULP
+    ULPT: 2
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/sinh.32.test
+++ b/test/Feature/HLSLLib/sinh.32.test
@@ -39,7 +39,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 2
+    ULPT: 4
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.16.test
+++ b/test/Feature/HLSLLib/tanh.16.test
@@ -38,8 +38,8 @@ Buffers:
     # -0.0, 0.0, 0.761594, -0.761594, -0.0, 0.0, 0.761594, -0.761594, -0.0, 0.0, 0.761594, -0.761594,
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.0008
+    Rule: BufferFloatULP
+    ULPT: 2
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.16.test
+++ b/test/Feature/HLSLLib/tanh.16.test
@@ -39,7 +39,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 3
+    ULPT: 5
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.16.test
+++ b/test/Feature/HLSLLib/tanh.16.test
@@ -39,7 +39,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 2
+    ULPT: 3
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -37,7 +37,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 2
+    ULPT: 5
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -37,7 +37,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 120  # Metal has an ULP range of 5, CUDA has 2, but NV drivers seem to have wider drift
+    ULPT: 5
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:
@@ -61,5 +61,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_5 -Gis -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -37,7 +37,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 5
+    ULPT: 10  # Metal has an ULP range of 5, CUDA has 2, but NV drivers seem to have wider drift
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -36,8 +36,8 @@ Buffers:
     Data: [ -0.0, 0.0, 0.761594, -0.761594, -0.0, 0.0, 0.761594, -0.761594, -0.0, 0.0, 0.761594, -0.761594]
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.0008
+    Rule: BufferFloatULP
+    ULPT: 2
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -37,7 +37,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 5
+    ULPT: 120  # Metal has an ULP range of 5, CUDA has 2, but NV drivers seem to have wider drift
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tanh.32.test
+++ b/test/Feature/HLSLLib/tanh.32.test
@@ -37,7 +37,7 @@ Buffers:
 Results:
   - Result: Test1
     Rule: BufferFloatULP
-    ULPT: 10  # Metal has an ULP range of 5, CUDA has 2, but NV drivers seem to have wider drift
+    ULPT: 120  # Metal has an ULP range of 5, CUDA has 2, but NV drivers seem to have wider drift
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:


### PR DESCRIPTION
Unlike the standard trig functions which may be implemented as natural calculations or as hyperbolic aproximations, the hyperbolic functions are guaranteed to be hyperbolc aproximations and thus have consistent precision characteristics.

These can all be guaranteed within 2 ULP, which gives a better match and will resolve the test failures on AMD GPUs.

The `cosh.16` test is not updated in this PR because it is already using ULP rules and 2 ULP range specification.

I've captured a spec issue to follow up on the very wide range requirements for `tanh` on NVIDIA GPUs:
https://github.com/microsoft/hlsl-specs/issues/601

This issue has also been observed by WGSL and is reflected in their spec:
https://github.com/gpuweb/gpuweb/pull/5199

Fixes #326