### PR TITLE
Remove XFAIL from failing test

### DIFF
--- a/test/WaveOps/WaveReadLaneAt.index.test
+++ b/test/WaveOps/WaveReadLaneAt.index.test
@@ -114,8 +114,6 @@ DescriptorSets:
         Binding: 3
 ...
 #--- end
-# Tracked by https://github.com/llvm/offload-test-suite/issues/352
-# XFAIL: Clang-Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This PR removes an XFAIL that is passing on our actions now.