### PR TITLE
[RootSignature] Add `StaticSampler` testing

### DIFF
--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -130,7 +130,9 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
+# Unsupported: https://github.com/llvm/llvm-project/issues/101558
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -133,7 +133,7 @@ DescriptorSets:
 # Unsupported: https://github.com/llvm/llvm-project/issues/101558
 # XFAIL: Clang
 
-# REQUIRES: Derivatives
+# REQUIRES: DerivativesInCompute
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -19,7 +19,7 @@ RWTexture2D<float4> OtherOut : register(u2);
   "  minLOD = 32.0, "                                                          \
   "  maxLOD = 32.0, "                                                          \
   "  addressV = TEXTURE_ADDRESS_MIRROR, "                                      \
-  "  filter = FILTER_MAXIMUM_MIN_MAG_MIP_POINT "                                                           \
+  "  filter = FILTER_MAXIMUM_MIN_MAG_MIP_POINT "                               \
   ")"
 
 [RootSignature(RootSig)]

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -3,10 +3,10 @@
 Texture2D<float4> In : register(t0);
 
 SamplerState DefaultSampler: register(s0);
-SamplerState OtherSampler: register(s1);
+SamplerState SpecifiedSampler: register(s1);
 
 RWTexture2D<float4> DefaultOut : register(u1);
-RWTexture2D<float4> OtherOut : register(u2);
+RWTexture2D<float4> SpecifiedOut : register(u2);
 
 #define RootSig                                                                \
   "DescriptorTable( "                                                          \
@@ -31,8 +31,8 @@ void main(uint GI : SV_GroupIndex) {
   float4 DefaultColor = In.Sample(DefaultSampler, UV);
   DefaultOut[GID.xy] = DefaultColor.bgra;
 
-  float4 OtherColor = In.Sample(OtherSampler, UV);
-  OtherOut[GID.xy] = OtherColor.bgra;
+  float4 SpecifiedColor = In.Sample(SpecifiedSampler, UV);
+  SpecifiedOut[GID.xy] = SpecifiedColor.bgra;
 }
 
 //--- pipeline.yaml
@@ -61,7 +61,7 @@ Buffers:
       Height: 2
       Width: 2
       Depth: 16
-  - Name: OtherOut
+  - Name: SpecifiedOut
     Format: Float32
     Channels: 4
     ZeroInitSize: 64
@@ -81,10 +81,10 @@ Buffers:
       Width: 2
       Depth: 16
   ## Modifying the LOD parameters does not affect the output. However,
-  ## The applied filter will output [0, 0, 1, 1, ... 0, 0, 1, 1] and then
+  ## the applied filter will output [0, 0, 1, 1, ... 0, 0, 1, 1] and then
   ## setting addressV to mirror outputs [0, 0, 1, 1, ..., 1, 0, 0, 1] as shown
   ## below
