### PR TITLE
[RootSignature] Add `obj2yaml` testing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ list(APPEND OFFLOADTEST_DEPS
   split-file
   imgdiff
   OffloadTestUnit
+  obj2yaml
   not)
 
 if (OFFLOADTEST_TEST_CLANG)

--- a/test/Feature/RootSignatures/Defaults.test
+++ b/test/Feature/RootSignatures/Defaults.test
@@ -85,8 +85,58 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 40, 192, 504, 1024 ]
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 80, 384, 1008, 2048 ]
+
+## Root Signature Header
+# OBJ: - Name:            RTS0
+# OBJ:  Size:            140
+# OBJ:  RootSignature:
+# OBJ:  Version:         2
+# OBJ:  NumRootParameters: 3
+# OBJ:  RootParametersOffset: 24
+# OBJ:  NumStaticSamplers: 0
+# OBJ:  StaticSamplersOffset: 140
+
+# OBJ: Parameters:
+
+## RootConstants(num32BitConstants = 4, b0)
+# OBJ: - ParameterType:   1
+# OBJ:  ShaderVisibility: 0
+# OBJ:  Constants:
+# OBJ:  Num32BitValues:  4
+# OBJ:  RegisterSpace:   0
+# OBJ:  ShaderRegister:  0
+
+## DescriptorTable
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       2
+# OBJ:   RangesOffset:    80
+# OBJ:   Ranges:
+
+## SRV(t0)
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 0
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+
+## UAV(u1)
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+
+## UAV(u2)
+# OBJ: - ParameterType:   4
+# OBJ: ShaderVisibility: 0
+# OBJ: Descriptor:
+# OBJ: RegisterSpace:   0
+# OBJ: ShaderRegister:  2

--- a/test/Feature/RootSignatures/Defaults.test
+++ b/test/Feature/RootSignatures/Defaults.test
@@ -113,7 +113,7 @@ DescriptorSets:
 # OBJ-NEXT:     ShaderRegister:  0
 
 ## DescriptorTable
-# OBJ-NEXT:   - ParameterType:   0
+# OBJ:        - ParameterType:   0
 # OBJ-NEXT:     ShaderVisibility: 0
 # OBJ-NEXT:     Table:
 # OBJ-NEXT:     NumRanges:       2
@@ -128,14 +128,14 @@ DescriptorSets:
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1)
-# OBJ-NEXT:     - RangeType:       1
+# OBJ:          - RangeType:       1
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 1
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u2)
-# OBJ-NEXT:     - ParameterType:   4
+# OBJ:          - ParameterType:   4
 # OBJ-NEXT:       ShaderVisibility: 0
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0

--- a/test/Feature/RootSignatures/Defaults.test
+++ b/test/Feature/RootSignatures/Defaults.test
@@ -93,50 +93,50 @@ DescriptorSets:
 # CHECK: Data: [ 80, 384, 1008, 2048 ]
 
 ## Root Signature Header
-# OBJ: - Name:            RTS0
-# OBJ:  Size:            140
-# OBJ:  RootSignature:
-# OBJ:  Version:         2
-# OBJ:  NumRootParameters: 3
-# OBJ:  RootParametersOffset: 24
-# OBJ:  NumStaticSamplers: 0
-# OBJ:  StaticSamplersOffset: 140
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            140
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 3
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 140
 
-# OBJ: Parameters:
+# OBJ-NEXT: Parameters:
 
 ## RootConstants(num32BitConstants = 4, b0)
-# OBJ: - ParameterType:   1
-# OBJ:  ShaderVisibility: 0
-# OBJ:  Constants:
-# OBJ:  Num32BitValues:  4
-# OBJ:  RegisterSpace:   0
-# OBJ:  ShaderRegister:  0
+# OBJ-NEXT:   - ParameterType:   1
+# OBJ-NEXT:     ShaderVisibility: 0
+# OBJ-NEXT:     Constants:
+# OBJ-NEXT:     Num32BitValues:  4
+# OBJ-NEXT:     RegisterSpace:   0
+# OBJ-NEXT:     ShaderRegister:  0
 
 ## DescriptorTable
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       2
-# OBJ:   RangesOffset:    80
-# OBJ:   Ranges:
+# OBJ-NEXT:   - ParameterType:   0
+# OBJ-NEXT:     ShaderVisibility: 0
+# OBJ-NEXT:     Table:
+# OBJ-NEXT:     NumRanges:       2
+# OBJ-NEXT:     RangesOffset:    80
+# OBJ-NEXT:     Ranges:
 
 ## SRV(t0)
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 0
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 0
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1)
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 1
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u2)
-# OBJ: - ParameterType:   4
-# OBJ: ShaderVisibility: 0
-# OBJ: Descriptor:
-# OBJ: RegisterSpace:   0
-# OBJ: ShaderRegister:  2
+# OBJ-NEXT:     - ParameterType:   4
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Descriptor:
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderRegister:  2

