### PR TITLE
Add flags to control debug and validation layers

### DIFF
--- a/include/API/Device.h
+++ b/include/API/Device.h
@@ -30,6 +30,11 @@ namespace offloadtest {
 
 struct Pipeline;
 
+struct DeviceConfig {
+  bool EnableDebugLayer = false;
+  bool EnableValidationLayer = false;
+};
+
 class Device {
 protected:
   std::string Description;
@@ -46,7 +51,7 @@ public:
   llvm::StringRef getDescription() const { return Description; }
 
   static void registerDevice(std::shared_ptr<Device> D);
-  static llvm::Error initialize();
+  static llvm::Error initialize(const DeviceConfig Config);
   static void uninitialize();
 
   using DeviceArray = llvm::SmallVector<std::shared_ptr<Device>>;
@@ -58,16 +63,16 @@ public:
   static inline DeviceRange devices() { return DeviceRange(begin(), end()); }
 
 #ifdef OFFLOADTEST_ENABLE_D3D12
-  static llvm::Error initializeDXDevices();
+  static llvm::Error initializeDXDevices(const DeviceConfig Config);
 #endif
 
 #ifdef OFFLOADTEST_ENABLE_VULKAN
-  static llvm::Error initializeVKDevices();
+  static llvm::Error initializeVKDevices(const DeviceConfig Config);
   static void cleanupVKDevices();
 #endif
 
 #ifdef OFFLOADTEST_ENABLE_METAL
-  static llvm::Error initializeMtlDevices();
+  static llvm::Error initializeMtlDevices(const DeviceConfig Config);
 #endif
 };
 

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -287,7 +287,8 @@ public:
   llvm::StringRef getAPIName() const override { return "DirectX"; }
   GPUAPI getAPI() const override { return GPUAPI::DirectX; }
 
-  static llvm::Expected<DXDevice> create(ComPtr<IDXCoreAdapter> Adapter) {
+  static llvm::Expected<DXDevice> create(ComPtr<IDXCoreAdapter> Adapter,
+                                         const DeviceConfig &Config) {
     ComPtr<ID3D12Device> Device;
     if (auto Err =
             HR::toError(D3D12CreateDevice(Adapter.Get(), D3D_FEATURE_LEVEL_11_0,
@@ -302,8 +303,9 @@ public:
     std::vector<char> DescVec(BufferSize);
     Adapter->GetProperty(DXCoreAdapterProperty::DriverDescription, BufferSize,
                          (void *)DescVec.data());
-    if (auto Err = configureInfoQueue(Device.Get()))
-      return Err;
+    if (Config.EnableDebugLayer || Config.EnableValidationLayer)
+      if (auto Err = configureInfoQueue(Device.Get()))
+        return Err;
     return DXDevice(Adapter, Device, std::string(DescVec.data()));
   }
 
@@ -335,7 +337,6 @@ public:
 
   static llvm::Error configureInfoQueue(ID3D12Device *Device) {
 #ifdef _WIN32
-#ifndef NDEBUG
     ComPtr<ID3D12InfoQueue> InfoQueue;
     if (auto Err = HR::toError(Device->QueryInterface(InfoQueue.GetAddressOf()),
                                "Error initializing info queue"))
@@ -343,7 +344,6 @@ public:
     InfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, TRUE);
     InfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, TRUE);
     InfoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, TRUE);
-#endif
 #endif
     return llvm::Error::success();
   }
@@ -1208,7 +1208,7 @@ llvm::Error Device::initializeDXDevices(const DeviceConfig Config) {
             "Failed to acquire adapter")) {
       return Err;
     }
-    auto ExDevice = DXDevice::create(Adapter);
+    auto ExDevice = DXDevice::create(Adapter, Config);
     if (!ExDevice)
       return ExDevice.takeError();
     auto ShPtr = std::make_shared<DXDevice>(*ExDevice);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1169,18 +1169,19 @@ public:
 };
 } // namespace
 
