### PR TITLE
[NFC] Update flags for portability

### DIFF
--- a/test/Feature/HLSLLib/abs.32.test
+++ b/test/Feature/HLSLLib/abs.32.test
@@ -138,5 +138,5 @@ DescriptorSets:
 # XFAIL: DXC-Vulkan
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/abs.fp16.test
+++ b/test/Feature/HLSLLib/abs.fp16.test
@@ -60,5 +60,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/abs.fp64.test
+++ b/test/Feature/HLSLLib/abs.fp64.test
@@ -59,5 +59,5 @@ DescriptorSets:
 
 # REQUIRES: Double
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/acos.16.test
+++ b/test/Feature/HLSLLib/acos.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 # REQUIRES: Half
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/acos.32.test
+++ b/test/Feature/HLSLLib/acos.32.test
@@ -61,5 +61,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/asfloat.test
+++ b/test/Feature/HLSLLib/asfloat.test
@@ -132,5 +132,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target  -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/asin.16.test
+++ b/test/Feature/HLSLLib/asin.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/asin.32.test
+++ b/test/Feature/HLSLLib/asin.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/atan.16.test
+++ b/test/Feature/HLSLLib/atan.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/atan.32.test
+++ b/test/Feature/HLSLLib/atan.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/ceil.16.test
+++ b/test/Feature/HLSLLib/ceil.16.test
@@ -64,5 +64,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/ceil.32.test
+++ b/test/Feature/HLSLLib/ceil.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cos.16.test
+++ b/test/Feature/HLSLLib/cos.16.test
@@ -65,5 +65,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cos.32.test
+++ b/test/Feature/HLSLLib/cos.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cosh.16.test
+++ b/test/Feature/HLSLLib/cosh.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/cosh.32.test
+++ b/test/Feature/HLSLLib/cosh.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/degrees.16.test
+++ b/test/Feature/HLSLLib/degrees.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/degrees.32.test
+++ b/test/Feature/HLSLLib/degrees.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/exp.16.test
+++ b/test/Feature/HLSLLib/exp.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/exp.32.test
+++ b/test/Feature/HLSLLib/exp.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/exp2.16.test
+++ b/test/Feature/HLSLLib/exp2.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/exp2.32.test
+++ b/test/Feature/HLSLLib/exp2.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/floor.16.test
+++ b/test/Feature/HLSLLib/floor.16.test
@@ -64,5 +64,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/floor.32.test
+++ b/test/Feature/HLSLLib/floor.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/frac.16.test
+++ b/test/Feature/HLSLLib/frac.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/frac.16.test
+++ b/test/Feature/HLSLLib/frac.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/frac.32.test
+++ b/test/Feature/HLSLLib/frac.32.test
@@ -62,5 +62,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/frac.32.test
+++ b/test/Feature/HLSLLib/frac.32.test
@@ -62,5 +62,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -67,5 +67,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/isinf.32.test
+++ b/test/Feature/HLSLLib/isinf.32.test
@@ -59,5 +59,5 @@ DescriptorSets:
 # XFAIL: Clang-Vulkan
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/ldexp.16.test
+++ b/test/Feature/HLSLLib/ldexp.16.test
@@ -75,5 +75,5 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/ldexp.32.test
+++ b/test/Feature/HLSLLib/ldexp.32.test
@@ -73,5 +73,5 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/log.16.test
+++ b/test/Feature/HLSLLib/log.16.test
@@ -68,5 +68,5 @@ DescriptorSets:
 # XFAIL: Clang
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/log.32.test
+++ b/test/Feature/HLSLLib/log.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/log10.16.test
+++ b/test/Feature/HLSLLib/log10.16.test
@@ -65,5 +65,5 @@ DescriptorSets:
 # XFAIL: Clang-Vulkan
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/log10.32.test
+++ b/test/Feature/HLSLLib/log10.32.test
@@ -62,5 +62,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/log2.16.test
+++ b/test/Feature/HLSLLib/log2.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/log2.32.test
+++ b/test/Feature/HLSLLib/log2.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/radians.16.test
+++ b/test/Feature/HLSLLib/radians.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/radians.32.test
+++ b/test/Feature/HLSLLib/radians.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/round.16.test
+++ b/test/Feature/HLSLLib/round.16.test
@@ -64,5 +64,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/round.32.test
+++ b/test/Feature/HLSLLib/round.32.test
@@ -64,5 +64,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/rsqrt.16.test
+++ b/test/Feature/HLSLLib/rsqrt.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/rsqrt.32.test
+++ b/test/Feature/HLSLLib/rsqrt.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/saturate.16.test
+++ b/test/Feature/HLSLLib/saturate.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/saturate.32.test
+++ b/test/Feature/HLSLLib/saturate.32.test
@@ -47,7 +47,7 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
 
 # CHECK: - Name: In