--- a/test/Feature/RootSignatures/DescriptorTables.test
+++ b/test/Feature/RootSignatures/DescriptorTables.test
@@ -85,12 +85,12 @@ DescriptorSets:
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:       - RangeType:       1
+# OBJ:            - RangeType:       1
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1
 # OBJ-NEXT:         RegisterSpace:   4
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:       - RangeType:       1
+# OBJ:            - RangeType:       1
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   4

--- a/test/Feature/RootSignatures/DescriptorTables.test
+++ b/test/Feature/RootSignatures/DescriptorTables.test
@@ -65,33 +65,33 @@ DescriptorSets:
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 40, 96, 168, 256 ]
 
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            116
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 1
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 116
-# OBJ:   Parameters:
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       3
-# OBJ:   RangesOffset:    44
-# OBJ:   Ranges:
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   4
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   4
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            116
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 1
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 116
+# OBJ-NEXT:     Parameters:
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       3
+# OBJ-NEXT:       RangesOffset:    44
+# OBJ-NEXT:       Ranges:
+# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 2
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:       - RangeType:       1
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 1
+# OBJ-NEXT:         RegisterSpace:   4
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:       - RangeType:       1
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 2
+# OBJ-NEXT:         RegisterSpace:   4
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/DescriptorTables.test
+++ b/test/Feature/RootSignatures/DescriptorTables.test
@@ -57,9 +57,41 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK: Data:
 # CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 20, 48, 84, 128 ]
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 40, 96, 168, 256 ]
+
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            116
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 1
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 116
+# OBJ:   Parameters:
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       3
+# OBJ:   RangesOffset:    44
+# OBJ:   Ranges:
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   4
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   4
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/Flags.test
+++ b/test/Feature/RootSignatures/Flags.test
@@ -95,8 +95,75 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 20, 48, 84, 128 ]
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 40, 96, 168, 256 ]
+
+## Root Signature Header
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            140
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 1
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 140
+
+# OBJ: Parameters:
+
+## Descriptor Table
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       4
+# OBJ:   RangesOffset:    44
+# OBJ:   Ranges:
+
+## SRV(t0, flags = DATA_STATIC)
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 0
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+## Only data flag set as expected:
+# OBJ:   DATA_STATIC:     true
+
+## SRV(t1, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE)
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+## Only data flag set as expected:
+# OBJ:   DATA_STATIC_WHILE_SET_AT_EXECUTE: true
+
+## UAV(u1, flags = DESCRIPTORS_VOLATILE | DATA_VOLATILE)
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+## Both flags set as expected:
+# OBJ:   DESCRIPTORS_VOLATILE: true
+# OBJ:   DATA_VOLATILE:   true
+
+## UAV(u2, flags = 0)
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+## No flags set as expected (verified using OBJ-NEXT below):
+
+## RootFlags(
+##   ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+##   CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED  |
+##   ALLOW_STREAM_OUTPUT 
+## )
+## RootFlags set as expected:
+# OBJ-NEXT:   AllowInputAssemblerInputLayout: true
+# OBJ:   AllowStreamOutput: true
+# OBJ:   CBVSRVUAVHeapDirectlyIndexed: true

--- a/test/Feature/RootSignatures/Flags.test
+++ b/test/Feature/RootSignatures/Flags.test
@@ -103,59 +103,59 @@ DescriptorSets:
 # CHECK: Data: [ 40, 96, 168, 256 ]
 
 ## Root Signature Header
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            140
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 1
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 140
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            140
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 1
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 140
 