-llvm::Error Device::initializeDXDevices() {
+llvm::Error Device::initializeDXDevices(const DeviceConfig Config) {
 #ifdef _WIN32
-#ifndef NDEBUG
-  ComPtr<ID3D12Debug1> Debug1;
+  if (Config.EnableDebugLayer || Config.EnableValidationLayer) {
+    ComPtr<ID3D12Debug1> Debug1;
 
-  if (auto Err = HR::toError(D3D12GetDebugInterface(IID_PPV_ARGS(&Debug1)),
-                             "failed to create D3D12 Debug Interface"))
-    return Err;
+    if (auto Err = HR::toError(D3D12GetDebugInterface(IID_PPV_ARGS(&Debug1)),
+                               "failed to create D3D12 Debug Interface"))
+      return Err;
 
-  Debug1->EnableDebugLayer();
-  Debug1->SetEnableGPUBasedValidation(true);
-#endif
+    if (Config.EnableDebugLayer)
+      Debug1->EnableDebugLayer();
+    Debug1->SetEnableGPUBasedValidation(Config.EnableValidationLayer);
+  }
 #endif
 
   ComPtr<IDXCoreAdapterFactory> Factory;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -1178,8 +1178,7 @@ llvm::Error Device::initializeDXDevices(const DeviceConfig Config) {
                                "failed to create D3D12 Debug Interface"))
       return Err;
 
-    if (Config.EnableDebugLayer)
-      Debug1->EnableDebugLayer();
+    Debug1->EnableDebugLayer();
     Debug1->SetEnableGPUBasedValidation(Config.EnableValidationLayer);
   }
 #endif

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -54,13 +54,13 @@ void Device::registerDevice(std::shared_ptr<Device> D) {
   DeviceContext::instance().registerDevice(D);
 }
 
-llvm::Error Device::initialize() {
+llvm::Error Device::initialize(const DeviceConfig Config) {
 #ifdef OFFLOADTEST_ENABLE_D3D12
-  if (auto Err = initializeDXDevices())
+  if (auto Err = initializeDXDevices(Config))
     return Err;
 #endif
 #ifdef OFFLOADTEST_ENABLE_VULKAN
-  if (auto Err = initializeVKDevices())
+  if (auto Err = initializeVKDevices(Config))
     return Err;
   // Validation layers have internal state which require a specific destruction
   // ordering. Relying on the global dtor call for this is unreliable and can
@@ -70,7 +70,7 @@ llvm::Error Device::initialize() {
   atexit(Device::cleanupVKDevices);
 #endif
 #ifdef OFFLOADTEST_ENABLE_METAL
-  if (auto Err = initializeMtlDevices())
+  if (auto Err = initializeMtlDevices(Config))
     return Err;
 #endif
   return llvm::Error::success();

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -304,6 +304,6 @@ public:
 
 } // namespace
 
-llvm::Error Device::initializeMtlDevices() {
+llvm::Error Device::initializeMtlDevices(const DeviceConfig /*Config*/) {
   return MTLContext::instance().initialize();
 }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -330,13 +330,10 @@ private:
 #endif
 
     Features.pNext = &Features11;
-    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
-      Features11.pNext = &Features12;
-    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0))
-      Features12.pNext = &Features13;
+    Features11.pNext = &Features12;
+    Features12.pNext = &Features13;
 #ifdef VK_VERSION_1_4
-    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 4, 0))
-      Features13.pNext = &Features14;
+    Features13.pNext = &Features14;
 #endif
     vkGetPhysicalDeviceFeatures2(Device, &Features);
 
@@ -440,13 +437,10 @@ public:
 #endif
 
     Features.pNext = &Features11;
-    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
-      Features11.pNext = &Features12;
-    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0))
-      Features12.pNext = &Features13;
+    Features11.pNext = &Features12;
+    Features12.pNext = &Features13;
 #ifdef VK_VERSION_1_4
-    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 4, 0))
-      Features13.pNext = &Features14;
+    Features13.pNext = &Features14;
 #endif
     vkGetPhysicalDeviceFeatures2(Device, &Features);
 

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -330,10 +330,13 @@ private:
 #endif
 
     Features.pNext = &Features11;
-    Features11.pNext = &Features12;
-    Features12.pNext = &Features13;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
+      Features11.pNext = &Features12;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0))
+      Features12.pNext = &Features13;
 #ifdef VK_VERSION_1_4
-    Features13.pNext = &Features14;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 4, 0))
+      Features13.pNext = &Features14;
 #endif
     vkGetPhysicalDeviceFeatures2(Device, &Features);
 
