### PR TITLE
Switch Warp tests back to Intel while AMD machine is being debugged

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-amd]
+        SKU: [windows-intel]
         TestTarget: [check-hlsl-warp-d3d12, check-hlsl-clang-warp-d3d12]
 
     uses: ./.github/workflows/build-and-test-callable.yaml


### PR DESCRIPTION
The AMD machine has been having issues, so the Warp tests will be switched back to running on the Intel machine while the issue with the AMD machine is being sorted out.