-# OBJ: Parameters:
+# OBJ-NEXT: Parameters:
 
 ## Descriptor Table
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       4
-# OBJ:   RangesOffset:    44
-# OBJ:   Ranges:
+# OBJ-NEXT:   - ParameterType:   0
+# OBJ-NEXT:     ShaderVisibility: 0
+# OBJ-NEXT:     Table:
+# OBJ-NEXT:     NumRanges:       4
+# OBJ-NEXT:     RangesOffset:    44
+# OBJ-NEXT:     Ranges:
 
 ## SRV(t0, flags = DATA_STATIC)
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 0
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 0
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 ## Only data flag set as expected:
-# OBJ:   DATA_STATIC:     true
+# OBJ-NEXT:       DATA_STATIC:     true
 
 ## SRV(t1, flags = DATA_STATIC_WHILE_SET_AT_EXECUTE)
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 1
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 ## Only data flag set as expected:
-# OBJ:   DATA_STATIC_WHILE_SET_AT_EXECUTE: true
+# OBJ-NEXT:       DATA_STATIC_WHILE_SET_AT_EXECUTE: true
 
 ## UAV(u1, flags = DESCRIPTORS_VOLATILE | DATA_VOLATILE)
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 1
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 ## Both flags set as expected:
-# OBJ:   DESCRIPTORS_VOLATILE: true
-# OBJ:   DATA_VOLATILE:   true
+# OBJ-NEXT:       DESCRIPTORS_VOLATILE: true
+# OBJ-NEXT:       DATA_VOLATILE:   true
 
 ## UAV(u2, flags = 0)
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 2
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
 ## No flags set as expected (verified using OBJ-NEXT below):
 
 ## RootFlags(
@@ -165,5 +165,5 @@ DescriptorSets:
 ## )
 ## RootFlags set as expected:
 # OBJ-NEXT:   AllowInputAssemblerInputLayout: true
-# OBJ:   AllowStreamOutput: true
-# OBJ:   CBVSRVUAVHeapDirectlyIndexed: true
+# OBJ-NEXT:   AllowStreamOutput: true
+# OBJ-NEXT:   CBVSRVUAVHeapDirectlyIndexed: true

--- a/test/Feature/RootSignatures/ManualDescriptors.test
+++ b/test/Feature/RootSignatures/ManualDescriptors.test
@@ -91,8 +91,60 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 20, 48, 84, 128 ]
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 40, 96, 168, 256 ]
+
+## Root Signature Header
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            116
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 1
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 116
+
+# OBJ: Parameters:
+
+## DescriptorTable
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       3
+# OBJ:   RangesOffset:    44
+# OBJ:   Ranges:
+
+## UAV(u2, offset = 3, numDescriptors = unbounded)
+# OBJ: - RangeType:       1
+## Ensure unbounded descriptors
+# OBJ:   NumDescriptors:  -1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   0
+## Ensure offset = 3
+# OBJ:   OffsetInDescriptorsFromTableStart: 3
+
+## SRV(t0, offset = 0, numDescriptors = 2)
+# OBJ: - RangeType:       0
+## Ensure 2 descriptors
+# OBJ:  NumDescriptors:  2
+# OBJ:  BaseShaderRegister: 0
+# OBJ:  RegisterSpace:   0
+## Ensure offset = 0
+# OBJ:  OffsetInDescriptorsFromTableStart: 0
+
+## UAV(u1,
+##  offset = DESCRIPTOR_RANGE_OFFSET_APPEND,
+##  numDescriptors = 1
+## )
+# OBJ: - RangeType:       1
+## Ensure 1 descriptor
+# OBJ: NumDescriptors:  1
+# OBJ: BaseShaderRegister: 1
+# OBJ: RegisterSpace:   0
+
+## Ensure append
+# OBJ: OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/ManualDescriptors.test
+++ b/test/Feature/RootSignatures/ManualDescriptors.test
@@ -99,52 +99,51 @@ DescriptorSets:
 # CHECK: Data: [ 40, 96, 168, 256 ]
 
 ## Root Signature Header
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            116
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 1
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 116
-
-# OBJ: Parameters:
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            116
+# OBJ-NEXT:     RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 1
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 116
+# OBJ-NEXT:     Parameters:
 
 ## DescriptorTable
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       3
-# OBJ:   RangesOffset:    44
-# OBJ:   Ranges:
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       3
+# OBJ-NEXT:       RangesOffset:    44
+# OBJ-NEXT:       Ranges:
 
 ## UAV(u2, offset = 3, numDescriptors = unbounded)