@@ -437,10 +440,13 @@ public:
 #endif
 
     Features.pNext = &Features11;
-    Features11.pNext = &Features12;
-    Features12.pNext = &Features13;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
+      Features11.pNext = &Features12;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0))
+      Features12.pNext = &Features13;
 #ifdef VK_VERSION_1_4
-    Features13.pNext = &Features14;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 4, 0))
+      Features13.pNext = &Features14;
 #endif
     vkGetPhysicalDeviceFeatures2(Device, &Features);
 
@@ -1238,7 +1244,7 @@ public:
     Instance = VK_NULL_HANDLE;
   }
 
-  llvm::Error initialize() {
+  llvm::Error initialize(const DeviceConfig Config) {
     // Create a Vulkan 1.1 instance to determine the API version
     VkApplicationInfo AppInfo = {};
     AppInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
@@ -1286,15 +1292,18 @@ public:
       auto TmpDev = std::make_shared<VKDevice>(PhysicalDevicesTmp[0]);
       AppInfo.apiVersion = TmpDev->getProps().apiVersion;
 
-#ifndef NDEBUG
-      const llvm::StringRef ValidationLayer = "VK_LAYER_KHRONOS_validation";
-      if (TmpDev->isLayerSupported(ValidationLayer))
-        Layers.push_back(ValidationLayer.data());
+      if (Config.EnableValidationLayer) {
+        const llvm::StringRef ValidationLayer = "VK_LAYER_KHRONOS_validation";
+        if (TmpDev->isLayerSupported(ValidationLayer))
+          Layers.push_back(ValidationLayer.data());
+      }
 
-      const llvm::StringRef DebugUtilsExtensionName = "VK_EXT_debug_utils";
-      if (TmpDev->isExtensionSupported(DebugUtilsExtensionName))
-        Extensions.push_back(DebugUtilsExtensionName.data());
-#endif
+      if (Config.EnableDebugLayer) {
+        const llvm::StringRef DebugUtilsExtensionName = "VK_EXT_debug_utils";
+        if (TmpDev->isExtensionSupported(DebugUtilsExtensionName))
+          Extensions.push_back(DebugUtilsExtensionName.data());
+      }
+
       CreateInfo.ppEnabledLayerNames = Layers.data();
       CreateInfo.enabledLayerCount = Layers.size();
       CreateInfo.ppEnabledExtensionNames = Extensions.data();
@@ -1338,8 +1347,8 @@ public:
 };
 } // namespace
 
