### PR TITLE
Add `step` tests

### DIFF
--- a/test/Feature/HLSLLib/step.16.test
+++ b/test/Feature/HLSLLib/step.16.test
@@ -1,0 +1,75 @@
+#--- source.hlsl
+StructuredBuffer<half4> Y : register(t0);
+StructuredBuffer<half4> X : register(t1);
+
+RWStructuredBuffer<half4> Out : register(u2);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = step(Y[0], X[0]);
+  Out[1] = half4(step(Y[1].xyz, X[1].xyz), step(Y[1].w, X[1].w));
+  Out[2] = half4(step(Y[2].xy, X[2].xy), step(Y[2].zw, X[2].zw));
+  Out[3] = step(half4(0.0, 1.0, 2.0, -2.0), half4(0.0, 1.0, 1.999, -1.999));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Y
+    Format: Float16
+    Stride: 8
+    Data: [ 0x0000, 0x3c00, 0x4000, 0xc000, 0x429a, 0x489a, 0x7207, 0xd971, 0xc44d, 0x4248, 0x0011, 0x7bff ]
+    # 0.0, 1.0, 2.0, -2.0, 3.3, 9.2, 12344, -174.12, -4.3, 3.14159, 0.000001, 65504
+  - Name: X
+    Format: Float16
+    Stride: 8
+    Data: [ 0x0000, 0x3c00, 0x3fff, 0xbfff, 0x474d, 0x419a, 0x7207, 0xe00a, 0x444d, 0x4170, 0x0022, 0x7bff ]
+    # 0.0, 1.0, 1.999, -1.999, 7.3, 2.8, 12345, -517.23, 4.3, 2.71828, 0.000002, 65504
+  - Name: Out
+    Format: Float16
+    Stride: 8
+    ZeroInitSize: 32
+  - Name: ExpectedOut
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3c00, 0x3c00, 0, 0x3c00, 0x3c00, 0, 0x3c00, 0, 0x3c00, 0, 0x3c00, 0x3c00, 0x3c00, 0x3c00, 0, 0x3c00 ]
+    # 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 1
+Results:
+  - Result: Test
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# REQUIRES: Half
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/step.32.test
+++ b/test/Feature/HLSLLib/step.32.test
@@ -1,0 +1,72 @@
+#--- source.hlsl
+StructuredBuffer<float4> Y : register(t0);
+StructuredBuffer<float4> X : register(t1);
+
+RWStructuredBuffer<float4> Out : register(u2);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = step(Y[0], X[0]);
+  Out[1] = float4(step(Y[1].xyz, X[1].xyz), step(Y[1].w, X[1].w));
+  Out[2] = float4(step(Y[2].xy, X[2].xy), step(Y[2].zw, X[2].zw));
+  Out[3] = step(float4(0.0, 1.0, 2.0, -2.0), float4(0.0, 1.0, 1.999, -1.999));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: Y
+    Format: Float32
+    Stride: 16
+    Data: [ 0.0, 1.0, 2.0, -2.0, 3.3, 9.2, 12344, -174.12, -4.3, 3.14159, 0.000001, 3e+38  ]
+  - Name: X
+    Format: Float32
+    Stride: 16
+    Data: [ 0.0, 1.0, 1.999, -1.999, 7.3, 2.8, 12345, -517.23, 4.3, 2.71828, 0.000002, 3e+38 ]
+  - Name: Out
+    Format: Float32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedOut
+    Format: Float32
+    Stride: 16
+    Data: [ 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 1 ]
+Results:
+  - Result: Test
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #154.

Adds tests for `step` testing `half` and `float`. 