-# OBJ: - RangeType:       1
+# OBJ-NEXT:       - RangeType:       1
 ## Ensure unbounded descriptors
-# OBJ:   NumDescriptors:  -1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   0
+# OBJ-NEXT:         NumDescriptors:  -1
+# OBJ-NEXT:         BaseShaderRegister: 2
+# OBJ-NEXT:         RegisterSpace:   0
 ## Ensure offset = 3
-# OBJ:   OffsetInDescriptorsFromTableStart: 3
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 3
 
 ## SRV(t0, offset = 0, numDescriptors = 2)
-# OBJ: - RangeType:       0
+# OBJ-NEXT:       - RangeType:       0
 ## Ensure 2 descriptors
-# OBJ:  NumDescriptors:  2
-# OBJ:  BaseShaderRegister: 0
-# OBJ:  RegisterSpace:   0
+# OBJ-NEXT:         NumDescriptors:  2
+# OBJ-NEXT:         BaseShaderRegister: 0
+# OBJ-NEXT:         RegisterSpace:   0
 ## Ensure offset = 0
-# OBJ:  OffsetInDescriptorsFromTableStart: 0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 0
 
 ## UAV(u1,
 ##  offset = DESCRIPTOR_RANGE_OFFSET_APPEND,
 ##  numDescriptors = 1
 ## )
-# OBJ: - RangeType:       1
+# OBJ-NEXT:       - RangeType:       1
 ## Ensure 1 descriptor
-# OBJ: NumDescriptors:  1
-# OBJ: BaseShaderRegister: 1
-# OBJ: RegisterSpace:   0
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 1
+# OBJ-NEXT:         RegisterSpace:   0
 
 ## Ensure append
-# OBJ: OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/ManualDescriptors.test
+++ b/test/Feature/RootSignatures/ManualDescriptors.test
@@ -118,7 +118,7 @@ DescriptorSets:
 # OBJ-NEXT:       Ranges:
 
 ## UAV(u2, offset = 3, numDescriptors = unbounded)
-# OBJ-NEXT:       - RangeType:       1
+# OBJ:            - RangeType:       1
 ## Ensure unbounded descriptors
 # OBJ-NEXT:         NumDescriptors:  -1
 # OBJ-NEXT:         BaseShaderRegister: 2
@@ -127,7 +127,7 @@ DescriptorSets:
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 3
 
 ## SRV(t0, offset = 0, numDescriptors = 2)
-# OBJ-NEXT:       - RangeType:       0
+# OBJ:            - RangeType:       0
 ## Ensure 2 descriptors
 # OBJ-NEXT:         NumDescriptors:  2
 # OBJ-NEXT:         BaseShaderRegister: 0
@@ -139,7 +139,7 @@ DescriptorSets:
 ##  offset = DESCRIPTOR_RANGE_OFFSET_APPEND,
 ##  numDescriptors = 1
 ## )
-# OBJ-NEXT:       - RangeType:       1
+# OBJ:            - RangeType:       1
 ## Ensure 1 descriptor
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1

--- a/test/Feature/RootSignatures/NumberParameters.test
+++ b/test/Feature/RootSignatures/NumberParameters.test
@@ -90,8 +90,61 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 40, 192, 504, 1024 ]
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 80, 384, 1008, 2048 ]
+
+## Root Signature Header
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            140
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 3
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 140
+
+# OBJ: Parameters:
+
+## RootConstants(num32BitConstants = +61, b0)
+# OBJ: - ParameterType:   1
+# OBJ:  ShaderVisibility: 0
+# OBJ:  Constants:
+## Check positively signed integer
+# OBJ:  Num32BitValues:  61
+# OBJ:  RegisterSpace:   0
+# OBJ:  ShaderRegister:  0
+
+## DescriptorTable
+# OBJ: - ParameterType:   0
+# OBJ:  ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       2
+# OBJ:   RangesOffset:    80
+# OBJ:   Ranges:
+
+## SRV(t4294967294)
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+## Check edge-case
+# OBJ:   BaseShaderRegister: 4294967294
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+
+## UAV(u1, space = 4294967279)
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+## Check edge-case
+# OBJ:   RegisterSpace:   4294967279
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+
+## UAV(u2)
+# OBJ: - ParameterType:   4
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Descriptor:
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderRegister:  2