-llvm::Error Device::initializeVKDevices() {
-  return VKContext::instance().initialize();
+llvm::Error Device::initializeVKDevices(const DeviceConfig Config) {
+  return VKContext::instance().initialize(Config);
 }
 
 void Device::cleanupVKDevices() { VKContext::instance().cleanup(); }

--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -62,6 +62,8 @@ DescriptorSets:
 # UHD drivers. This issue does not reproduce when compiled with Clang because
 # LLVM's load-store optimization performs correct optimizations that hide the
 # problem.
+# This test fails randomly but inconsistently without validation enabled. With
+# validation enabled it fails consistently every time.
 # Tracking issue: https://github.com/llvm/offload-test-suite/issues/226
 # XFAIL: Intel-Memory-Coherence-Issue-226 && !Clang
 
@@ -71,4 +73,4 @@ DescriptorSets:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
-# RUN: %offloader %t/pipeline.yaml %t.o
+# RUN: %offloader -validation-layer %t/pipeline.yaml %t.o

--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -62,8 +62,6 @@ DescriptorSets:
 # UHD drivers. This issue does not reproduce when compiled with Clang because
 # LLVM's load-store optimization performs correct optimizations that hide the
 # problem.
-# This test fails randomly but inconsistently without validation enabled. With
-# validation enabled it fails consistently every time.
 # Tracking issue: https://github.com/llvm/offload-test-suite/issues/226
 # XFAIL: Intel-Memory-Coherence-Issue-226 && !Clang
 
@@ -73,4 +71,4 @@ DescriptorSets:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
-# RUN: %offloader -validation-layer %t/pipeline.yaml %t.o
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Bugs/UAV-Sequental-Consistency.yaml
+++ b/test/Bugs/UAV-Sequental-Consistency.yaml
@@ -60,9 +60,11 @@ DescriptorSets:
 # UHD drivers. This issue does not reproduce when compiled with Clang because
 # LLVM's load-store optimization performs correct optimizations that hide the
 # problem.
+# This test fails randomly but inconsistently without validation enabled. With
+# validation enabled it fails consistently every time.
 # Tracking issue: https://github.com/llvm/offload-test-suite/issues/226
 # XFAIL: Intel-Memory-Coherence-Issue-226 && !Clang
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
-# RUN: %offloader %t/pipeline.yaml %t.o
+# RUN: %offloader -validation-layer %t/pipeline.yaml %t.o

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ function(try_compile_hlsl output)
 endfunction()
 
 option(OFFLOADTEST_ENABLE_DEBUG "Enable available runtime debug layers (defaults On)." ON)
+option(OFFLOADTEST_ENABLE_VALIDATION "Enable available runtime validation layers (defaults Off)." OFF)
 
 list(APPEND OFFLOADTEST_DEPS
   api-query
@@ -102,7 +103,8 @@ if (OFFLOADTEST_ENABLE_METAL)
 endif()
 
 llvm_canonicalize_cmake_booleans(OFFLOADTEST_TEST_CLANG
-                                 OFFLOADTEST_ENABLE_DEBUG)
+                                 OFFLOADTEST_ENABLE_DEBUG
+                                 OFFLOADTEST_ENABLE_VALIDATION)
 
 foreach(platform ${platforms_to_test})
   set(TEST_${platform} False)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,8 @@ function(try_compile_hlsl output)
   message(STATUS "${output} - ${${output}}")
 endfunction()
 
+option(OFFLOADTEST_ENABLE_DEBUG "Enable available runtime debug layers (defaults On)." ON)
+
 list(APPEND OFFLOADTEST_DEPS
   api-query
   offloader
@@ -99,7 +101,8 @@ if (OFFLOADTEST_ENABLE_METAL)
   list(APPEND platforms_to_test mtl)
 endif()
 
-llvm_canonicalize_cmake_booleans(OFFLOADTEST_TEST_CLANG)
+llvm_canonicalize_cmake_booleans(OFFLOADTEST_TEST_CLANG
+                                 OFFLOADTEST_ENABLE_DEBUG)
 
 foreach(platform ${platforms_to_test})
   set(TEST_${platform} False)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -109,7 +109,9 @@ if config.offloadtest_test_warp:
 if config.offloadtest_enable_debug:
     offloader_args.append("-debug-layer")
 
-tools.append(ToolSubst("%offloader", command=FindTool("offloader"), extra_args=offloader_args))
+tools.append(
+    ToolSubst("%offloader", command=FindTool("offloader"), extra_args=offloader_args)
+)
 
 ExtraCompilerArgs = []
 if config.offloadtest_enable_vulkan:

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -103,13 +103,13 @@ def setDeviceFeatures(config, device, compiler):
         for Extension in device["Extensions"]:
             config.available_features.add(Extension["ExtensionName"])
 
-
+offloader_args = []
 if config.offloadtest_test_warp:
-    tools.append(
-        ToolSubst("%offloader", command=FindTool("offloader"), extra_args=["-warp"])
-    )
-else:
-    tools.append(ToolSubst("%offloader", FindTool("offloader")))
+    offloader_args.append("-warp")
+if config.offloadtest_enable_debug:
+    offloader_args.append("-debug-layer")
+
+tools.append(ToolSubst("%offloader", command=FindTool("offloader"), extra_args=offloader_args))
 
 ExtraCompilerArgs = []
 if config.offloadtest_enable_vulkan:

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -57,7 +57,11 @@ def setDeviceFeatures(config, device, compiler):
         config.available_features.add("WARP-%s" % config.warp_arch)
     if "Intel" in device["Description"]:
         config.available_features.add("%s-Intel" % API)
-        if "UHD Graphics" in device["Description"] and API == "DirectX":
+        if (
+            "UHD Graphics" in device["Description"]
+            and API == "DirectX"
+            and config.offloadtest_enable_validation
+        ):
             # When Intel resolves the driver issue and tests XFAILing on the
             # feature below are resolved we can resolve
             # https://github.com/llvm/offload-test-suite/issues/226 by updating
@@ -103,11 +107,14 @@ def setDeviceFeatures(config, device, compiler):
         for Extension in device["Extensions"]:
             config.available_features.add(Extension["ExtensionName"])
 
+
 offloader_args = []
 if config.offloadtest_test_warp:
     offloader_args.append("-warp")
 if config.offloadtest_enable_debug:
     offloader_args.append("-debug-layer")
+if config.offloadtest_enable_validation:
+    offloader_args.append("-validation-layer")
 
 tools.append(
     ToolSubst("%offloader", command=FindTool("offloader"), extra_args=offloader_args)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -57,11 +57,7 @@ def setDeviceFeatures(config, device, compiler):
         config.available_features.add("WARP-%s" % config.warp_arch)
     if "Intel" in device["Description"]:
         config.available_features.add("%s-Intel" % API)
-        if (
-            "UHD Graphics" in device["Description"]
-            and API == "DirectX"
-            and config.offloadtest_enable_validation
-        ):
+        if "UHD Graphics" in device["Description"] and API == "DirectX":
             # When Intel resolves the driver issue and tests XFAILing on the
             # feature below are resolved we can resolve
             # https://github.com/llvm/offload-test-suite/issues/226 by updating

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -20,6 +20,7 @@ config.offloadtest_enable_vulkan = @TEST_vk@
 config.offloadtest_enable_metal = @TEST_mtl@
 config.offloadtest_os = "@CMAKE_SYSTEM_NAME@"
 config.offloadtest_enable_debug = @OFFLOADTEST_ENABLE_DEBUG@
+config.offloadtest_enable_validation = @OFFLOADTEST_ENABLE_VALIDATION@
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -19,6 +19,7 @@ config.offloadtest_enable_d3d12 = @TEST_d3d12@
 config.offloadtest_enable_vulkan = @TEST_vk@
 config.offloadtest_enable_metal = @TEST_mtl@
 config.offloadtest_os = "@CMAKE_SYSTEM_NAME@"
+config.offloadtest_enable_debug = @OFFLOADTEST_ENABLE_DEBUG@
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/tools/api-query/api-query.cpp
+++ b/tools/api-query/api-query.cpp
@@ -26,7 +26,8 @@ int main(int ArgC, char **ArgV) {
 
   const ExitOnError ExitOnErr("api-query: error: ");
 
-  if (auto Err = Device::initialize())
+  const DeviceConfig Config;
+  if (auto Err = Device::initialize(Config))
     logAllUnhandledErrors(std::move(Err), errs(), "api-query: error: ");
 
   outs() << "Devices:\n";

--- a/tools/offloader/offloader.cpp
+++ b/tools/offloader/offloader.cpp
@@ -55,6 +55,12 @@ static cl::opt<std::string>
 static cl::opt<bool>
     Quiet("quiet", cl::desc("Suppress printing the pipeline as output"));
 
+static cl::opt<bool> Debug("debug-layer",
+                           cl::desc("Enable runtime debug layers"));
+
+static cl::opt<bool> Validation("validation-layer",
+                                cl::desc("Enable runtime validation layers"));
+
 static cl::opt<bool> UseWarp("warp", cl::desc("Use warp"));
 
 static std::unique_ptr<MemoryBuffer> readFile(const std::string &Path) {
@@ -80,7 +86,9 @@ int main(int ArgC, char **ArgV) {
 
 int run() {
   const ExitOnError ExitOnErr("gpu-exec: error: ");
-  logAllUnhandledErrors(Device::initialize(), errs(), "gpu-exec: warning: ");
+  const DeviceConfig Config = {Debug, Validation};
+  logAllUnhandledErrors(Device::initialize(Config), errs(),
+                        "gpu-exec: warning: ");
 
   const std::unique_ptr<MemoryBuffer> PipelineBuf = readFile(InputPipeline);
   Pipeline PipelineDesc;


### PR DESCRIPTION
This PR adds flags to enable the debug and validation layers for runtimes. Both default to `off` in the offloader tool, but the default CMake configuration enables the debug layer during test suite runs.