### PR TITLE
Add XFAIL for Clang crash

### DIFF
--- a/test/Feature/HLSLLib/asint.test
+++ b/test/Feature/HLSLLib/asint.test
@@ -136,6 +136,9 @@ DescriptorSets:
 ...
 #--- end
 
+# https://github.com/llvm/llvm-project/issues/154214
+# XFAIL: Clang-Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Tracking the fix in https://github.com/llvm/llvm-project/issues/154214