--- a/test/Feature/RootSignatures/NumberParameters.test
+++ b/test/Feature/RootSignatures/NumberParameters.test
@@ -98,53 +98,53 @@ DescriptorSets:
 # CHECK: Data: [ 80, 384, 1008, 2048 ]
 
 ## Root Signature Header
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            140
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 3
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 140
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            140
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 3
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 140
 
-# OBJ: Parameters:
+# OBJ-NEXT: Parameters:
 
 ## RootConstants(num32BitConstants = +61, b0)
-# OBJ: - ParameterType:   1
-# OBJ:  ShaderVisibility: 0
-# OBJ:  Constants:
+# OBJ-NEXT:     - ParameterType:   1
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Constants:
 ## Check positively signed integer
-# OBJ:  Num32BitValues:  61
-# OBJ:  RegisterSpace:   0
-# OBJ:  ShaderRegister:  0
+# OBJ-NEXT:       Num32BitValues:  61
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderRegister:  0
 
 ## DescriptorTable
-# OBJ: - ParameterType:   0
-# OBJ:  ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       2
-# OBJ:   RangesOffset:    80
-# OBJ:   Ranges:
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       2
+# OBJ-NEXT:       RangesOffset:    80
+# OBJ-NEXT:       Ranges:
 
 ## SRV(t4294967294)
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
+# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:         NumDescriptors:  1
 ## Check edge-case
-# OBJ:   BaseShaderRegister: 4294967294
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:         BaseShaderRegister: 4294967294
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1, space = 4294967279)
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
+# OBJ-NEXT:       - RangeType:       1
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 1
 ## Check edge-case
-# OBJ:   RegisterSpace:   4294967279
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:         RegisterSpace:   4294967279
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u2)
-# OBJ: - ParameterType:   4
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Descriptor:
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderRegister:  2
+# OBJ-NEXT:       - ParameterType:   4
+# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ-NEXT:         Descriptor:
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         ShaderRegister:  2

--- a/test/Feature/RootSignatures/NumberParameters.test
+++ b/test/Feature/RootSignatures/NumberParameters.test
@@ -135,7 +135,7 @@ DescriptorSets:
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1, space = 4294967279)
-# OBJ-NEXT:       - RangeType:       1
+# OBJ:            - RangeType:       1
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1
 ## Check edge-case
@@ -143,7 +143,7 @@ DescriptorSets:
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u2)
-# OBJ-NEXT:       - ParameterType:   4
+# OBJ:            - ParameterType:   4
 # OBJ-NEXT:         ShaderVisibility: 0
 # OBJ-NEXT:         Descriptor:
 # OBJ-NEXT:         RegisterSpace:   0

--- a/test/Feature/RootSignatures/ParameterInsensitivity.test
+++ b/test/Feature/RootSignatures/ParameterInsensitivity.test
@@ -78,6 +78,41 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
+
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            116
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 2
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 116
+# OBJ-NEXT:     Parameters:
+# OBJ-NEXT:       - ParameterType:   1
+# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ-NEXT:         Constants:
+# OBJ-NEXT:           Num32BitValues:  4
+# OBJ-NEXT:           RegisterSpace:   2
+# OBJ-NEXT:           ShaderRegister:  0
+# OBJ-NEXT:       - ParameterType:   0
+# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ-NEXT:         Table:
+# OBJ-NEXT:           NumRanges:       2
+# OBJ-NEXT:           RangesOffset:    68
+# OBJ-NEXT:           Ranges:
+# OBJ-NEXT:             - RangeType:       0
+# OBJ-NEXT:               NumDescriptors:  1
+# OBJ-NEXT:               BaseShaderRegister: 0
+# OBJ-NEXT:               RegisterSpace:   0
+# OBJ-NEXT:               OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:               DATA_STATIC:     true
+# OBJ-NEXT:             - RangeType:       1
+# OBJ-NEXT:               NumDescriptors:  -1
+# OBJ-NEXT:               BaseShaderRegister: 1
+# OBJ-NEXT:               RegisterSpace:   0
+# OBJ-NEXT:               OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     AllowInputAssemblerInputLayout: true

