### PR TITLE
Add `normalize` tests

### DIFF
--- a/test/Feature/HLSLLib/normalize.16.test
+++ b/test/Feature/HLSLLib/normalize.16.test
@@ -1,0 +1,63 @@
+#--- source.hlsl
+StructuredBuffer<half4> In : register(t0);
+
+RWStructuredBuffer<half4> Out : register(u1);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = normalize(In[0]);
+  Out[1] = half4(normalize(In[1].xyz), normalize(In[1].w));
+  Out[2] = half4(normalize(In[2].xy), normalize(In[2].zw));
+  Out[3] = normalize(half4(1, 2, -3, 4));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float16
+    Stride: 8
+    Data: [ 0x3c00, 0x4000, 0xc200, 0x4400, 0x0000, 0x44b3, 0xc840, 0x491a, 0x4500, 0x4a00, 0x4200, 0xc400 ]
+    # 1, 2, -3, 4, 0, 4.7, -8.5, 10.2, 5, 12, 3, -4
+  - Name: Out
+    Format: Float16
+    Stride: 8
+    ZeroInitSize: 32
+  - Name: ExpectedOut
+    Format: Float16
+    Stride: 8
+    Data: [ 0x31d8, 0x35d8, 0xb862, 0x39d8, 0, 0x37be, 0xbb00, 0x3c00, 0x3627, 0x3b62, 0x38cd, 0xba66, 0x31d8, 0x35d8, 0xb862, 0x39d8 ]
+    # 0.18257, 0.36515, -0.54772, 0.73030, 0, 0.48389, -0.87513, 1, 0.38462, 0.92308, 0.6, -0.8, 0.18257, 0.36515, -0.54772, 0.73030
+Results:
+  - Result: Test0
+    Rule: BufferFloatULP
+    ULPT: 2
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+#--- end
+
+# REQUIRES: Half
+# RUN: split-file %s %t
+# RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/normalize.32.test
+++ b/test/Feature/HLSLLib/normalize.32.test
@@ -1,0 +1,60 @@
+#--- source.hlsl
+StructuredBuffer<float4> In : register(t0);
+
+RWStructuredBuffer<float4> Out : register(u1);
+
+
+[numthreads(1,1,1)]
+void main() {
+  Out[0] = normalize(In[0]);
+  Out[1] = float4(normalize(In[1].xyz), normalize(In[1].w));
+  Out[2] = float4(normalize(In[2].xy), normalize(In[2].zw));
+  Out[3] = normalize(float4(1, 2, -3, 4));
+}
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+    DispatchSize: [1, 1, 1]
+Buffers:
+  - Name: In
+    Format: Float32
+    Stride: 16
+    Data: [ 1, 2, -3, 4, 0, 4.7, -8.5, 10.2, 5, 12, 3, -4 ]
+  - Name: Out
+    Format: Float32
+    Stride: 16
+    ZeroInitSize: 64
+  - Name: ExpectedOut
+    Format: Float32
+    Stride: 16
+    Data: [ 0.18257, 0.36515, -0.54772, 0.73030, 0, 0.48389, -0.87513, 1, 0.38462, 0.92308, 0.6, -0.8, 0.18257, 0.36515, -0.54772, 0.73030 ]
+Results:
+  - Result: Test0
+    Rule: BufferFloatEpsilon
+    Epsilon: 0.008
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Closes #110.

Adds tests for `normalize` testing `half` and `float`.