### PR TITLE
Add `cross` tests

### DIFF
--- a/test/Feature/HLSLLib/cross.16.test
+++ b/test/Feature/HLSLLib/cross.16.test
@@ -1,0 +1,77 @@
+#--- source.hlsl
+StructuredBuffer<half4> X : register(t0);
+StructuredBuffer<half4> Y : register(t1);
+
+RWStructuredBuffer<half4> Out : register(u2);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // Only accepts vectors of length 3
+  Out[0] = half4(cross(X[0].xyz, Y[0].xyz), 0);
+  Out[1] = half4(cross(X[1].xyz, Y[1].xyz), 0);
+  Out[2] = half4(cross(X[2].xyz, Y[2].xyz), 0);
+  Out[3] = half4(cross(half3(1, 0, 0), half3(0, 1, 0)), 0);
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3c00, 0x0000, 0x0000, 0x0000, 0x4000, 0x4200, 0x4400, 0x0000, 0xbd00, 0xc100, 0xc200, 0x0000 ] # Every 4th value is filler
+    # 1, 0, 0, 0, 2, 3, 4, 0, -1.25, -2.5, -3, 0
+  - Name: Y
+    Format: Float16
+    Stride: 8
+    Data: [ 0x0000, 0x3c00, 0x0000, 0x0000, 0x4400, 0x4600, 0x4800, 0x0000, 0x4440, 0x4500, 0x46c0, 0x0000 ] # Every 4th value is filler
+    # 0, 1, 0, 0, 4, 6, 8, 0, 4.25, 5, 6.75, 0
+  - Name: Out
+    Format: Float16
+    Stride: 8
+    ZeroInitSize: 32
+  - Name: ExpectedOut
+    Format: Float16
+    Stride: 8
+    Data: [ 0x0000, 0x0000, 0x3c00, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0xbf80, 0xc450, 0x4460, 0x0000, 0x0000, 0x0000, 0x3c00, 0x0000 ] # Every 4th value is filler
+    # 0, 0, 1, 0, 0, 0, 0, 0, -1.875, -4.3125, 4.375, 0, 0, 0, 1, 0
+Results:
+  - Result: Test0
+    Rule: BufferFloatULP
+    ULPT: 2
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# REQUIRES: Half
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cross.16.test
+++ b/test/Feature/HLSLLib/cross.16.test
@@ -73,5 +73,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cross.32.test
+++ b/test/Feature/HLSLLib/cross.32.test
@@ -69,5 +69,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cross.32.test
+++ b/test/Feature/HLSLLib/cross.32.test
@@ -1,0 +1,73 @@
+#--- source.hlsl
+StructuredBuffer<float4> X : register(t0);
+StructuredBuffer<float4> Y : register(t1);
+
+RWStructuredBuffer<float4> Out : register(u2);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // Only accepts vectors of length 3
+  Out[0] = float4(cross(X[0].xyz, Y[0].xyz), 0);
+  Out[1] = float4(cross(X[1].xyz, Y[1].xyz), 0);
+  Out[2] = float4(cross(X[2].xyz, Y[2].xyz), 0);
+  Out[3] = float4(cross(float3(1, 0, 0), float3(0, 1, 0)), 0);
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: X
+    Format: Float32
+    Stride: 16
+    Data: [ 1, 0, 0, 0, 2, 3, 4, 0, -1.25, -2.5, -3, 0 ] # Every 4th value is filler
+  - Name: Y
+    Format: Float32
+    Stride: 16
+    Data: [ 0, 1, 0, 0, 4, 6, 8, 0, 4.25, 5, 6.75, 0 ] # Every 4th value is filler
+  - Name: Out
+    Format: Float32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedOut
+    Format: Float32
+    Stride: 16
+    Data: [ 0, 0, 1, 0, 0, 0, 0, 0, -1.875, -4.3125, 4.375, 0, 0, 0, 1, 0 ] # Every 4th value is filler
+Results:
+  - Result: Test0
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.0008
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: X
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Y
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #159. 

Adds tests for `cross` testing `half3` and `float3` (it only accepts vectors of length 3). 
Still had to use `half4` and `float4` for the buffers because of alignment issues.