--- a/test/Feature/RootSignatures/ParameterInsensitivity.test
+++ b/test/Feature/RootSignatures/ParameterInsensitivity.test
@@ -115,4 +115,4 @@ DescriptorSets:
 # OBJ-NEXT:               BaseShaderRegister: 1
 # OBJ-NEXT:               RegisterSpace:   0
 # OBJ-NEXT:               OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:     AllowInputAssemblerInputLayout: true
+# OBJ:          AllowInputAssemblerInputLayout: true

--- a/test/Feature/RootSignatures/RootConstants.test
+++ b/test/Feature/RootSignatures/RootConstants.test
@@ -64,34 +64,34 @@ DescriptorSets:
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
 
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            116
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 2
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 116
-# OBJ:   Parameters:
-# OBJ: - ParameterType:   1
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Constants:
-# OBJ:   Num32BitValues:  4
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderRegister:  2
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       2
-# OBJ:   RangesOffset:    68
-# OBJ:   Ranges:
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   4
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            116
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 2
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 116
+# OBJ-NEXT:     Parameters:
+# OBJ-NEXT:     - ParameterType:   1
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Constants:
+# OBJ-NEXT:       Num32BitValues:  4
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderRegister:  2
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       2
+# OBJ-NEXT:       RangesOffset:    68
+# OBJ-NEXT:       Ranges:
+# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 2
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:       - RangeType:       1
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 1
+# OBJ-NEXT:         RegisterSpace:   4
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/RootConstants.test
+++ b/test/Feature/RootSignatures/RootConstants.test
@@ -79,18 +79,18 @@ DescriptorSets:
 # OBJ-NEXT:       Num32BitValues:  4
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ-NEXT:     - ParameterType:   0
+# OBJ:          - ParameterType:   0
 # OBJ-NEXT:       ShaderVisibility: 0
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       2
 # OBJ-NEXT:       RangesOffset:    68
 # OBJ-NEXT:       Ranges:
-# OBJ-NEXT:       - RangeType:       0
+# OBJ:            - RangeType:       0
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:       - RangeType:       1
+# OBJ:            - RangeType:       1
 # OBJ-NEXT:         NumDescriptors:  1
 # OBJ-NEXT:         BaseShaderRegister: 1
 # OBJ-NEXT:         RegisterSpace:   4

--- a/test/Feature/RootSignatures/RootConstants.test
+++ b/test/Feature/RootSignatures/RootConstants.test
@@ -59,6 +59,39 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
+
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            116
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 2
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 116
+# OBJ:   Parameters:
+# OBJ: - ParameterType:   1
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Constants:
+# OBJ:   Num32BitValues:  4
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderRegister:  2
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       2
+# OBJ:   RangesOffset:    68
+# OBJ:   Ranges:
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   4
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/RootDescriptorAndTables.test
+++ b/test/Feature/RootSignatures/RootDescriptorAndTables.test
@@ -83,7 +83,7 @@ DescriptorSets:
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ-NEXT:     - ParameterType:   0
+# OBJ:          - ParameterType:   0
 # OBJ-NEXT:       ShaderVisibility: 0
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       1
@@ -94,7 +94,7 @@ DescriptorSets:
 # OBJ-NEXT:         BaseShaderRegister: 2
 # OBJ-NEXT:         RegisterSpace:   0
 # OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:       - ParameterType:   4
+# OBJ:            - ParameterType:   4
 # OBJ-NEXT:         ShaderVisibility: 0
 # OBJ-NEXT:         Descriptor:
 # OBJ-NEXT:         RegisterSpace:   4

--- a/test/Feature/RootSignatures/RootDescriptorAndTables.test
+++ b/test/Feature/RootSignatures/RootDescriptorAndTables.test
@@ -64,6 +64,38 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
+
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            116
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 3
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 116
+# OBJ:   Parameters:
+# OBJ: - ParameterType:   2
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Descriptor:
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderRegister:  2
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       1
+# OBJ:   RangesOffset:    80
+# OBJ:   Ranges:
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ: - ParameterType:   4
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Descriptor:
+# OBJ:   RegisterSpace:   4
+# OBJ:   ShaderRegister:  1