-  - Name: ExpectedOtherOut
+  - Name: ExpectedSpecifiedOut
     Format: Float32
     Channels: 4
     Data: [0, 0, 1, 1,
@@ -100,10 +100,10 @@ Results:
     Rule: BufferExact
     Actual: DefaultOut
     Expected: ExpectedDefaultOut
-  - Result: OtherTest
+  - Result: SpecifiedTest
     Rule: BufferExact
-    Actual: OtherOut
-    Expected: ExpectedOtherOut
+    Actual: SpecifiedOut
+    Expected: ExpectedSpecifiedOut
 DescriptorSets:
   - Resources:
     - Name: In
@@ -120,7 +120,7 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: OtherOut
+    - Name: SpecifiedOut
       Kind: RWTexture2D
       DirectXBinding:
         Register: 2

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -137,57 +137,55 @@ DescriptorSets:
 # RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
 
 ## Root Signature Header
-# OBJ: - Name:            RTS0
-# OBJ:   Size:            196
-# OBJ:   RootSignature:
-# OBJ:   Version:         2
-# OBJ:   NumRootParameters: 1
-# OBJ:   RootParametersOffset: 24
-# OBJ:   NumStaticSamplers: 2
-# OBJ:   StaticSamplersOffset: 92
-
-# OBJ:   Parameters:
+# OBJ:      - Name:            RTS0
+# OBJ-NEXT:   Size:            196
+# OBJ-NEXT:   RootSignature:
+# OBJ-NEXT:     Version:         2
+# OBJ-NEXT:     NumRootParameters: 1
+# OBJ-NEXT:     RootParametersOffset: 24
+# OBJ-NEXT:     NumStaticSamplers: 2
+# OBJ-NEXT:     StaticSamplersOffset: 92
+# OBJ-NEXT:     Parameters:
 
 ## Descriptor Table
-# OBJ: - ParameterType:   0
-# OBJ:   ShaderVisibility: 0
-# OBJ:   Table:
-# OBJ:   NumRanges:       2
-# OBJ:   RangesOffset:    44
-
-# OBJ:   Ranges:
+# OBJ:          - ParameterType:   0
+# OBJ-NEXT:       ShaderVisibility: 0
+# OBJ-NEXT:       Table:
+# OBJ-NEXT:       NumRanges:       2
+# OBJ-NEXT:       RangesOffset:    44
+# OBJ-NEXT:       Ranges:
 
 ## SRV(t0)
-# OBJ: - RangeType:       0
-# OBJ:   NumDescriptors:  1
-# OBJ:   BaseShaderRegister: 0
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ:            - RangeType:       0
+# OBJ-NEXT:         NumDescriptors:  1
+# OBJ-NEXT:         BaseShaderRegister: 0
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
 ## UAV(u1, numDescriptors = 2)
-# OBJ: - RangeType:       1
-# OBJ:   NumDescriptors:  2
-# OBJ:   BaseShaderRegister: 1
-# OBJ:   RegisterSpace:   0
-# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+# OBJ-NEXT:       - RangeType:       1
+# OBJ-NEXT:         NumDescriptors:  2
+# OBJ-NEXT:         BaseShaderRegister: 1
+# OBJ-NEXT:         RegisterSpace:   0
+# OBJ-NEXT:         OffsetInDescriptorsFromTableStart: 4294967295
 
-# OBJ:   Samplers:
+# OBJ:          Samplers:
 
 ## StaticSampler(s0)
 ## Ensures the defaults are set as expected
-# OBJ: - Filter:          85
-# OBJ:   AddressU:        1
-# OBJ:   AddressV:        1
-# OBJ:   AddressW:        1
-# OBJ:   MipLODBias:      0
-# OBJ:   MaxAnisotropy:   16
-# OBJ:   ComparisonFunc:  4
-# OBJ:   BorderColor:     2
-# OBJ:   MinLOD:          0
-# OBJ:   MaxLOD:          3.40282e+38
-# OBJ:   ShaderRegister:  0
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderVisibility: 0
+# OBJ-NEXT:     - Filter:          85
+# OBJ-NEXT:       AddressU:        1
+# OBJ-NEXT:       AddressV:        1
+# OBJ-NEXT:       AddressW:        1
+# OBJ-NEXT:       MipLODBias:      0
+# OBJ-NEXT:       MaxAnisotropy:   16
+# OBJ-NEXT:       ComparisonFunc:  4
+# OBJ-NEXT:       BorderColor:     2
+# OBJ-NEXT:       MinLOD:          0
+# OBJ-NEXT:       MaxLOD:          3.40282e+38
+# OBJ-NEXT:       ShaderRegister:  0
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderVisibility: 0
 
 ## StaticSampler(s1,
 ##   mipLODBias = -15.99,
@@ -197,16 +195,16 @@ DescriptorSets:
 ##   filter = FILTER_MAXIMUM_MIN_MAG_MIP_POINT
 ## )
 ## Ensures the specified values are set as expected
-# OBJ: - Filter:          384
-# OBJ:   AddressU:        1
-# OBJ:   AddressV:        2
-# OBJ:   AddressW:        1
-# OBJ:   MipLODBias:      -15.99
-# OBJ:   MaxAnisotropy:   16
-# OBJ:   ComparisonFunc:  4
-# OBJ:   BorderColor:     2
-# OBJ:   MinLOD:          32
-# OBJ:   MaxLOD:          32
-# OBJ:   ShaderRegister:  1
-# OBJ:   RegisterSpace:   0
-# OBJ:   ShaderVisibility: 0
+# OBJ:          - Filter:          384
+# OBJ-NEXT:       AddressU:        1
+# OBJ-NEXT:       AddressV:        2
+# OBJ-NEXT:       AddressW:        1
+# OBJ-NEXT:       MipLODBias:      -15.99
+# OBJ-NEXT:       MaxAnisotropy:   16
+# OBJ-NEXT:       ComparisonFunc:  4
+# OBJ-NEXT:       BorderColor:     2
+# OBJ-NEXT:       MinLOD:          32
+# OBJ-NEXT:       MaxLOD:          32
+# OBJ-NEXT:       ShaderRegister:  1
+# OBJ-NEXT:       RegisterSpace:   0
+# OBJ-NEXT:       ShaderVisibility: 0

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -133,6 +133,8 @@ DescriptorSets:
 # Unsupported: https://github.com/llvm/llvm-project/issues/101558
 # XFAIL: Clang
 
+# REQUIRES: Derivatives
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -1,0 +1,212 @@
+#--- source.hlsl
+
+Texture2D<float4> In : register(t0);
+
+SamplerState DefaultSampler: register(s0);
+SamplerState OtherSampler: register(s1);
+
+RWTexture2D<float4> DefaultOut : register(u1);
+RWTexture2D<float4> OtherOut : register(u2);
+
+#define RootSig                                                                \
+  "DescriptorTable( "                                                          \
+  "  SRV(t0), "                                                                \
+  "  UAV(u1, numDescriptors = 2) "                                             \
+  "), "                                                                        \
+  "StaticSampler(s0), "                                                        \
+  "StaticSampler(s1, "                                                         \
+  "  mipLODBias = -15.99, "                                                    \
+  "  minLOD = 32.0, "                                                          \
+  "  maxLOD = 32.0, "                                                          \
+  "  addressV = TEXTURE_ADDRESS_MIRROR, "                                      \
+  "  filter = FILTER_MAXIMUM_MIN_MAG_MIP_POINT "                                                           \
+  ")"
+
+[RootSignature(RootSig)]
+[numthreads(4,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  uint Width, Height;
+  uint2 GID = {GI / 2, GI % 2};
+  float2 UV = GID;
+  float4 DefaultColor = In.Sample(DefaultSampler, UV);
+  DefaultOut[GID.xy] = DefaultColor.bgra;
+
+  float4 OtherColor = In.Sample(OtherSampler, UV);
+  OtherOut[GID.xy] = OtherColor.bgra;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Channels: 4
+    Data: [1.0, 0.0, 0.0, 1.0,
+           0.0, 1.0, 0.0, 1.0,
+           0.0, 0.0, 1.0, 1.0,
+           1.0, 1.0, 0.0, 1.0]
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 16
+  - Name: DefaultOut
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 64
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 16
+  - Name: OtherOut
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 64
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 16
+  - Name: ExpectedDefaultOut
+    Format: Float32
+    Channels: 4
+    Data: [0.25, 0.5, 0.5, 1,
+	        0.25, 0.5, 0.5, 1,
+			0.25, 0.5, 0.5,
+			1, 0.25, 0.5, 0.5, 1]
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 16
+  ## Modifying the LOD parameters does not affect the output. However,
+  ## The applied filter will output [0, 0, 1, 1, ... 0, 0, 1, 1] and then
+  ## setting addressV to mirror outputs [0, 0, 1, 1, ..., 1, 0, 0, 1] as shown
+  ## below
+  - Name: ExpectedOtherOut
+    Format: Float32
+    Channels: 4
+    Data: [0, 0, 1, 1,
+		   0, 0, 1, 1,
+	       1, 0, 0, 1,
+	       1, 0, 0, 1 ]
+    OutputProps:
+      Height: 2
+      Width: 2
+      Depth: 16
+Results:
+  - Result: DefaultTest
+    Rule: BufferExact
+    Actual: DefaultOut
+    Expected: ExpectedDefaultOut
+  - Result: OtherTest
+    Rule: BufferExact
+    Actual: OtherOut
+    Expected: ExpectedOtherOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: Texture2D
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: DefaultOut
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OtherOut
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# UNSUPPORTED: Clang
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o
+# RUN: obj2yaml %t.o | FileCheck %s --check-prefix=OBJ
+
+## Root Signature Header
+# OBJ: - Name:            RTS0
+# OBJ:   Size:            196
+# OBJ:   RootSignature:
+# OBJ:   Version:         2
+# OBJ:   NumRootParameters: 1
+# OBJ:   RootParametersOffset: 24
+# OBJ:   NumStaticSamplers: 2
+# OBJ:   StaticSamplersOffset: 92
+
+# OBJ:   Parameters:
+
+## Descriptor Table
+# OBJ: - ParameterType:   0
+# OBJ:   ShaderVisibility: 0
+# OBJ:   Table:
+# OBJ:   NumRanges:       2
+# OBJ:   RangesOffset:    44
+
+# OBJ:   Ranges:
+
+## SRV(t0)
+# OBJ: - RangeType:       0
+# OBJ:   NumDescriptors:  1
+# OBJ:   BaseShaderRegister: 0
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+
+## UAV(u1, numDescriptors = 2)
+# OBJ: - RangeType:       1
+# OBJ:   NumDescriptors:  2
+# OBJ:   BaseShaderRegister: 1
+# OBJ:   RegisterSpace:   0
+# OBJ:   OffsetInDescriptorsFromTableStart: 4294967295
+
+# OBJ:   Samplers:
+
+## StaticSampler(s0)
+## Ensures the defaults are set as expected
+# OBJ: - Filter:          85
+# OBJ:   AddressU:        1
+# OBJ:   AddressV:        1
+# OBJ:   AddressW:        1
+# OBJ:   MipLODBias:      0
+# OBJ:   MaxAnisotropy:   16
+# OBJ:   ComparisonFunc:  4
+# OBJ:   BorderColor:     2
+# OBJ:   MinLOD:          0
+# OBJ:   MaxLOD:          3.40282e+38
+# OBJ:   ShaderRegister:  0
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderVisibility: 0
+
+## StaticSampler(s1,
+##   mipLODBias = -15.99,
+##   minLOD = 32.0,
+##   maxLOD = 32.0,
+##   addressV = TEXTURE_ADDRESS_MIRROR,
+##   filter = FILTER_MAXIMUM_MIN_MAG_MIP_POINT
+## )
+## Ensures the specified values are set as expected
+# OBJ: - Filter:          384
+# OBJ:   AddressU:        1
+# OBJ:   AddressV:        2
+# OBJ:   AddressW:        1
+# OBJ:   MipLODBias:      -15.99
+# OBJ:   MaxAnisotropy:   16
+# OBJ:   ComparisonFunc:  4
+# OBJ:   BorderColor:     2
+# OBJ:   MinLOD:          32
+# OBJ:   MaxLOD:          32
+# OBJ:   ShaderRegister:  1
+# OBJ:   RegisterSpace:   0
+# OBJ:   ShaderVisibility: 0

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -47,9 +47,10 @@ tools = [
     ToolSubst("imgdiff", FindTool("imgdiff")),
 ]
 
+
 def getHighestShaderModel(features):
     sm = features.get("HighestShaderModel", 6.0)
-    major, minor = str(sm).split('.')
+    major, minor = str(sm).split(".")
     return int(major), int(minor)
 
 def setDeviceFeatures(config, device, compiler):

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,6 +49,8 @@ tools = [
 
 
 def getHighestShaderModel(features):
+    if sm == None:
+        return 6, 0
     sm = features.get("HighestShaderModel", 6.0)
     major, minor = str(sm).split(".")
     return int(major), int(minor)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -49,7 +49,7 @@ tools = [
 
 
 def getHighestShaderModel(features):
-    if sm == None:
+    if features == None:
         return 6, 0
     sm = features.get("HighestShaderModel", 6.0)
     major, minor = str(sm).split(".")

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -47,6 +47,10 @@ tools = [
     ToolSubst("imgdiff", FindTool("imgdiff")),
 ]
 
+def getHighestShaderModel(features):
+    sm = features.get("HighestShaderModel", 6.0)
+    major, minor = str(sm).split('.')
+    return int(major), int(minor)
 
 def setDeviceFeatures(config, device, compiler):
     API = device["API"]
@@ -73,6 +77,11 @@ def setDeviceFeatures(config, device, compiler):
         config.available_features.add("%s-AMD" % API)
 
     config.available_features.add("%s-%s" % (compiler, API))
+
+    HighestShaderModel = getHighestShaderModel(device["Features"])
+    if (6, 6) <= HighestShaderModel:
+        # https://github.com/microsoft/DirectX-Specs/blob/master/d3d/HLSL_ShaderModel6_6.md#derivatives
+        config.available_features.add("Derivatives")
 
     if device["API"] == "DirectX":
         if device["Features"].get("Native16BitShaderOpsSupported", False):

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -85,7 +85,7 @@ def setDeviceFeatures(config, device, compiler):
     HighestShaderModel = getHighestShaderModel(device["Features"])
     if (6, 6) <= HighestShaderModel:
         # https://github.com/microsoft/DirectX-Specs/blob/master/d3d/HLSL_ShaderModel6_6.md#derivatives
-        config.available_features.add("Derivatives")
+        config.available_features.add("DerivativesInCompute")
 
     if device["API"] == "DirectX":
         if device["Features"].get("Native16BitShaderOpsSupported", False):

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -55,6 +55,7 @@ def getHighestShaderModel(features):
     major, minor = str(sm).split(".")
     return int(major), int(minor)
 
+
 def setDeviceFeatures(config, device, compiler):
     API = device["API"]
     config.available_features.add(API)


### PR DESCRIPTION
This pr adds testing for using a `StaticSampler` to describe a `Sampler` resource.

It checks both default and specified parameters are generated correctly.

Resolves https://github.com/llvm/offload-test-suite/issues/261.