--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -177,5 +177,5 @@ DescriptorSets:
 # XFAIL: DXC-Vulkan
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sign.fp16.test
+++ b/test/Feature/HLSLLib/sign.fp16.test
@@ -99,5 +99,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sign.fp64.test
+++ b/test/Feature/HLSLLib/sign.fp64.test
@@ -94,5 +94,5 @@ DescriptorSets:
 
 # REQUIRES: Double
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sin.16.test
+++ b/test/Feature/HLSLLib/sin.16.test
@@ -65,5 +65,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sin.32.test
+++ b/test/Feature/HLSLLib/sin.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sinh.16.test
+++ b/test/Feature/HLSLLib/sinh.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sinh.32.test
+++ b/test/Feature/HLSLLib/sinh.32.test
@@ -25,7 +25,7 @@ Buffers:
   - Name: In
     Format: Float32
     Stride: 16
-    Data: [ nan, -inf, -0x1.a61298p+0, -0, 0, 0x1.a61298p+0, inf, 1, -1, nan, nan, nan,]
+    Data: [ nan, -inf, -0x1p-1, -0, 0, 0x1p-1, inf, 1, -1, nan, nan, nan,]
     #  NaN, -Inf, -0.5, -0, 0, 0.5, Inf, 1, -1,
   - Name: Out
     Format: Float32
@@ -34,7 +34,7 @@ Buffers:
   - Name: ExpectedOut # The result we expect
     Format: Float32
     Stride: 16
-    Data: [ nan, -inf, -0x1.af122ap+0, 0.0, 0.0, 0x1.af122ap+0, inf, 1.175201, -1.175201, nan, nan, nan,]
+    Data: [ nan, -inf, -0x1.0acdp-1, 0.0, 0.0, 0x1.0acdp-1, inf, 1.175201, -1.175201, nan, nan, nan,]
     #  NaN, -Inf, -0.52109530549, 0.0, 0.0, 0.52109530549, Inf, 1.175201, -1.175201,
 Results:
   - Result: Test1

--- a/test/Feature/HLSLLib/sinh.32.test
+++ b/test/Feature/HLSLLib/sinh.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sinh.32.test
+++ b/test/Feature/HLSLLib/sinh.32.test
@@ -25,8 +25,8 @@ Buffers:
   - Name: In
     Format: Float32
     Stride: 16
-    Data: [ nan, -inf, -0x1.e7d42cp-127, -0, 0, 0x1.e7d42cp-127, inf, 1, -1, nan, nan, nan,]
-    #  NaN, -Inf, -denorm, -0, 0, denorm, Inf, 1, -1,
+    Data: [ nan, -inf, -0x1.a61298p+0, -0, 0, 0x1.a61298p+0, inf, 1, -1, nan, nan, nan,]
+    #  NaN, -Inf, -0.5, -0, 0, 0.5, Inf, 1, -1,
   - Name: Out
     Format: Float32
     Stride: 16
@@ -34,8 +34,8 @@ Buffers:
   - Name: ExpectedOut # The result we expect
     Format: Float32
     Stride: 16
-    Data: [ nan, -inf, 0.0, 0.0, 0.0, 0.0, inf, 1.175201, -1.175201, nan, nan, nan,]
-    #  NaN, -Inf, 0.0, 0.0, 0.0, 0.0, Inf, 1.175201, -1.175201,
+    Data: [ nan, -inf, -0x1.af122ap+0, 0.0, 0.0, 0x1.af122ap+0, inf, 1.175201, -1.175201, nan, nan, nan,]
+    #  NaN, -Inf, -0.52109530549, 0.0, 0.0, 0.52109530549, Inf, 1.175201, -1.175201,
 Results:
   - Result: Test1
     Rule: BufferFloatULP

--- a/test/Feature/HLSLLib/sqrt.16.test
+++ b/test/Feature/HLSLLib/sqrt.16.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/sqrt.32.test
+++ b/test/Feature/HLSLLib/sqrt.32.test
@@ -63,5 +63,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/trunc.16.test
+++ b/test/Feature/HLSLLib/trunc.16.test
@@ -64,5 +64,5 @@ DescriptorSets:
 
 # REQUIRES: Half
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/trunc.32.test
+++ b/test/Feature/HLSLLib/trunc.32.test
@@ -64,5 +64,5 @@ DescriptorSets:
 
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Tools/Offloader/BufferFloat-16bit.test
+++ b/test/Tools/Offloader/BufferFloat-16bit.test
@@ -159,5 +159,5 @@ DescriptorSets:
 
 # UNSUPPORTED: Clang-Vulkan
 # RUN: split-file %s %t
-# RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -enable-16bit-types -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Tools/Offloader/BufferFloat-64bit.test
+++ b/test/Tools/Offloader/BufferFloat-64bit.test
@@ -132,5 +132,5 @@ DescriptorSets:
 
 # REQUIRES: Double
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Tools/Offloader/BufferFloat-error-64bit.test
+++ b/test/Tools/Offloader/BufferFloat-error-64bit.test
@@ -106,7 +106,7 @@ DescriptorSets:
 
 # REQUIRES: Double
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s
 
 # CHECK: Test failed: Test1

--- a/test/Tools/Offloader/BufferFloat.test
+++ b/test/Tools/Offloader/BufferFloat.test
@@ -131,5 +131,5 @@ DescriptorSets:
 #--- end
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -Gis -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This updates all the tests that rely on nan-preservation to pass `-Gis` which ensures NaN preservation. Any of the tests that are touched in this PR which also test literal values which could be constant evaluated also should use `-HV 202x` to have consistent literal types, so that change is also made to a few test cases.

Fixes #348