### PR TITLE
Fix vulkan validation error for device init

### DIFF
--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -330,10 +330,13 @@ private:
 #endif
 
     Features.pNext = &Features11;
-    Features11.pNext = &Features12;
-    Features12.pNext = &Features13;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
+      Features11.pNext = &Features12;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0))
+      Features12.pNext = &Features13;
 #ifdef VK_VERSION_1_4
-    Features13.pNext = &Features14;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 4, 0))
+      Features13.pNext = &Features14;
 #endif
     vkGetPhysicalDeviceFeatures2(Device, &Features);
 
@@ -437,10 +440,13 @@ public:
 #endif
 
     Features.pNext = &Features11;
-    Features11.pNext = &Features12;
-    Features12.pNext = &Features13;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
+      Features11.pNext = &Features12;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 3, 0))
+      Features12.pNext = &Features13;
 #ifdef VK_VERSION_1_4
-    Features13.pNext = &Features14;
+    if (Props.apiVersion >= VK_MAKE_API_VERSION(0, 1, 4, 0))
+      Features13.pNext = &Features14;
 #endif
     vkGetPhysicalDeviceFeatures2(Device, &Features);
 


### PR DESCRIPTION
The valdiation layer produces a warning if we use a features structure that is higher version than the device's API version.