### PR TITLE
Remove XFAIL from isinf tests for fixed issue.

### DIFF
--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -62,9 +62,6 @@ DescriptorSets:
 # Version 3 fixes this issue.
 # UNSUPPORTED: Clang-Metal && !metal-shaderconverter-3.0.0-or-later
 
-# Bug https://github.com/llvm/llvm-project/issues/148051
-# XFAIL: Clang-Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/isinf.32.test
+++ b/test/Feature/HLSLLib/isinf.32.test
@@ -55,9 +55,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/148051
-# XFAIL: Clang-Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Remove Clang-Vulkan xfail from isinf tests because the issue was fixed.