### PR TITLE
Enable fixed-size resource array tests for Clang

### DIFF
--- a/test/Feature/ResourceArrays/array-global.test
+++ b/test/Feature/ResourceArrays/array-global.test
@@ -118,10 +118,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet implemented in Clang:
-# https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
-
 # Offload tests are missing support for resource arrays on Metal
 # https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal

--- a/test/Feature/ResourceArrays/array-local.test
+++ b/test/Feature/ResourceArrays/array-local.test
@@ -79,8 +79,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
-
 # Resource arrays are not yet supported on Metal
 # UNSUPPORTED: Metal
 

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -74,8 +74,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
-
 # DXC-DirectX has a bug here because it does not create a local copy
 # of a function argument if the type is resource or resource array.
 https://github.com/microsoft/DirectXShaderCompiler/issues/7678

--- a/test/Feature/ResourceArrays/multi-dim-array-global.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-global.test
@@ -69,8 +69,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
-
 # Resource arrays are not yet supported on Metal
 # UNSUPPORTED: Metal
 

--- a/test/Feature/ResourceArrays/multi-dim-array-local.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-local.test
@@ -76,8 +76,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
-
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan
 

--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -46,10 +46,6 @@ DescriptorSets:
 # https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal
 
-# Resource arrays are not yet implemented in Clang:
-# https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
-
 # WARP has an issue counters in resource arrays
 # Internal issue #58567630
 # XFAIL: DXC && DirectX-WARP

--- a/test/Tools/Offloader/BufferExact-error-array.test
+++ b/test/Tools/Offloader/BufferExact-error-array.test
@@ -46,10 +46,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Resource arrays are not yet implemented in Clang:
-# https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
-
 # Offload tests are missing support for resource arrays on Metal
 # https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal


### PR DESCRIPTION
Since the support for fixed-size resource array has been implemented in Clang, these tests are now passing.