--- a/test/Feature/RootSignatures/RootDescriptorAndTables.test
+++ b/test/Feature/RootSignatures/RootDescriptorAndTables.test
@@ -69,33 +69,33 @@ DescriptorSets:
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
 
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            116
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 3
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 116
-# OBJ:   Parameters:
-# OBJ: - ParameterType:   2
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Descriptor:
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderRegister:  2
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       1
-# OBJ:   RangesOffset:    80
-# OBJ:   Ranges:
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ: - ParameterType:   4
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Descriptor:
-# OBJ:   RegisterSpace:   4
-# OBJ:   ShaderRegister:  1
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            116
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 3
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 116
+# OBJ-NEXT:     Parameters:
+# OBJ-NEXT:     - ParameterType:   2
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Descriptor:
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderRegister:  2
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       1
+# OBJ-NEXT:       RangesOffset:    80
+# OBJ-NEXT:       Ranges:
+# OBJ-NEXT:       - RangeType:       0
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 2
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:       - ParameterType:   4
+# OBJ-NEXT:         ShaderVisibility: 0
+# OBJ-NEXT:         Descriptor:
+# OBJ-NEXT:         RegisterSpace:   4
+# OBJ-NEXT:         ShaderRegister:  1

--- a/test/Feature/RootSignatures/RootDescriptors.test
+++ b/test/Feature/RootSignatures/RootDescriptors.test
@@ -61,6 +61,32 @@ DescriptorSets: []
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
+
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            96
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 3
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 96
+# OBJ:   Parameters:
+# OBJ: - ParameterType:   2
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Descriptor:
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderRegister:  2
+# OBJ: - ParameterType:   3
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Descriptor:
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderRegister:  2
+# OBJ: - ParameterType:   4
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Descriptor:
+# OBJ:   RegisterSpace:   4
+# OBJ:   ShaderRegister:  1

--- a/test/Feature/RootSignatures/RootDescriptors.test
+++ b/test/Feature/RootSignatures/RootDescriptors.test
@@ -80,12 +80,12 @@ DescriptorSets: []
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ-NEXT:     - ParameterType:   3
+# OBJ:          - ParameterType:   3
 # OBJ-NEXT:       ShaderVisibility: 0
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       ShaderRegister:  2
-# OBJ-NEXT:     - ParameterType:   4
+# OBJ:          - ParameterType:   4
 # OBJ-NEXT:       ShaderVisibility: 0
 # OBJ-NEXT:       Descriptor:
 # OBJ-NEXT:       RegisterSpace:   4

--- a/test/Feature/RootSignatures/RootDescriptors.test
+++ b/test/Feature/RootSignatures/RootDescriptors.test
@@ -66,27 +66,27 @@ DescriptorSets: []
 # CHECK-LABEL: Name: Out
 # CHECK: Data: [ 40, 192, 504, 1024 ]
 
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            96
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 3
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 96
-# OBJ:   Parameters:
-# OBJ: - ParameterType:   2
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Descriptor:
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderRegister:  2
-# OBJ: - ParameterType:   3
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Descriptor:
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderRegister:  2
-# OBJ: - ParameterType:   4
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Descriptor:
-# OBJ:   RegisterSpace:   4
-# OBJ:   ShaderRegister:  1
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            96
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 3
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 96
+# OBJ-NEXT:     Parameters:
+# OBJ-NEXT:     - ParameterType:   2
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Descriptor:
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderRegister:  2
+# OBJ-NEXT:     - ParameterType:   3
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Descriptor:
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderRegister:  2
+# OBJ-NEXT:     - ParameterType:   4
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Descriptor:
+# OBJ-NEXT:       RegisterSpace:   4
+# OBJ-NEXT:       ShaderRegister:  1

