### PR TITLE
Add `all` tests

### DIFF
--- a/test/Feature/HLSLLib/all.32.test
+++ b/test/Feature/HLSLLib/all.32.test
@@ -1,0 +1,142 @@
+#--- source.hlsl
+StructuredBuffer<float4> In0 : register(t0);
+StructuredBuffer<int4> In1 : register(t1);
+StructuredBuffer<uint4> In2 : register(t2);
+
+RWStructuredBuffer<bool> Out0 : register(u3);
+RWStructuredBuffer<bool> Out1 : register(u4);
+RWStructuredBuffer<bool> Out2 : register(u5);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // float
+  Out0[0] = all(In0[0]);
+  Out0[1] = all(In0[1].xyz);
+  Out0[2] = all(In0[1].w);
+  Out0[3] = all(In0[2].xy);
+  Out0[4] = all(In0[2].zw);
+  Out0[5] = all(float4(1.0, -2.5, 0, 4.2));
+
+  // int
+  Out1[0] = all(In1[0]);
+  Out1[1] = all(In1[1].xyz);
+  Out1[2] = all(In1[1].w);
+  Out1[3] = all(In1[2].xy);
+  Out1[4] = all(In1[2].zw);
+  Out1[5] = all(int4(1, -2, 0, 4));
+
+  // uint
+  Out2[0] = all(In2[0]);
+  Out2[1] = all(In2[1].xyz);
+  Out2[2] = all(In2[1].w);
+  Out2[3] = all(In2[2].xy);
+  Out2[4] = all(In2[2].zw);
+  Out2[5] = all(uint4(1, 2, 0, 4));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In0
+    Format: Float32
+    Stride: 16
+    Data: [ 1.0, -2.5, 0, 4.5, 2.0, 3.0, 4.0, -5.5, 0, 0, -0.01, 0.01 ]
+  - Name: In1
+    Format: Int32
+    Stride: 16
+    Data: [ 1, -2, 0, 4, 2, 3, 4, -5, 0, 0, -1, 1 ]
+  - Name: In2
+    Format: UInt32
+    Stride: 16
+    Data: [ 1, 2, 0, 4, 2, 3, 4, 5, 0, 0, 100, 1 ]
+  - Name: Out0
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut0
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+  - Name: Out1
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut1
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+  - Name: Out2
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut2
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+  - Result: Test2
+    Rule: BufferExact
+    Actual: Out2
+    Expected: ExpectedOut2
+DescriptorSets:
+  - Resources:
+    - Name: In0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: In1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: In2
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: Out2
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/all.bool.test
+++ b/test/Feature/HLSLLib/all.bool.test
@@ -1,0 +1,64 @@
+#--- source.hlsl
+StructuredBuffer<bool4> In : register(t0);
+
+RWStructuredBuffer<bool> Out : register(u1);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = all(In[0]);
+  Out[1] = all(In[1].xyz);
+  Out[2] = all(In[1].w);
+  Out[3] = all(In[2].xy);
+  Out[4] = all(In[2].zw);
+  Out[5] = all(bool4(1, 1, 0, 1));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Bool
+    Stride: 16
+    Data: [ 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1 ]
+  - Name: Out
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+#--- end
+
+# https://github.com/llvm/llvm-project/issues/140824
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/all.fp16.test
+++ b/test/Feature/HLSLLib/all.fp16.test
@@ -1,0 +1,63 @@
+#--- source.hlsl
+StructuredBuffer<half4> In : register(t0);
+
+RWStructuredBuffer<bool> Out : register(u1);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = all(In[0]);
+  Out[1] = all(In[1].xyz);
+  Out[2] = all(In[1].w);
+  Out[3] = all(In[2].xy);
+  Out[4] = all(In[2].zw);
+  Out[5] = all(half4(1.0, -2.5, 0, 4.2));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3c00, 0xc100, 0x0000, 0xc480, 0x4000, 0x4200, 0x4400, 0xc580, 0x0000, 0x0000, 0xa11f, 0x211f ]
+    # 1.0, -2.5, 0, 4.5, 2.0, 3.0, 4.0, -5.5, 0, 0, -0.01, 0.01
+  - Name: Out
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+#--- end
+
+# REQUIRES: Half
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/all.fp64.test
+++ b/test/Feature/HLSLLib/all.fp64.test
@@ -1,0 +1,62 @@
+#--- source.hlsl
+StructuredBuffer<double4> In : register(t0);
+
+RWStructuredBuffer<bool> Out : register(u1);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = all(In[0]);
+  Out[1] = all(In[1].xyz);
+  Out[2] = all(In[1].w);
+  Out[3] = all(In[2].xy);
+  Out[4] = all(In[2].zw);
+  Out[5] = all(double4(1.0, -2.5, 0, 4.2));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float64
+    Stride: 32
+    Data: [ 1.0, -2.5, 0, 4.5, 2.0, 3.0, 4.0, -5.5, 0, 0, -0.01, 0.01 ]
+  - Name: Out
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+#--- end
+
+# REQUIRES: Double
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/all.int16.test
+++ b/test/Feature/HLSLLib/all.int16.test
@@ -1,0 +1,103 @@
+#--- source.hlsl
+StructuredBuffer<int16_t4> In0 : register(t0);
+StructuredBuffer<uint16_t4> In1 : register(t1);
+
+RWStructuredBuffer<bool> Out0 : register(u2);
+RWStructuredBuffer<bool> Out1 : register(u3);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // int16_t
+  Out0[0] = all(In0[0]);
+  Out0[1] = all(In0[1].xyz);
+  Out0[2] = all(In0[1].w);
+  Out0[3] = all(In0[2].xy);
+  Out0[4] = all(In0[2].zw);
+  Out0[5] = all(int16_t4(1, -2, 0, 4));
+
+  // uint16_t
+  Out1[0] = all(In1[0]);
+  Out1[1] = all(In1[1].xyz);
+  Out1[2] = all(In1[1].w);
+  Out1[3] = all(In1[2].xy);
+  Out1[4] = all(In1[2].zw);
+  Out1[5] = all(uint16_t4(1, 2, 0, 4));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In0
+    Format: Int16
+    Stride: 8
+    Data: [ 1, -2, 0, 4, 2, 3, 4, -5, 0, 0, -1, 1 ]
+  - Name: In1
+    Format: UInt16
+    Stride: 8
+    Data: [ 1, 2, 0, 4, 2, 3, 4, 5, 0, 0, 100, 1 ]
+  - Name: Out0
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut0
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+  - Name: Out1
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut1
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+DescriptorSets:
+  - Resources:
+    - Name: In0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: In1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+#--- end
+
+# REQUIRES: Int16
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/all.int64.test
+++ b/test/Feature/HLSLLib/all.int64.test
@@ -1,0 +1,103 @@
+#--- source.hlsl
+StructuredBuffer<int64_t4> In0 : register(t0);
+StructuredBuffer<uint64_t4> In1 : register(t1);
+
+RWStructuredBuffer<bool> Out0 : register(u2);
+RWStructuredBuffer<bool> Out1 : register(u3);
+
+
+[numthreads(1,1,1)]
+void main() {
+  // int64_t
+  Out0[0] = all(In0[0]);
+  Out0[1] = all(In0[1].xyz);
+  Out0[2] = all(In0[1].w);
+  Out0[3] = all(In0[2].xy);
+  Out0[4] = all(In0[2].zw);
+  Out0[5] = all(int64_t4(1, -2, 0, 4));
+
+  // uint64_t
+  Out1[0] = all(In1[0]);
+  Out1[1] = all(In1[1].xyz);
+  Out1[2] = all(In1[1].w);
+  Out1[3] = all(In1[2].xy);
+  Out1[4] = all(In1[2].zw);
+  Out1[5] = all(uint64_t4(1, 2, 0, 4));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In0
+    Format: Int64
+    Stride: 32
+    Data: [ 1, -2, 0, 4, 2, 3, 4, -5, 0, 0, -1, 1 ]
+  - Name: In1
+    Format: UInt64
+    Stride: 32
+    Data: [ 1, 2, 0, 4, 2, 3, 4, 5, 0, 0, 100, 1 ]
+  - Name: Out0
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut0
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+  - Name: Out1
+    Format: Bool
+    Stride: 4
+    ZeroInitSize: 24
+  - Name: ExpectedOut1
+    Format: Bool
+    Stride: 4
+    Data: [ 0, 1, 1, 0, 1, 0 ]
+Results:
+  - Result: Test0
+    Rule: BufferExact
+    Actual: Out0
+    Expected: ExpectedOut0
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out1
+    Expected: ExpectedOut1
+DescriptorSets:
+  - Resources:
+    - Name: In0
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: In1
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Out0
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Out1
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+#--- end
+
+# REQUIRES: Int64
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #111.

Adds tests for `all` testing 16 bit int types, half, 32 bit types, 64 bit int types, and double.
I moved the bool tests from `all.32.test` to a separate file because [this bug](https://github.com/llvm/llvm-project/issues/140824) is causing the vec1 test to fail on Clang, and I didn't want to XFAIL the rest of the 32 bit tests over it. We can combine them in the future once the bug is fixed.