### PR TITLE
Reduce all the AMD scheduled builds to every 6 hours

### DIFF
--- a/.github/workflows/windows-amd-clang-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
 
 jobs:
   Windows-D3D12-AMD-Clang:

--- a/.github/workflows/windows-amd-clang-vk.yaml
+++ b/.github/workflows/windows-amd-clang-vk.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
 
 jobs:
   Windows-VK-AMD-Clang:

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 2 hours
 
 jobs:
   Windows-D3D12-Warp-Clang:

--- a/.github/workflows/windows-amd-clang-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-clang-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */6 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
 
 jobs:
   Windows-D3D12-Warp-Clang:

--- a/.github/workflows/windows-amd-dxc-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *' # run every 30 minutes
+    - cron: '0 */6 * * *' # run every 6 hours
 
 jobs:
   Windows-D3D12-AMD-DXC:

--- a/.github/workflows/windows-amd-dxc-vk.yaml
+++ b/.github/workflows/windows-amd-dxc-vk.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
 
 jobs:
   Windows-VK-AMD-DXC:

--- a/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
+++ b/.github/workflows/windows-amd-dxc-warp-d3d12.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *' # run every 2 hours
+    - cron: '0 */6 * * *' # run every 6 hours
 
 jobs:
   Windows-D3D12-Warp-DXC:


### PR DESCRIPTION
Since each build is taking 20-30 minutes, running 6 builds every 2 hours doesn't work. Scaling back to every 6 hours.