--- a/test/Feature/RootSignatures/TwoDescriptorTables.test
+++ b/test/Feature/RootSignatures/TwoDescriptorTables.test
@@ -58,9 +58,47 @@ DescriptorSets:
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 # CHECK: Data:
 # CHECK-LABEL: Name: Out1
 # CHECK: Data: [ 20, 48, 84, 128 ]
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 40, 96, 168, 256 ]
+
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            136
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 2
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 0
+# OBJ:   StaticSamplersOffset: 136
+# OBJ:   Parameters:
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       2
+# OBJ:   RangesOffset:    56
+# OBJ:   Ranges:
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   4
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       1
+# OBJ:   RangesOffset:    112
+# OBJ:   Ranges:
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 2
+# OBJ:   RegisterSpace:   4
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/TwoDescriptorTables.test
+++ b/test/Feature/RootSignatures/TwoDescriptorTables.test
@@ -66,39 +66,39 @@ DescriptorSets:
 # CHECK-LABEL: Name: Out2
 # CHECK: Data: [ 40, 96, 168, 256 ]
 
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            136
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 2
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 0
-# OBJ:   StaticSamplersOffset: 136
-# OBJ:   Parameters:
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       2
-# OBJ:   RangesOffset:    56
-# OBJ:   Ranges:
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   4
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       1
-# OBJ:   RangesOffset:    112
-# OBJ:   Ranges:
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 2
-# OBJ:   RegisterSpace:   4
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            136
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 2
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 0
+# OBJ-NEXT:     StaticSamplersOffset: 136
+# OBJ-NEXT:     Parameters:
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       2
+# OBJ-NEXT:       RangesOffset:    56
+# OBJ-NEXT:       Ranges:
+# OBJ-NEXT:     - RangeType:       0
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 2
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 1
+# OBJ-NEXT:       RegisterSpace:   4
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:     - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       1
+# OBJ-NEXT:       RangesOffset:    112
+# OBJ-NEXT:       Ranges:
+# OBJ-NEXT:     - RangeType:       1
+# OBJ-NEXT:       NumDescriptors:  1
+# OBJ-NEXT:       BaseShaderRegister: 2
+# OBJ-NEXT:       RegisterSpace:   4
+# OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295

--- a/test/Feature/RootSignatures/TwoDescriptorTables.test
+++ b/test/Feature/RootSignatures/TwoDescriptorTables.test
@@ -81,23 +81,23 @@ DescriptorSets:
 # OBJ-NEXT:       NumRanges:       2
 # OBJ-NEXT:       RangesOffset:    56
 # OBJ-NEXT:       Ranges:
-# OBJ-NEXT:     - RangeType:       0
+# OBJ:          - RangeType:       0
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 2
 # OBJ-NEXT:       RegisterSpace:   0
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:     - RangeType:       1
+# OBJ:          - RangeType:       1
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 1
 # OBJ-NEXT:       RegisterSpace:   4
 # OBJ-NEXT:       OffsetInDescriptorsFromTableStart: 4294967295
-# OBJ-NEXT:     - ParameterType:   0
+# OBJ:          - ParameterType:   0
 # OBJ-NEXT:       ShaderVisibility: 0
 # OBJ-NEXT:       Table:
 # OBJ-NEXT:       NumRanges:       1
 # OBJ-NEXT:       RangesOffset:    112
 # OBJ-NEXT:       Ranges:
-# OBJ-NEXT:     - RangeType:       1
+# OBJ:          - RangeType:       1
 # OBJ-NEXT:       NumDescriptors:  1
 # OBJ-NEXT:       BaseShaderRegister: 2
 # OBJ-NEXT:       RegisterSpace:   4

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -150,6 +150,8 @@ else:
 
 config.available_features.add(HLSLCompiler)
 
+tools.append(ToolSubst("obj2yaml", FindTool("obj2yaml")))
+
 llvm_config.add_tool_substitutions(tools, config.llvm_tools_dir)
 
 api_query = os.path.join(config.llvm_tools_dir, "api-query")


### PR DESCRIPTION
This pr adds testing using `obj2yaml` for root signatures.

There are types of tests added:
- edge-cases: which check for edge cases as specified in the test cases
- consistency: which checks that `DXC` and `clang` set the root signature values to be the same. The particular values are not necessarily important, as they will have been covered in the edge-cases 

Resolves: https://github.com/llvm/offload-test-suite/issues/260.