### PR TITLE
Add Graphics support to DX, VK and MTL

### DIFF
--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -271,6 +271,13 @@ private:
 #else // WSL
     int Event;
 #endif
+
+    // Resources for graphics pipelines.
+    ComPtr<ID3D12Resource> RT;
+    ComPtr<ID3D12Resource> RTReadback;
+    ComPtr<ID3D12DescriptorHeap> RTVHeap;
+    ComPtr<ID3D12Resource> VB;
+
     llvm::SmallVector<DescriptorTable> DescTables;
     llvm::SmallVector<ResourcePair> RootResources;
   };
@@ -412,7 +419,10 @@ public:
 
     CD3DX12_ROOT_SIGNATURE_DESC Desc;
     Desc.Init(static_cast<uint32_t>(RootParams.size()), RootParams.data(), 0,
-              nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
+              nullptr,
+              P.isGraphics()
+                  ? D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT
+                  : D3D12_ROOT_SIGNATURE_FLAG_NONE);
 
     ComPtr<ID3DBlob> Signature;
     ComPtr<ID3DBlob> Error;
@@ -452,7 +462,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createPSO(llvm::StringRef DXIL, InvocationState &State) {
+  llvm::Error createComputePSO(llvm::StringRef DXIL, InvocationState &State) {
     const D3D12_COMPUTE_PIPELINE_STATE_DESC Desc = {
         State.RootSig.Get(),
         {DXIL.data(), DXIL.size()},
@@ -1066,7 +1076,7 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error readBack(InvocationState &IS) {
+  llvm::Error readBack(Pipeline &P, InvocationState &IS) {
     auto MemCpyBack = [](ResourcePair &R) -> llvm::Error {
       if (!R.first->isReadWrite())
         return llvm::Error::success();
@@ -1103,11 +1113,257 @@ public:
     for (auto &R : IS.RootResources)
       if (auto Err = MemCpyBack(R))
         return Err;
+
+    // If there is no render target, return early.
+    if (IS.RTReadback == nullptr)
+      return llvm::Error::success();
+
+    // Map readback and copy into host buffer, accounting for row pitch and
+    // flipping vertical orientation. DirectX render target origin is top-left,
+    // while our image writer expects bottom-left.
+    const Buffer &B = *P.Bindings.RTargetBufferPtr;
+    void *Mapped = nullptr;
+    if (auto Err = HR::toError(IS.RTReadback->Map(0, nullptr, &Mapped),
+                               "Failed to map render target readback"))
+      return Err;
+
+    // Query the copy footprint to get the actual padded row pitch used by the
+    // copy operation.
+    const D3D12_RESOURCE_DESC RTDesc = IS.RT->GetDesc();
+    D3D12_PLACED_SUBRESOURCE_FOOTPRINT Placed = {};
+    uint32_t NumRows = 0;
+    uint64_t RowSizeInBytes = 0;
+    uint64_t TotalBytes = 0;
+    Device->GetCopyableFootprints(&RTDesc, 0u, 1u, 0u, &Placed, &NumRows,
+                                  &RowSizeInBytes, &TotalBytes);
+
+    const uint32_t RowPitch = Placed.Footprint.RowPitch;
+    const uint32_t RowBytes =
+        static_cast<uint32_t>(B.getElementSize() * B.OutputProps.Width);
+    const uint32_t Height = static_cast<uint32_t>(B.OutputProps.Height);
+
+    uint8_t *SrcBase = reinterpret_cast<uint8_t *>(Mapped);
+    uint8_t *DstBase =
+        reinterpret_cast<uint8_t *>(P.Bindings.RTargetBufferPtr->Data[0].get());
+
+    // Copy rows in reverse order.
+    for (uint32_t Y = 0; Y < Height; ++Y) {
+      uint8_t *SrcRow = SrcBase + static_cast<size_t>(Y) * RowPitch;
+      uint8_t *DstRow =
+          DstBase + static_cast<size_t>(Height - 1 - Y) * RowBytes;
+      memcpy(DstRow, SrcRow, RowBytes);
+    }
+
+    IS.RTReadback->Unmap(0, nullptr);
+    return llvm::Error::success();
+  }
+
+  llvm::Error createRenderTarget(Pipeline &P, InvocationState &IS) {
+    if (!P.Bindings.RTargetBufferPtr)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "No render target bound for graphics pipeline.");
+    const Buffer &OutBuf = *P.Bindings.RTargetBufferPtr;
+    D3D12_RESOURCE_DESC Desc = {};
+    Desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    Desc.Width = OutBuf.OutputProps.Width;
+    Desc.Height = OutBuf.OutputProps.Height;
+    Desc.DepthOrArraySize = 1;
+    Desc.MipLevels = 1;
+    Desc.Format = getDXFormat(OutBuf.Format, OutBuf.Channels);
+    Desc.SampleDesc.Count = 1;
+    Desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    Desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+    D3D12_CLEAR_VALUE ClearValue = {};
+    ClearValue.Format = Desc.Format;
+    ClearValue.Color[0] = 0.0f;
+    ClearValue.Color[1] = 0.0f;
+    ClearValue.Color[2] = 0.0f;
+    ClearValue.Color[3] = 0.0f;
+
+    CD3DX12_HEAP_PROPERTIES HeapProps =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+    if (auto Err = HR::toError(Device->CreateCommittedResource(
+                                   &HeapProps, D3D12_HEAP_FLAG_NONE, &Desc,
+                                   D3D12_RESOURCE_STATE_RENDER_TARGET,
+                                   &ClearValue, IID_PPV_ARGS(&IS.RT)),
+                               "Failed to create render target"))
+      return Err;
+
+    // Create readback buffer sized for the pixel data (raw bytes).
+    const uint64_t RBSize = static_cast<uint64_t>(OutBuf.size());
+    D3D12_RESOURCE_DESC const RbDesc = CD3DX12_RESOURCE_DESC::Buffer(RBSize);
+    CD3DX12_HEAP_PROPERTIES RbHeap =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK);
+    if (auto Err =
+            HR::toError(Device->CreateCommittedResource(
+                            &RbHeap, D3D12_HEAP_FLAG_NONE, &RbDesc,
+                            D3D12_RESOURCE_STATE_COPY_DEST, nullptr,
+                            IID_PPV_ARGS(&IS.RTReadback)),
+                        "Failed to create render target readback buffer"))
+      return Err;
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error createVertexBuffer(Pipeline &P, InvocationState &IS) {
+    if (!P.Bindings.VertexBufferPtr)
+      return llvm::createStringError(
+          std::errc::invalid_argument,
+          "No vertex buffer bound for graphics pipeline.");
+    const Buffer &VB = *P.Bindings.VertexBufferPtr;
+    const uint64_t VBSize = VB.size();
+    D3D12_RESOURCE_DESC const Desc = CD3DX12_RESOURCE_DESC::Buffer(VBSize);
+    CD3DX12_HEAP_PROPERTIES HeapProps =
+        CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+    if (auto Err = HR::toError(Device->CreateCommittedResource(
+                                   &HeapProps, D3D12_HEAP_FLAG_NONE, &Desc,
+                                   D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                                   IID_PPV_ARGS(&IS.VB)),
+                               "Failed to create vertex buffer"))
+      return Err;
+
+    void *Ptr = nullptr;
+    if (auto Err = HR::toError(IS.VB->Map(0, nullptr, &Ptr),
+                               "Failed to map vertex buffer"))
+      return Err;
+    memcpy(Ptr, VB.Data[0].get(), VBSize);
+    IS.VB->Unmap(0, nullptr);
+
+    D3D12_VERTEX_BUFFER_VIEW VBView = {};
+    VBView.BufferLocation = IS.VB->GetGPUVirtualAddress();
+    VBView.SizeInBytes = static_cast<UINT>(VBSize);
+    VBView.StrideInBytes = P.Bindings.getVertexStride();
+
+    IS.CmdList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    IS.CmdList->IASetVertexBuffers(0, 1, &VBView);
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error createGraphicsPSO(Pipeline &P, InvocationState &IS) {
+    // Create the input layout based on the vertex attributes.
+    std::vector<D3D12_INPUT_ELEMENT_DESC> InputLayout;
+    for (size_t I = 0; I < P.Bindings.VertexAttributes.size(); ++I) {
+      const VertexAttribute &Attr = P.Bindings.VertexAttributes[I];
+      InputLayout.push_back({Attr.Name.c_str(), 0,
+                             getDXFormat(Attr.Format, Attr.Channels), 0,
+                             static_cast<UINT>(Attr.Offset),
+                             D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0});
+    }
+
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC PSODesc = {};
+    PSODesc.InputLayout = {InputLayout.data(), (UINT)InputLayout.size()};
+    PSODesc.pRootSignature = IS.RootSig.Get();
+
+    for (auto &S : P.Shaders) {
+      switch (S.Stage) {
+      case Stages::Vertex:
+        PSODesc.VS = {S.Shader->getBuffer().data(),
+                      S.Shader->getBuffer().size()};
+        break;
+      case Stages::Pixel:
+        PSODesc.PS = {S.Shader->getBuffer().data(),
+                      S.Shader->getBuffer().size()};
+        break;
+      default:
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Unsupported shader type in graphics pipeline.");
+      }
+    }
+
+    // TODO: Add support for more shader stages and different pipeline shapes.
+    if (PSODesc.VS.BytecodeLength == 0 || PSODesc.PS.BytecodeLength == 0)
+      return llvm::createStringError(std::errc::invalid_argument,
+                                     "Graphics pipeline requires both a vertex "
+                                     "shader and a pixel shader.");
+
+    PSODesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
+    PSODesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT);
+    PSODesc.DepthStencilState.DepthEnable = false;
+    PSODesc.DepthStencilState.StencilEnable = false;
+    PSODesc.SampleMask = UINT_MAX;
+    PSODesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    PSODesc.NumRenderTargets = 1;
+    PSODesc.RTVFormats[0] = getDXFormat(P.Bindings.RTargetBufferPtr->Format,
+                                        P.Bindings.RTargetBufferPtr->Channels);
+    PSODesc.SampleDesc.Count = 1;
+
+    if (auto Err = HR::toError(Device->CreateGraphicsPipelineState(
+                                   &PSODesc, IID_PPV_ARGS(&IS.PSO)),
+                               "Failed to create graphics PSO."))
+      return Err;
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error createGraphicsCommands(Pipeline &P, InvocationState &IS) {
+    // Create descriptor heap for the render target view. We do this later and
+    // separately from other descriptors just as a convenience since we need the
+    // descriptor handle to bind the render target.
+    D3D12_DESCRIPTOR_HEAP_DESC RTVHeapDesc = {};
+    RTVHeapDesc.NumDescriptors = 1;
+    RTVHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
+    RTVHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+    if (auto Err = HR::toError(Device->CreateDescriptorHeap(
+                                   &RTVHeapDesc, IID_PPV_ARGS(&IS.RTVHeap)),
+                               "Failed to create RTV heap"))
+      return Err;
+    const D3D12_CPU_DESCRIPTOR_HANDLE RTVHandle =
+        IS.RTVHeap->GetCPUDescriptorHandleForHeapStart();
+    Device->CreateRenderTargetView(IS.RT.Get(), nullptr, RTVHandle);
+
+    IS.CmdList->SetPipelineState(IS.PSO.Get());
+    IS.CmdList->SetGraphicsRootSignature(IS.RootSig.Get());
+
+    IS.CmdList->OMSetRenderTargets(1, &RTVHandle, false, nullptr);
+
+    D3D12_VIEWPORT VP = {};
+    VP.Width =
+        static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Width);
+    VP.Height =
+        static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
+    VP.MinDepth = 0.0f;
+    VP.MaxDepth = 1.0f;
+    VP.TopLeftX = 0.0f;
+    VP.TopLeftY = 0.0f;
+    IS.CmdList->RSSetViewports(1, &VP);
+    const D3D12_RECT Scissor = {0, 0, static_cast<LONG>(VP.Width),
+                                static_cast<LONG>(VP.Height)};
+    IS.CmdList->RSSetScissorRects(1, &Scissor);
+
+    if (IS.DescHeap) {
+      ID3D12DescriptorHeap *const Heaps[] = {IS.DescHeap.Get()};
+      IS.CmdList->SetDescriptorHeaps(1, Heaps);
+      IS.CmdList->SetGraphicsRootDescriptorTable(
+          0, IS.DescHeap->GetGPUDescriptorHandleForHeapStart());
+    }
+
+    IS.CmdList->DrawInstanced(P.Bindings.getVertexCount(), 1, 0, 0);
+
+    // Transition the render target to copy source and copy to the readback
+    // buffer.
+    const D3D12_RESOURCE_BARRIER Barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+        IS.RT.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET,
+        D3D12_RESOURCE_STATE_COPY_SOURCE);
+    IS.CmdList->ResourceBarrier(1, &Barrier);
+
+    const Buffer &B = *P.Bindings.RTargetBufferPtr;
+    const D3D12_PLACED_SUBRESOURCE_FOOTPRINT Footprint{
+        0,
+        CD3DX12_SUBRESOURCE_FOOTPRINT(
+            getDXFormat(B.Format, B.Channels), B.OutputProps.Width,
+            B.OutputProps.Height, 1, B.OutputProps.Width * B.getElementSize())};
+    const CD3DX12_TEXTURE_COPY_LOCATION DstLoc(IS.RTReadback.Get(), Footprint);
+    const CD3DX12_TEXTURE_COPY_LOCATION SrcLoc(IS.RT.Get(), 0);
+
+    IS.CmdList->CopyTextureRegion(&DstLoc, 0, 0, 0, &SrcLoc, nullptr);
     return llvm::Error::success();
   }
 
   llvm::Error executeProgram(Pipeline &P) override {
-
     llvm::sys::AddSignalHandler(
         [](void *Cookie) {
           ID3D12Device *Device = (ID3D12Device *)Cookie;
@@ -1142,9 +1398,7 @@ public:
     if (auto Err = createDescriptorHeap(P, State))
       return Err;
     llvm::outs() << "Descriptor heap created.\n";
-    if (auto Err = createPSO(P.Shaders[0].Shader->getBuffer(), State))
-      return Err;
-    llvm::outs() << "PSO created.\n";
+
     if (auto Err = createCommandStructures(State))
       return Err;
     llvm::outs() << "Command structures created.\n";
@@ -1154,13 +1408,40 @@ public:
     if (auto Err = createEvent(State))
       return Err;
     llvm::outs() << "Event prepared.\n";
-    if (auto Err = createComputeCommands(P, State))
-      return Err;
-    llvm::outs() << "Compute command list created.\n";
+
+    if (P.isCompute()) {
+      // This is an arbitrary distinction that we could alter in the future.
+      if (P.Shaders.size() != 1 || P.Shaders[0].Stage != Stages::Compute)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Compute pipeline must have exactly one compute shader.");
+      if (auto Err = createComputePSO(P.Shaders[0].Shader->getBuffer(), State))
+        return Err;
+      llvm::outs() << "PSO created.\n";
+      if (auto Err = createComputeCommands(P, State))
+        return Err;
+      llvm::outs() << "Compute command list created.\n";
+
+    } else {
+      // Create render target, readback and vertex buffer and PSO.
+      if (auto Err = createRenderTarget(P, State))
+        return Err;
+      llvm::outs() << "Render target created.\n";
+      if (auto Err = createVertexBuffer(P, State))
+        return Err;
+      llvm::outs() << "Vertex buffer created.\n";
+      if (auto Err = createGraphicsPSO(P, State))
+        return Err;
+      llvm::outs() << "Graphics PSO created.\n";
+      if (auto Err = createGraphicsCommands(P, State))
+        return Err;
+      llvm::outs() << "Graphics command list created complete.\n";
+    }
+
     if (auto Err = executeCommandList(State))
       return Err;
     llvm::outs() << "Compute commands executed.\n";
-    if (auto Err = readBack(State))
+    if (auto Err = readBack(P, State))
       return Err;
     llvm::outs() << "Read data back.\n";
 

--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
+#include <algorithm>
 
 using namespace offloadtest;
 
@@ -50,6 +51,26 @@ static MTL::PixelFormat getMTLFormat(DataFormat Format, int Channels) {
   return MTL::PixelFormatInvalid;
 }
 
+#define MTLVTXFormats(Base)                                                    \
+  if (Channels == 1)                                                           \
+    return MTL::VertexFormat##Base;                                            \
+  if (Channels == 2)                                                           \
+    return MTL::VertexFormat##Base##2;                                         \
+  if (Channels == 3)                                                           \
+    return MTL::VertexFormat##Base##3;                                         \
+  if (Channels == 4)                                                           \
+    return MTL::VertexFormat##Base##4;
+
+static MTL::VertexFormat getMTLVertexFormat(DataFormat Format, int Channels) {
+  switch (Format) {
+  case DataFormat::Float32:
+    MTLVTXFormats(Float) break;
+  default:
+    llvm_unreachable("Unsupported Resource format specified");
+  }
+  return MTL::VertexFormatInvalid;
+}
+
 namespace {
 class MTLDevice : public offloadtest::Device {
   Capabilities Caps;
@@ -62,12 +83,10 @@ class MTLDevice : public offloadtest::Device {
         T->release();
       for (MTL::Buffer *B : Buffers)
         B->release();
-      if (Fn)
-        Fn->release();
-      if (Lib)
-        Lib->release();
-      if (PipelineState)
-        PipelineState->release();
+      if (ComputePipeline)
+        ComputePipeline->release();
+      if (RenderPipeline)
+        RenderPipeline->release();
       if (Queue)
         Queue->release();
 
@@ -76,30 +95,157 @@ class MTLDevice : public offloadtest::Device {
 
     NS::AutoreleasePool *Pool = nullptr;
     MTL::CommandQueue *Queue = nullptr;
-    MTL::Library *Lib = nullptr;
-    MTL::Function *Fn = nullptr;
-    MTL::ComputePipelineState *PipelineState;
+    MTL::ComputePipelineState *ComputePipeline = nullptr;
+    MTL::RenderPipelineState *RenderPipeline = nullptr;
     MTL::Buffer *ArgBuffer;
+    MTL::Buffer *VertexBuffer;
+    MTL::VertexDescriptor *VertexDescriptor;
     llvm::SmallVector<MTL::Texture *> Textures;
     llvm::SmallVector<MTL::Buffer *> Buffers;
+    MTL::Texture *FrameBufferTexture = nullptr;
+    MTL::CommandBuffer *CmdBuffer = nullptr;
   };
 
-  llvm::Error loadShaders(InvocationState &IS, const Shader &P) {
-    NS::Error *Error = nullptr;
-    const llvm::StringRef Program = P.Shader->getBuffer();
-    dispatch_data_t Data = dispatch_data_create(Program.data(), Program.size(),
-                                                dispatch_get_main_queue(),
-                                                ^{
-                                                });
-    IS.Lib = Device->newLibrary(Data, &Error);
-    if (Error)
-      return toError(Error);
+  llvm::Error setupVertexShader(InvocationState &IS, const Pipeline &P,
+                                MTL::Function *Fn) {
+    if (P.Bindings.VertexBufferPtr) {
+      NS::Array *FnAttrs = Fn->vertexAttributes();
+      // I'm not really sure if there's any valid case for a vertex shader with
+      // no vertex attributes, so we just error if that ever occurs.
+      if (!FnAttrs)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Vertex shader has no vertex attributes.");
+      if (FnAttrs->count() != P.Bindings.VertexAttributes.size())
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Mismatch between vertex shader attribute count and pipeline "
+            "vertex input count.");
+      // Collect the attribute indices the shader expects so that we can map the
+      // specified attributes onto the correct indices.
+      llvm::StringMap<uint32_t> ShaderAttrIndices;
+      for (uint32_t Ai = 0; Ai < FnAttrs->count(); ++Ai) {
+        auto *A = static_cast<MTL::VertexAttribute *>(FnAttrs->object(Ai));
+        if (A && A->active()) {
+          ShaderAttrIndices.insert(std::make_pair(
+              llvm::StringRef(A->name()->utf8String()), A->attributeIndex()));
+          llvm::errs() << "Shader attr: " << A->name()->utf8String()
+                       << " at index " << A->attributeIndex() << "\n";
+        }
+      }
 
-    IS.Fn = IS.Lib->newFunction(
-        NS::String::string(P.Entry.c_str(), NS::UTF8StringEncoding));
-    IS.PipelineState = Device->newComputePipelineState(IS.Fn, &Error);
-    if (Error)
-      return toError(Error);
+      IS.VertexDescriptor = MTL::VertexDescriptor::alloc()->init();
+      const uint32_t Stride = P.Bindings.getVertexStride();
+      for (const VertexAttribute &VA : P.Bindings.VertexAttributes) {
+        llvm::SmallString<32> AttrName(VA.Name);
+        llvm::transform(AttrName, AttrName.begin(), tolower);
+        // Append a zero since we're only supporting one attribute per name.
+        // We'll need to revisit this if we ever support indexed attributes.
+        AttrName += "0";
+        MTL::VertexAttributeDescriptor *VADesc =
+            MTL::VertexAttributeDescriptor::alloc()->init();
+        VADesc->setBufferIndex(0);
+        VADesc->setOffset(VA.Offset);
+        VADesc->setFormat(getMTLVertexFormat(VA.Format, VA.Channels));
+        IS.VertexDescriptor->attributes()->setObject(
+            VADesc, ShaderAttrIndices[AttrName]);
+      }
+
+      MTL::VertexBufferLayoutDescriptor *LDesc =
+          MTL::VertexBufferLayoutDescriptor::alloc()->init();
+      LDesc->setStride(Stride);
+      LDesc->setStepRate(1);
+      LDesc->setStepFunction(MTL::VertexStepFunctionPerVertex);
+      IS.VertexDescriptor->layouts()->setObject(LDesc, 0);
+    }
+    return llvm::Error::success();
+  }
+
+  llvm::Error loadShaders(InvocationState &IS, const Pipeline &P) {
+    NS::Error *Error = nullptr;
+    if (P.isCompute()) {
+      // This is an arbitrary distinction that we could alter in the future.
+      if (P.Shaders.size() != 1)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Compute pipeline must have exactly one compute shader.");
+      const llvm::StringRef Program = P.Shaders[0].Shader->getBuffer();
+      dispatch_data_t Data = dispatch_data_create(
+          Program.data(), Program.size(), dispatch_get_main_queue(),
+          ^{
+          });
+      MTL::Library *Lib = Device->newLibrary(Data, &Error);
+      if (Error)
+        return toError(Error);
+      IS.Pool->addObject(Lib);
+
+      MTL::Function *Fn = Lib->newFunction(NS::String::string(
+          P.Shaders[0].Entry.c_str(), NS::UTF8StringEncoding));
+      IS.ComputePipeline = Device->newComputePipelineState(Fn, &Error);
+      if (Error)
+        return toError(Error);
+      IS.Pool->addObject(Fn);
+    } else {
+      MTL::RenderPipelineDescriptor *Desc =
+          MTL::RenderPipelineDescriptor::alloc()->init();
+      IS.Pool->addObject(Desc);
+      for (const auto &S : P.Shaders) {
+        const llvm::StringRef Program = S.Shader->getBuffer();
+        dispatch_data_t Data = dispatch_data_create(
+            Program.data(), Program.size(), dispatch_get_main_queue(),
+            ^{
+            });
+        MTL::Library *Lib = Device->newLibrary(Data, &Error);
+        if (Error)
+          return toError(Error);
+        IS.Pool->addObject(Lib);
+
+        MTL::Function *Fn = Lib->newFunction(
+            NS::String::string(S.Entry.c_str(), NS::UTF8StringEncoding));
+        switch (S.Stage) {
+        case Stages::Vertex:
+          Desc->setVertexFunction(Fn);
+          if (llvm::Error Err = setupVertexShader(IS, P, Fn))
+            return Err;
+
+          Desc->setVertexDescriptor(IS.VertexDescriptor);
+          break;
+        case Stages::Pixel:
+          Desc->setFragmentFunction(Fn);
+          break;
+        case Stages::Compute:
+          return llvm::createStringError(
+              std::errc::not_supported,
+              "Metal: Compute shader invalid with render pipeline!");
+        }
+        if (Error)
+          return toError(Error);
+        IS.Pool->addObject(Fn);
+      }
+
+      // TODO: Add support for more shader stages and different pipeline shapes.
+      if (Desc->vertexFunction() == nullptr ||
+          Desc->fragmentFunction() == nullptr)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "Graphics pipeline requires both a vertex shader and a fragment "
+            "shader.");
+
+      if (P.Bindings.RTargetBufferPtr) {
+        // Configure the render target color attachment.
+        const MTL::PixelFormat PF =
+            getMTLFormat(P.Bindings.RTargetBufferPtr->Format,
+                         P.Bindings.RTargetBufferPtr->Channels);
+        MTL::RenderPipelineColorAttachmentDescriptor *RPCA =
+            MTL::RenderPipelineColorAttachmentDescriptor::alloc()->init();
+        RPCA->setPixelFormat(PF);
+        Desc->colorAttachments()->setObject(RPCA, 0);
+      }
+
+      IS.RenderPipeline = Device->newRenderPipelineState(Desc, &Error);
+      if (Error)
+        return toError(Error);
+    }
 
     return llvm::Error::success();
   }
@@ -165,28 +311,39 @@ class MTLDevice : public offloadtest::Device {
   }
 
   llvm::Error createBuffers(Pipeline &P, InvocationState &IS) {
-    const size_t TableSize =
-        sizeof(IRDescriptorTableEntry) * P.getDescriptorCount();
-    IS.ArgBuffer =
-        Device->newBuffer(TableSize, MTL::ResourceStorageModeManaged);
+    const size_t ResourceCount = P.getDescriptorCount();
+    const size_t TableSize = sizeof(IRDescriptorTableEntry) * ResourceCount;
 
-    uint32_t HeapIndex = 0;
-    for (auto &D : P.Sets) {
-      for (auto &R : D.Resources) {
-        if (auto Err = createDescriptor(R, IS, HeapIndex++))
-          return Err;
+    if (TableSize > 0) {
+      IS.ArgBuffer =
+          Device->newBuffer(TableSize, MTL::ResourceStorageModeManaged);
+      uint32_t HeapIndex = 0;
+      for (auto &D : P.Sets) {
+        for (auto &R : D.Resources) {
+          if (auto Err = createDescriptor(R, IS, HeapIndex++))
+            return Err;
+        }
       }
+      IS.ArgBuffer->didModifyRange(NS::Range::Make(0, IS.ArgBuffer->length()));
     }
-    IS.ArgBuffer->didModifyRange(NS::Range::Make(0, IS.ArgBuffer->length()));
+    if (P.isGraphics()) {
+      // Create and mark the vertex buffer as modified.
+      IS.VertexBuffer = Device->newBuffer(
+          P.Bindings.VertexBufferPtr->Data.back().get(),
+          P.Bindings.VertexBufferPtr->size(), MTL::ResourceStorageModeManaged);
+      IS.VertexBuffer->didModifyRange(
+          NS::Range::Make(0, IS.VertexBuffer->length()));
+    }
     return llvm::Error::success();
   }
 
-  llvm::Error executeCommands(Pipeline &P, InvocationState &IS) {
-    MTL::CommandBuffer *CmdBuffer = IS.Queue->commandBuffer();
+  llvm::Error createComputeCommands(Pipeline &P, InvocationState &IS) {
+    IS.CmdBuffer = IS.Queue->commandBuffer();
 
-    MTL::ComputeCommandEncoder *CmdEncoder = CmdBuffer->computeCommandEncoder();
+    MTL::ComputeCommandEncoder *CmdEncoder =
+        IS.CmdBuffer->computeCommandEncoder();
 
-    CmdEncoder->setComputePipelineState(IS.PipelineState);
+    CmdEncoder->setComputePipelineState(IS.ComputePipeline);
     CmdEncoder->setBuffer(IS.ArgBuffer, 0, 2);
     for (uint64_t I = 0; I < IS.Textures.size(); ++I)
       CmdEncoder->useResource(IS.Textures[I],
@@ -195,20 +352,80 @@ class MTLDevice : public offloadtest::Device {
       CmdEncoder->useResource(IS.Buffers[I],
                               MTL::ResourceUsageRead | MTL::ResourceUsageWrite);
 
-    const NS::UInteger TGS = IS.PipelineState->maxTotalThreadsPerThreadgroup();
+    const NS::UInteger TGS =
+        IS.ComputePipeline->maxTotalThreadsPerThreadgroup();
     const llvm::ArrayRef<int> DispatchSize =
         llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
     const MTL::Size GridSize =
         MTL::Size(TGS * DispatchSize[0], DispatchSize[1], DispatchSize[2]);
     const MTL::Size GroupSize(TGS, 1, 1);
-
     CmdEncoder->dispatchThreads(GridSize, GroupSize);
     CmdEncoder->memoryBarrier(MTL::BarrierScopeBuffers);
 
     CmdEncoder->endEncoding();
+    return llvm::Error::success();
+  }
 
-    CmdBuffer->commit();
-    CmdBuffer->waitUntilCompleted();
+  llvm::Error createGraphicsCommands(Pipeline &P, InvocationState &IS) {
+    IS.CmdBuffer = IS.Queue->commandBuffer();
+
+    MTL::RenderPassDescriptor *Desc =
+        MTL::RenderPassDescriptor::alloc()->init();
+
+    // Setup the render target texture.
+    Buffer *RTarget = P.Bindings.RTargetBufferPtr;
+
+    const MTL::PixelFormat Format =
+        getMTLFormat(RTarget->Format, RTarget->Channels);
+
+    const uint64_t Width = RTarget->OutputProps.Width;
+    const uint64_t Height = RTarget->OutputProps.Height;
+    MTL::TextureDescriptor *TDesc = MTL::TextureDescriptor::texture2DDescriptor(
+        Format, Width, Height, false);
+    // Create a shared texture used for both rendering and CPU readback.
+    MTL::TextureDescriptor *SharedDesc = TDesc->copy();
+    SharedDesc->setUsage(MTL::TextureUsageRenderTarget |
+                         MTL::TextureUsageShaderRead |
+                         MTL::TextureUsageShaderWrite);
+    SharedDesc->setStorageMode(MTL::StorageModeShared);
+    IS.FrameBufferTexture = Device->newTexture(SharedDesc);
+
+    auto *CADesc = MTL::RenderPassColorAttachmentDescriptor::alloc()->init();
+    CADesc->setTexture(IS.FrameBufferTexture);
+    CADesc->setLoadAction(MTL::LoadActionClear);
+    CADesc->setClearColor(MTL::ClearColor());
+    CADesc->setStoreAction(MTL::StoreActionStore);
+    Desc->colorAttachments()->setObject(CADesc, 0);
+
+    MTL::RenderCommandEncoder *CmdEncoder =
+        IS.CmdBuffer->renderCommandEncoder(Desc);
+
+    CmdEncoder->setRenderPipelineState(IS.RenderPipeline);
+    // Explicitly set viewport to texture dimensions.
+    CmdEncoder->setViewport(
+        MTL::Viewport{0.0, 0.0, (double)Width, (double)Height, 0.0, 1.0});
+    CmdEncoder->setCullMode(MTL::CullModeNone);
+
+    // Bind vertex buffer at slot 0 to match the vertex descriptor which
+    // references buffer index 0.
+    CmdEncoder->setVertexBuffer(IS.VertexBuffer, 0, 0);
+
+    CmdEncoder->drawPrimitives(MTL::PrimitiveTypeTriangle, NS::UInteger(0),
+                               P.Bindings.getVertexCount());
+
+    CmdEncoder->endEncoding();
+
+    return llvm::Error::success();
+  }
+
+  llvm::Error executeCommands(InvocationState &IS) {
+    IS.CmdBuffer->commit();
+    IS.CmdBuffer->waitUntilCompleted();
+
+    // Check and surface any errors that occurred during execution.
+    NS::Error *CBErr = IS.CmdBuffer->error();
+    if (CBErr)
+      return toError(CBErr);
 
     return llvm::Error::success();
   }
@@ -241,6 +458,25 @@ class MTLDevice : public offloadtest::Device {
             MTL::Region(0, 0, Width, Height), 0);
       }
     }
+    if (P.isGraphics()) {
+      Buffer *RTarget = P.Bindings.RTargetBufferPtr;
+      const uint64_t Width = RTarget->OutputProps.Width;
+      const uint64_t Height = RTarget->OutputProps.Height;
+      const size_t ElemSize = RTarget->getElementSize();
+      const size_t RowBytes = Width * ElemSize;
+
+      // Read the framebuffer one row at a time into the output buffer.
+      // Read rows from the texture bottom-to-top into the buffer top-to-bottom
+      // so the final image is upright.
+      unsigned char *Buf =
+          reinterpret_cast<unsigned char *>(RTarget->Data[0].get());
+      for (uint64_t R = 0; R < Height; ++R) {
+        const uint32_t SrcRow = (uint32_t)((Height - 1) - R);
+        unsigned char *Dst = Buf + R * RowBytes;
+        IS.FrameBufferTexture->getBytes(
+            Dst, RowBytes, MTL::Region(0, SrcRow, (uint32_t)Width, 1), 0);
+      }
+    }
     return llvm::Error::success();
   }
 
@@ -260,13 +496,24 @@ public:
   llvm::Error executeProgram(Pipeline &P) override {
     InvocationState IS;
     IS.Queue = Device->newCommandQueue();
-    if (auto Err = loadShaders(IS, P.Shaders[0]))
-      return Err;
 
     if (auto Err = createBuffers(P, IS))
       return Err;
 
-    if (auto Err = executeCommands(P, IS))
+    if (auto Err = loadShaders(IS, P))
+      return Err;
+
+    if (P.isCompute()) {
+      if (auto Err = createComputeCommands(P, IS))
+        return Err;
+      llvm::outs() << "Created compute commands.\n";
+    } else {
+      if (auto Err = createGraphicsCommands(P, IS))
+        return Err;
+      llvm::outs() << "Created graphics commands.\n";
+    }
+
+    if (auto Err = executeCommands(IS))
       return Err;
 
     if (auto Err = copyBack(P, IS))

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -98,6 +98,17 @@ static VkImageViewType getImageViewType(const ResourceKind RK) {
   }
 }
 
+static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
+  switch (Stage) {
+  case Stages::Compute:
+    return VK_SHADER_STAGE_COMPUTE_BIT;
+  case Stages::Vertex:
+    return VK_SHADER_STAGE_VERTEX_BIT;
+  case Stages::Pixel:
+    return VK_SHADER_STAGE_FRAGMENT_BIT;
+  }
+}
+
 static std::string getMessageSeverityString(
     VkDebugUtilsMessageSeverityFlagBitsEXT MessageSeverity) {
   if (MessageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
@@ -164,6 +175,23 @@ static VkDebugUtilsMessengerEXT registerDebugUtilCallback(VkInstance Instance) {
   return DebugMessenger;
 }
 
+static llvm::Expected<uint32_t>
+getMemoryIndex(VkPhysicalDevice Device, uint32_t MemoryTypeBits,
+               VkMemoryPropertyFlags MemoryFlags) {
+  VkPhysicalDeviceMemoryProperties MemProperties;
+  vkGetPhysicalDeviceMemoryProperties(Device, &MemProperties);
+  for (uint32_t I = 0; I < MemProperties.memoryTypeCount; ++I) {
+    const uint32_t Bit = (1u << I);
+    if ((MemoryTypeBits & Bit) == 0)
+      continue;
+    if ((MemProperties.memoryTypes[I].propertyFlags & MemoryFlags) ==
+        MemoryFlags)
+      return I;
+  }
+  return llvm::createStringError(std::errc::not_enough_memory,
+                                 "Could not identify appropriate memory.");
+}
+
 namespace {
 
 class VKDevice : public offloadtest::Device {
@@ -224,7 +252,14 @@ private:
     VkDescriptorType DescriptorType;
     uint64_t Size;
     Buffer *BufferPtr;
+    VkImageLayout ImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     llvm::SmallVector<ResourceRef> ResourceRefs;
+  };
+
+  struct CompiledShader {
+    Stages Stage;
+    std::string Entry;
+    VkShaderModule Shader;
   };
 
   struct InvocationState {
@@ -233,16 +268,34 @@ private:
     VkCommandPool CmdPool;
     VkCommandBuffer CmdBuffer;
     VkPipelineLayout PipelineLayout;
-    VkDescriptorPool Pool;
+    VkDescriptorPool Pool = nullptr;
     VkPipelineCache PipelineCache;
-    VkShaderModule Shader;
     VkPipeline Pipeline;
 
+    // FrameBuffer associated data for offscreen rendering.
+    VkFramebuffer FrameBuffer;
+    ResourceBundle FrameBufferResource = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 0,
+                                          nullptr};
+    ImageRef DepthStencil = {0, 0, 0};
+    std::optional<ResourceRef> VertexBuffer = std::nullopt;
+
+    VkRenderPass RenderPass;
+    uint32_t ShaderStageMask = 0;
+
+    llvm::SmallVector<CompiledShader> Shaders;
     llvm::SmallVector<VkDescriptorSetLayout> DescriptorSetLayouts;
     llvm::SmallVector<ResourceBundle> Resources;
     llvm::SmallVector<VkDescriptorSet> DescriptorSets;
     llvm::SmallVector<VkBufferView> BufferViews;
     llvm::SmallVector<VkImageView> ImageViews;
+
+    uint32_t getFullShaderStageMask() {
+      if (0 != ShaderStageMask)
+        return ShaderStageMask;
+      for (const auto &S : Shaders)
+        ShaderStageMask |= getShaderStageFlag(S.Stage);
+      return ShaderStageMask;
+    }
   };
 
 public:
@@ -398,24 +451,36 @@ private:
 public:
   llvm::Error createDevice(InvocationState &IS) {
 
-    // Find a queue that supports compute
+    // Find a queue family that supports both graphics and compute.
     uint32_t QueueCount = 0;
-    vkGetPhysicalDeviceQueueFamilyProperties(Device, &QueueCount, 0);
-    const std::unique_ptr<VkQueueFamilyProperties[]> QueueFamilyProps =
-        std::unique_ptr<VkQueueFamilyProperties[]>(
-            new VkQueueFamilyProperties[QueueCount]);
+    vkGetPhysicalDeviceQueueFamilyProperties(Device, &QueueCount, nullptr);
+    if (QueueCount == 0)
+      return llvm::createStringError(std::errc::no_such_device,
+                                     "No queue families reported.");
+
+    const std::unique_ptr<VkQueueFamilyProperties[]> QueueFamilyProps(
+        new VkQueueFamilyProperties[QueueCount]);
     vkGetPhysicalDeviceQueueFamilyProperties(Device, &QueueCount,
                                              QueueFamilyProps.get());
-    uint32_t QueueIdx = 0;
-    for (; QueueIdx < QueueCount; ++QueueIdx)
-      if (QueueFamilyProps.get()[QueueIdx].queueFlags & VK_QUEUE_COMPUTE_BIT)
+
+    int SelectedIdx = -1;
+    for (uint32_t I = 0; I < QueueCount; ++I) {
+      const VkQueueFlags Flags = QueueFamilyProps[I].queueFlags;
+      // Prefer family supporting both GRAPHICS and COMPUTE
+      if ((Flags & VK_QUEUE_GRAPHICS_BIT) && (Flags & VK_QUEUE_COMPUTE_BIT)) {
+        SelectedIdx = static_cast<int>(I);
         break;
-    if (QueueIdx >= QueueCount)
+      }
+    }
+
+    if (SelectedIdx == -1)
       return llvm::createStringError(std::errc::no_such_device,
-                                     "No compute queue found.");
+                                     "No suitable queue family found.");
+
+    const uint32_t QueueIdx = static_cast<uint32_t>(SelectedIdx);
 
     VkDeviceQueueCreateInfo QueueInfo = {};
-    const float QueuePriority = 0.0f;
+    const float QueuePriority = 1.0f;
     QueueInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
     QueueInfo.queueFamilyIndex = QueueIdx;
     QueueInfo.queueCount = 1;
@@ -508,22 +573,12 @@ public:
     AllocInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
     AllocInfo.allocationSize = MemReqs.size;
 
-    VkPhysicalDeviceMemoryProperties MemProperties;
-    vkGetPhysicalDeviceMemoryProperties(Device, &MemProperties);
-    uint32_t MemIdx = 0;
-    for (; MemIdx < MemProperties.memoryTypeCount;
-         ++MemIdx, MemReqs.memoryTypeBits >>= 1) {
-      if ((MemReqs.memoryTypeBits & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) &&
-          ((MemProperties.memoryTypes[MemIdx].propertyFlags & MemoryFlags) ==
-           MemoryFlags)) {
-        break;
-      }
-    }
-    if (MemIdx >= MemProperties.memoryTypeCount)
-      return llvm::createStringError(std::errc::not_enough_memory,
-                                     "Could not identify appropriate memory.");
+    llvm::Expected<uint32_t> MemIdx =
+        getMemoryIndex(Device, MemReqs.memoryTypeBits, MemoryFlags);
+    if (!MemIdx)
+      return MemIdx.takeError();
 
-    AllocInfo.memoryTypeIndex = MemIdx;
+    AllocInfo.memoryTypeIndex = *MemIdx;
 
     if (vkAllocateMemory(IS.Device, &AllocInfo, nullptr, &Memory))
       return llvm::createStringError(std::errc::not_enough_memory,
@@ -553,7 +608,8 @@ public:
   }
 
   llvm::Expected<ResourceRef> createImage(InvocationState &IS, Resource &R,
-                                          BufferRef &Host) {
+                                          BufferRef &Host,
+                                          int UsageOverride = 0) {
     const offloadtest::Buffer &B = *R.BufferPtr;
     VkImageCreateInfo ImageCreateInfo = {};
     ImageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -568,11 +624,15 @@ public:
     ImageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     ImageCreateInfo.extent = {static_cast<uint32_t>(B.OutputProps.Width),
                               static_cast<uint32_t>(B.OutputProps.Height), 1};
-    ImageCreateInfo.usage =
-        VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-        (R.isReadWrite()
-             ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
-             : VK_IMAGE_USAGE_SAMPLED_BIT);
+    if (UsageOverride == 0) {
+      ImageCreateInfo.usage =
+          VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+          (R.isReadWrite()
+               ? (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+               : VK_IMAGE_USAGE_SAMPLED_BIT);
+    } else {
+      ImageCreateInfo.usage = UsageOverride;
+    }
 
     VkImage Image;
     if (vkCreateImage(IS.Device, &ImageCreateInfo, nullptr, &Image))
@@ -632,6 +692,50 @@ public:
     return llvm::Error::success();
   }
 
+  llvm::Error createDepthStencil(Pipeline &P, InvocationState &IS) {
+    // Create an optimal image used as the depth stencil attachment
+    VkImageCreateInfo ImageCi = {};
+    ImageCi.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    ImageCi.imageType = VK_IMAGE_TYPE_2D;
+    ImageCi.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
+    // Use example's height and width
+    ImageCi.extent = {
+        static_cast<uint32_t>(P.Bindings.RTargetBufferPtr->OutputProps.Width),
+        static_cast<uint32_t>(P.Bindings.RTargetBufferPtr->OutputProps.Height),
+        1};
+    ImageCi.mipLevels = 1;
+    ImageCi.arrayLayers = 1;
+    ImageCi.samples = VK_SAMPLE_COUNT_1_BIT;
+    ImageCi.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ImageCi.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    ImageCi.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    if (vkCreateImage(IS.Device, &ImageCi, nullptr, &IS.DepthStencil.Image))
+      return llvm::createStringError(std::errc::device_or_resource_busy,
+                                     "Depth stencil creation failed.");
+
+    // Allocate memory for the image (device local) and bind it to our image
+    VkMemoryAllocateInfo MemAlloc{};
+    MemAlloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    VkMemoryRequirements MemReqs;
+    vkGetImageMemoryRequirements(IS.Device, IS.DepthStencil.Image, &MemReqs);
+    MemAlloc.allocationSize = MemReqs.size;
+    llvm::Expected<uint32_t> MemIdx = getMemoryIndex(
+        Device, MemReqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (!MemIdx)
+      return MemIdx.takeError();
+
+    MemAlloc.memoryTypeIndex = *MemIdx;
+    if (vkAllocateMemory(IS.Device, &MemAlloc, nullptr,
+                         &IS.DepthStencil.Memory))
+      return llvm::createStringError(std::errc::not_enough_memory,
+                                     "Depth stencil memory allocation failed.");
+    if (vkBindImageMemory(IS.Device, IS.DepthStencil.Image,
+                          IS.DepthStencil.Memory, 0))
+      return llvm::createStringError(std::errc::not_enough_memory,
+                                     "Depth stencil memory binding failed.");
+    return llvm::Error::success();
+  }
+
   llvm::Error createBuffers(Pipeline &P, InvocationState &IS) {
     for (auto &D : P.Sets) {
       for (auto &R : D.Resources) {
@@ -639,6 +743,62 @@ public:
           return Err;
       }
     }
+
+    if (P.isGraphics()) {
+      if (!P.Bindings.RTargetBufferPtr)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "No RenderTarget buffer specified for graphics pipeline.");
+      Resource FrameBuffer = {
+          ResourceKind::Texture2D,     "RenderTarget", {}, {},
+          P.Bindings.RTargetBufferPtr, false};
+      IS.FrameBufferResource.Size = P.Bindings.RTargetBufferPtr->size();
+      IS.FrameBufferResource.BufferPtr = P.Bindings.RTargetBufferPtr;
+      IS.FrameBufferResource.ImageLayout =
+          VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+      auto ExHostBuf = createBuffer(
+          IS,
+          VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, FrameBuffer.size(),
+          FrameBuffer.BufferPtr->Data[0].get());
+      if (!ExHostBuf)
+        return ExHostBuf.takeError();
+      auto ExImageRef = createImage(IS, FrameBuffer, *ExHostBuf,
+                                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                        VK_IMAGE_USAGE_SAMPLED_BIT |
+                                        VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+      if (!ExImageRef)
+        return ExImageRef.takeError();
+      IS.FrameBufferResource.ResourceRefs.push_back(*ExImageRef);
+      if (auto Err = createDepthStencil(P, IS))
+        return Err;
+
+      if (P.Bindings.VertexBufferPtr == nullptr)
+        return llvm::createStringError(
+            std::errc::invalid_argument,
+            "No Vertex buffer specified for graphics pipeline.");
+      const Resource VertexBuffer = {
+          ResourceKind::StructuredBuffer, "VertexBuffer", {}, {},
+          P.Bindings.VertexBufferPtr,     false};
+      auto ExVHostBuf =
+          createBuffer(IS, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VertexBuffer.size(),
+                       VertexBuffer.BufferPtr->Data[0].get());
+      if (!ExVHostBuf)
+        return ExVHostBuf.takeError();
+      auto ExDeviceBuf = createBuffer(
+          IS,
+          VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VertexBuffer.size());
+      if (!ExDeviceBuf)
+        return ExDeviceBuf.takeError();
+      VkBufferCopy Copy = {};
+      Copy.size = VertexBuffer.size();
+      vkCmdCopyBuffer(IS.CmdBuffer, ExVHostBuf->Buffer, ExDeviceBuf->Buffer, 1,
+                      &Copy);
+      IS.VertexBuffer = ResourceRef(*ExVHostBuf, *ExDeviceBuf);
+    }
+
     return llvm::Error::success();
   }
 
@@ -704,14 +864,16 @@ public:
       }
     }
 
-    VkDescriptorPoolCreateInfo PoolCreateInfo = {};
-    PoolCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    PoolCreateInfo.poolSizeCount = PoolSizes.size();
-    PoolCreateInfo.pPoolSizes = PoolSizes.data();
-    PoolCreateInfo.maxSets = P.Sets.size();
-    if (vkCreateDescriptorPool(IS.Device, &PoolCreateInfo, nullptr, &IS.Pool))
-      return llvm::createStringError(std::errc::device_or_resource_busy,
-                                     "Failed to create descriptor pool.");
+    if (P.Sets.size() > 0) {
+      VkDescriptorPoolCreateInfo PoolCreateInfo = {};
+      PoolCreateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+      PoolCreateInfo.poolSizeCount = PoolSizes.size();
+      PoolCreateInfo.pPoolSizes = PoolSizes.data();
+      PoolCreateInfo.maxSets = P.Sets.size();
+      if (vkCreateDescriptorPool(IS.Device, &PoolCreateInfo, nullptr, &IS.Pool))
+        return llvm::createStringError(std::errc::device_or_resource_busy,
+                                       "Failed to create descriptor pool.");
+    }
     return llvm::Error::success();
   }
 
@@ -727,7 +889,7 @@ public:
         Binding.binding = R.VKBinding->Binding;
         Binding.descriptorType = getDescriptorType(R.Kind);
         Binding.descriptorCount = R.BufferPtr->ArraySize;
-        Binding.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        Binding.stageFlags = IS.getFullShaderStageMask();
         Bindings.push_back(Binding);
       }
       VkDescriptorSetLayoutCreateInfo LayoutCreateInfo = {};
@@ -753,6 +915,9 @@ public:
                                &IS.PipelineLayout))
       return llvm::createStringError(std::errc::device_or_resource_busy,
                                      "Failed to create pipeline layout.");
+
+    if (P.Sets.size() == 0)
+      return llvm::Error::success();
 
     VkDescriptorSetAllocateInfo DSAllocInfo = {};
     DSAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -886,14 +1051,160 @@ public:
     return llvm::Error::success();
   }
 
-  llvm::Error createShaderModule(llvm::StringRef Program, InvocationState &IS) {
-    VkShaderModuleCreateInfo ShaderCreateInfo = {};
-    ShaderCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    ShaderCreateInfo.codeSize = Program.size();
-    ShaderCreateInfo.pCode = reinterpret_cast<const uint32_t *>(Program.data());
-    if (vkCreateShaderModule(IS.Device, &ShaderCreateInfo, nullptr, &IS.Shader))
-      return llvm::createStringError(std::errc::not_supported,
-                                     "Failed to create shader module.");
+  llvm::Error createShaderModules(Pipeline &P, InvocationState &IS) {
+    for (const auto &Shader : P.Shaders) {
+      const llvm::StringRef Program = Shader.Shader->getBuffer();
+      VkShaderModuleCreateInfo ShaderCreateInfo = {};
+      ShaderCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+      ShaderCreateInfo.codeSize = Program.size();
+      ShaderCreateInfo.pCode =
+          reinterpret_cast<const uint32_t *>(Program.data());
+      CompiledShader CS = {Shader.Stage, Shader.Entry, 0};
+      if (vkCreateShaderModule(IS.Device, &ShaderCreateInfo, nullptr,
+                               &CS.Shader))
+        return llvm::createStringError(std::errc::not_supported,
+                                       "Failed to create shader module.");
+      IS.Shaders.emplace_back(CS);
+    }
+    return llvm::Error::success();
+  }
+
+  llvm::Error createRenderPass(Pipeline &P, InvocationState &IS) {
+    std::array<VkAttachmentDescription, 2> Attachments = {};
+
+    Attachments[0].format = getVKFormat(P.Bindings.RTargetBufferPtr->Format,
+                                        P.Bindings.RTargetBufferPtr->Channels);
+    Attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
+    Attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    Attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    Attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    Attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    Attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    Attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    Attachments[1].format = VK_FORMAT_D32_SFLOAT_S8_UINT;
+    Attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
+    Attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    Attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    Attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    Attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    Attachments[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    Attachments[1].finalLayout =
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference ColorReference = {};
+    ColorReference.attachment = 0;
+    ColorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference DepthReference = {};
+    DepthReference.attachment = 1;
+    DepthReference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription SubpassDescription = {};
+    SubpassDescription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    SubpassDescription.colorAttachmentCount = 1;
+    SubpassDescription.pColorAttachments = &ColorReference;
+    SubpassDescription.pDepthStencilAttachment = &DepthReference;
+    SubpassDescription.inputAttachmentCount = 0;
+    SubpassDescription.pInputAttachments = nullptr;
+    SubpassDescription.preserveAttachmentCount = 0;
+    SubpassDescription.pPreserveAttachments = nullptr;
+    SubpassDescription.pResolveAttachments = nullptr;
+
+    std::array<VkSubpassDependency, 2> Dependencies = {};
+
+    Dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+    Dependencies[0].dstSubpass = 0;
+    Dependencies[0].srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    Dependencies[0].dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                                   VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    Dependencies[0].srcAccessMask =
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    Dependencies[0].dstAccessMask =
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+    Dependencies[0].dependencyFlags = 0;
+
+    Dependencies[1].srcSubpass = VK_SUBPASS_EXTERNAL;
+    Dependencies[1].dstSubpass = 0;
+    Dependencies[1].srcStageMask =
+        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    Dependencies[1].dstStageMask =
+        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    Dependencies[1].srcAccessMask = 0;
+    Dependencies[1].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                    VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+    Dependencies[1].dependencyFlags = 0;
+
+    VkRenderPassCreateInfo RPCI = {};
+    RPCI.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    RPCI.attachmentCount = static_cast<uint32_t>(Attachments.size());
+    RPCI.pAttachments = Attachments.data();
+    RPCI.subpassCount = 1;
+    RPCI.pSubpasses = &SubpassDescription;
+    RPCI.dependencyCount = static_cast<uint32_t>(Dependencies.size());
+    RPCI.pDependencies = Dependencies.data();
+
+    if (vkCreateRenderPass(IS.Device, &RPCI, nullptr, &IS.RenderPass))
+      return llvm::createStringError(std::errc::device_or_resource_busy,
+                                     "Failed to create render pass.");
+    return llvm::Error::success();
+  }
+
+  llvm::Error createFrameBuffer(Pipeline &P, InvocationState &IS) {
+    std::array<VkImageView, 2> Views = {};
+    VkImageViewCreateInfo ViewCreateInfo = {};
+    ViewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    ViewCreateInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    ViewCreateInfo.format = getVKFormat(P.Bindings.RTargetBufferPtr->Format,
+                                        P.Bindings.RTargetBufferPtr->Channels);
+    ViewCreateInfo.components = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
+                                 VK_COMPONENT_SWIZZLE_B,
+                                 VK_COMPONENT_SWIZZLE_A};
+    ViewCreateInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    ViewCreateInfo.subresourceRange.baseMipLevel = 0;
+    ViewCreateInfo.subresourceRange.baseArrayLayer = 0;
+    ViewCreateInfo.subresourceRange.layerCount = 1;
+    ViewCreateInfo.subresourceRange.levelCount = 1;
+    ViewCreateInfo.image = IS.FrameBufferResource.ResourceRefs[0].Image.Image;
+    if (vkCreateImageView(IS.Device, &ViewCreateInfo, nullptr, &Views[0]))
+      return llvm::createStringError(
+          std::errc::device_or_resource_busy,
+          "Failed to create frame buffer image view.");
+    IS.ImageViews.push_back(Views[0]);
+
+    VkImageViewCreateInfo DepthStencilViewCi = {};
+    DepthStencilViewCi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    DepthStencilViewCi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    DepthStencilViewCi.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
+    DepthStencilViewCi.subresourceRange = {};
+    DepthStencilViewCi.subresourceRange.aspectMask =
+        VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+    DepthStencilViewCi.subresourceRange.baseMipLevel = 0;
+    DepthStencilViewCi.subresourceRange.levelCount = 1;
+    DepthStencilViewCi.subresourceRange.baseArrayLayer = 0;
+    DepthStencilViewCi.subresourceRange.layerCount = 1;
+    DepthStencilViewCi.image = IS.DepthStencil.Image;
+    if (vkCreateImageView(IS.Device, &DepthStencilViewCi, nullptr, &Views[1]))
+      return llvm::createStringError(
+          std::errc::device_or_resource_busy,
+          "Failed to create depth stencil image view.");
+    IS.ImageViews.push_back(Views[1]);
+
+    VkFramebufferCreateInfo FbufCreateInfo = {};
+    FbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    FbufCreateInfo.renderPass = IS.RenderPass;
+    FbufCreateInfo.attachmentCount = Views.size();
+    FbufCreateInfo.pAttachments = Views.data();
+    FbufCreateInfo.width = P.Bindings.RTargetBufferPtr->OutputProps.Width;
+    FbufCreateInfo.height = P.Bindings.RTargetBufferPtr->OutputProps.Height;
+    FbufCreateInfo.layers = 1;
+
+    if (vkCreateFramebuffer(IS.Device, &FbufCreateInfo, nullptr,
+                            &IS.FrameBuffer))
+      return llvm::createStringError(std::errc::device_or_resource_busy,
+                                     "Failed to create frame buffer.");
     return llvm::Error::success();
   }
 
@@ -905,20 +1216,137 @@ public:
       return llvm::createStringError(std::errc::device_or_resource_busy,
                                      "Failed to create pipeline cache.");
 
-    VkPipelineShaderStageCreateInfo StageInfo = {};
-    StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    StageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-    StageInfo.module = IS.Shader;
-    StageInfo.pName = P.Shaders[0].Entry.c_str();
+    if (P.isCompute()) {
+      const CompiledShader &S = IS.Shaders[0];
+      assert(IS.Shaders.size() == 1 &&
+             "Currently only support one compute shader");
+      VkPipelineShaderStageCreateInfo StageInfo = {};
+      StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+      StageInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+      StageInfo.module = S.Shader;
+      StageInfo.pName = S.Entry.c_str();
 
-    VkComputePipelineCreateInfo PipelineCreateInfo = {};
-    PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    PipelineCreateInfo.stage = StageInfo;
+      VkComputePipelineCreateInfo PipelineCreateInfo = {};
+      PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+      PipelineCreateInfo.stage = StageInfo;
+      PipelineCreateInfo.layout = IS.PipelineLayout;
+      if (vkCreateComputePipelines(IS.Device, IS.PipelineCache, 1,
+                                   &PipelineCreateInfo, nullptr, &IS.Pipeline))
+        return llvm::createStringError(std::errc::device_or_resource_busy,
+                                       "Failed to create pipeline.");
+      return llvm::Error::success();
+    }
+
+    llvm::SmallVector<VkPipelineShaderStageCreateInfo> Stages;
+    for (const auto &S : IS.Shaders) {
+      VkPipelineShaderStageCreateInfo StageInfo = {};
+      StageInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+      StageInfo.stage = getShaderStageFlag(S.Stage);
+      StageInfo.module = S.Shader;
+      StageInfo.pName = S.Entry.c_str();
+      Stages.emplace_back(StageInfo);
+    }
+
+    VkPipelineInputAssemblyStateCreateInfo InputAssemblyCI = {};
+    InputAssemblyCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    InputAssemblyCI.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineRasterizationStateCreateInfo RastStateCI = {};
+    RastStateCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    RastStateCI.polygonMode = VK_POLYGON_MODE_FILL;
+    RastStateCI.cullMode = VK_CULL_MODE_NONE;
+    RastStateCI.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    RastStateCI.depthClampEnable = VK_FALSE;
+    RastStateCI.rasterizerDiscardEnable = VK_FALSE;
+    RastStateCI.depthBiasEnable = VK_FALSE;
+    RastStateCI.lineWidth = 1.0f;
+
+    VkPipelineColorBlendAttachmentState BlendState = {};
+    BlendState.colorWriteMask = 0xf;
+    BlendState.blendEnable = VK_FALSE;
+    VkPipelineColorBlendStateCreateInfo BlendStateCI = {};
+    BlendStateCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    BlendStateCI.attachmentCount = 1;
+    BlendStateCI.pAttachments = &BlendState;
+
+    VkPipelineViewportStateCreateInfo ViewStateCI = {};
+    ViewStateCI.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    ViewStateCI.viewportCount = 1;
+    ViewStateCI.scissorCount = 1;
+
+    const VkDynamicState DynamicStates[] = {VK_DYNAMIC_STATE_VIEWPORT,
+                                            VK_DYNAMIC_STATE_SCISSOR};
+    VkPipelineDynamicStateCreateInfo DynamicStateCI = {};
+    DynamicStateCI.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    DynamicStateCI.pDynamicStates = &DynamicStates[0];
+    DynamicStateCI.dynamicStateCount = 2;
+
+    VkPipelineDepthStencilStateCreateInfo DepthStencilStateCI = {};
+    DepthStencilStateCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    DepthStencilStateCI.depthTestEnable = VK_TRUE;
+    DepthStencilStateCI.depthWriteEnable = VK_TRUE;
+    DepthStencilStateCI.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+    DepthStencilStateCI.depthBoundsTestEnable = VK_FALSE;
+    DepthStencilStateCI.back.failOp = VK_STENCIL_OP_KEEP;
+    DepthStencilStateCI.back.passOp = VK_STENCIL_OP_KEEP;
+    DepthStencilStateCI.back.compareOp = VK_COMPARE_OP_ALWAYS;
+    DepthStencilStateCI.stencilTestEnable = VK_FALSE;
+    DepthStencilStateCI.front = DepthStencilStateCI.back;
+
+    VkPipelineMultisampleStateCreateInfo MultisampleStateCI = {};
+    MultisampleStateCI.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    MultisampleStateCI.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    const uint32_t Stride = P.Bindings.getVertexStride();
+
+    VkVertexInputBindingDescription VertexInputBinding{};
+    VertexInputBinding.binding = 0;
+    VertexInputBinding.stride = Stride;
+    VertexInputBinding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+    llvm::SmallVector<VkVertexInputAttributeDescription> Attributes;
+    for (size_t I = 0; I < P.Bindings.VertexAttributes.size(); ++I) {
+      const VertexAttribute &VA = P.Bindings.VertexAttributes[I];
+      VkVertexInputAttributeDescription VkVA = {};
+      VkVA.location = I;
+      VkVA.binding = 0;
+      VkVA.format = getVKFormat(VA.Format, VA.Channels);
+      VkVA.offset = VA.Offset;
+      Attributes.push_back(VkVA);
+    }
+
+    VkPipelineVertexInputStateCreateInfo VertexInputStateCi = {};
+    VertexInputStateCi.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    VertexInputStateCi.vertexBindingDescriptionCount = 1;
+    VertexInputStateCi.pVertexBindingDescriptions = &VertexInputBinding;
+    VertexInputStateCi.vertexAttributeDescriptionCount = Attributes.size();
+    VertexInputStateCi.pVertexAttributeDescriptions = Attributes.data();
+
+    VkGraphicsPipelineCreateInfo PipelineCreateInfo = {};
+    PipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    PipelineCreateInfo.stageCount = Stages.size();
+    PipelineCreateInfo.pStages = Stages.data();
+    PipelineCreateInfo.pVertexInputState = &VertexInputStateCi;
+    PipelineCreateInfo.pInputAssemblyState = &InputAssemblyCI;
+    PipelineCreateInfo.pRasterizationState = &RastStateCI;
+    PipelineCreateInfo.pColorBlendState = &BlendStateCI;
+    PipelineCreateInfo.pMultisampleState = &MultisampleStateCI;
+    PipelineCreateInfo.pViewportState = &ViewStateCI;
+    PipelineCreateInfo.pDepthStencilState = &DepthStencilStateCI;
+    PipelineCreateInfo.pDynamicState = &DynamicStateCI;
+    PipelineCreateInfo.renderPass = IS.RenderPass;
     PipelineCreateInfo.layout = IS.PipelineLayout;
-    if (vkCreateComputePipelines(IS.Device, IS.PipelineCache, 1,
-                                 &PipelineCreateInfo, nullptr, &IS.Pipeline))
+
+    if (vkCreateGraphicsPipelines(IS.Device, IS.PipelineCache, 1,
+                                  &PipelineCreateInfo, nullptr, &IS.Pipeline))
       return llvm::createStringError(std::errc::device_or_resource_busy,
-                                     "Failed to create pipeline.");
+                                     "Failed to create graphics pipeline.");
 
     return llvm::Error::success();
   }
@@ -948,8 +1376,9 @@ public:
       ImageBarrier.subresourceRange = SubRange;
       ImageBarrier.srcAccessMask = 0;
       ImageBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-      ImageBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+      ImageBarrier.oldLayout = R.ImageLayout;
       ImageBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+      R.ImageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
       for (auto &ResRef : R.ResourceRefs) {
         ImageBarrier.image = ResRef.Image.Image;
@@ -1007,8 +1436,9 @@ public:
       ImageBarrier.subresourceRange = SubRange;
       ImageBarrier.srcAccessMask = 0;
       ImageBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-      ImageBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+      ImageBarrier.oldLayout = R.ImageLayout;
       ImageBarrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+      R.ImageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
       for (auto &ResRef : R.ResourceRefs) {
         ImageBarrier.image = ResRef.Image.Image;
@@ -1080,19 +1510,74 @@ public:
     }
   }
 
-  llvm::Error createComputeCommands(Pipeline &P, InvocationState &IS) {
+  llvm::Error createCommands(Pipeline &P, InvocationState &IS) {
     for (auto &R : IS.Resources)
       copyResourceDataToDevice(IS, R);
 
-    vkCmdBindPipeline(IS.CmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                      IS.Pipeline);
-    vkCmdBindDescriptorSets(IS.CmdBuffer, VK_PIPELINE_BIND_POINT_COMPUTE,
-                            IS.PipelineLayout, 0, IS.DescriptorSets.size(),
-                            IS.DescriptorSets.data(), 0, 0);
-    const llvm::ArrayRef<int> DispatchSize =
-        llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
-    vkCmdDispatch(IS.CmdBuffer, DispatchSize[0], DispatchSize[1],
-                  DispatchSize[2]);
+    if (P.isGraphics()) {
+      VkClearValue ClearValues[2] = {};
+      ClearValues[0].color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+      ClearValues[1].depthStencil = {1.0f, 0};
+
+      VkRenderPassBeginInfo RenderPassBeginInfo = {};
+      RenderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+      RenderPassBeginInfo.renderPass = IS.RenderPass;
+      RenderPassBeginInfo.framebuffer = IS.FrameBuffer;
+      RenderPassBeginInfo.renderArea.extent.width =
+          P.Bindings.RTargetBufferPtr->OutputProps.Width;
+      RenderPassBeginInfo.renderArea.extent.height =
+          P.Bindings.RTargetBufferPtr->OutputProps.Height;
+      RenderPassBeginInfo.clearValueCount = 2;
+      RenderPassBeginInfo.pClearValues = ClearValues;
+
+      vkCmdBeginRenderPass(IS.CmdBuffer, &RenderPassBeginInfo,
+                           VK_SUBPASS_CONTENTS_INLINE);
+
+      VkViewport Viewport = {};
+      Viewport.x = 0.0f;
+      Viewport.y = 0.0f;
+      Viewport.width =
+          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Width);
+      Viewport.height =
+          static_cast<float>(P.Bindings.RTargetBufferPtr->OutputProps.Height);
+      Viewport.minDepth = 0.0f;
+      Viewport.maxDepth = 1.0f;
+      vkCmdSetViewport(IS.CmdBuffer, 0, 1, &Viewport);
+
+      VkRect2D Scissor = {};
+      Scissor.offset = {0, 0};
+      Scissor.extent.width = P.Bindings.RTargetBufferPtr->OutputProps.Width;
+      Scissor.extent.height = P.Bindings.RTargetBufferPtr->OutputProps.Height;
+      vkCmdSetScissor(IS.CmdBuffer, 0, 1, &Scissor);
+    }
+
+    const VkPipelineBindPoint BindPoint = P.isGraphics()
+                                              ? VK_PIPELINE_BIND_POINT_GRAPHICS
+                                              : VK_PIPELINE_BIND_POINT_COMPUTE;
+    vkCmdBindPipeline(IS.CmdBuffer, BindPoint, IS.Pipeline);
+    if (IS.DescriptorSets.size() > 0)
+      vkCmdBindDescriptorSets(IS.CmdBuffer, BindPoint, IS.PipelineLayout, 0,
+                              IS.DescriptorSets.size(),
+                              IS.DescriptorSets.data(), 0, 0);
+
+    if (P.isCompute()) {
+      const llvm::ArrayRef<int> DispatchSize =
+          llvm::ArrayRef<int>(P.Shaders[0].DispatchSize);
+      vkCmdDispatch(IS.CmdBuffer, DispatchSize[0], DispatchSize[1],
+                    DispatchSize[2]);
+      llvm::outs() << "Dispatched compute shader: { " << DispatchSize[0] << ", "
+                   << DispatchSize[1] << ", " << DispatchSize[2] << " }\n";
+    } else {
+      VkDeviceSize Offsets[1]{0};
+      assert(IS.VertexBuffer.has_value());
+      vkCmdBindVertexBuffers(IS.CmdBuffer, 0, 1,
+                             &IS.VertexBuffer->Device.Buffer, Offsets);
+      // instanceCount must be >=1 to draw; previously was 0 which draws nothing
+      vkCmdDraw(IS.CmdBuffer, P.Bindings.getVertexCount(), 1, 0, 0);
+      llvm::outs() << "Drew " << P.Bindings.getVertexCount() << " vertices.\n";
+      vkCmdEndRenderPass(IS.CmdBuffer);
+      copyResourceDataToHost(IS, IS.FrameBufferResource);
+    }
 
     for (auto &R : IS.Resources)
       copyResourceDataToHost(IS, R);
@@ -1126,6 +1611,25 @@ public:
         }
       }
     }
+
+    // Copy back the frame buffer data if this was a graphics pipeline.
+    if (P.isGraphics()) {
+      VkMappedMemoryRange Range = {};
+      Range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+      Range.offset = 0;
+      Range.size = VK_WHOLE_SIZE;
+      const ResourceRef &ResRef = IS.FrameBufferResource.ResourceRefs[0];
+
+      void *Mapped = nullptr;
+      vkMapMemory(IS.Device, ResRef.Host.Memory, 0, VK_WHOLE_SIZE, 0, &Mapped);
+
+      Range.memory = ResRef.Host.Memory;
+      vkInvalidateMappedMemoryRanges(IS.Device, 1, &Range);
+
+      const Buffer &B = *P.Bindings.RTargetBufferPtr;
+      memcpy(B.Data[0].get(), Mapped, B.size());
+      vkUnmapMemory(IS.Device, ResRef.Host.Memory);
+    }
     return llvm::Error::success();
   }
 
@@ -1152,9 +1656,30 @@ public:
       }
     }
 
+    if (IS.getFullShaderStageMask() != VK_SHADER_STAGE_COMPUTE_BIT) {
+      if (IS.VertexBuffer.has_value()) {
+        vkDestroyBuffer(IS.Device, IS.VertexBuffer->Device.Buffer, nullptr);
+        vkFreeMemory(IS.Device, IS.VertexBuffer->Device.Memory, nullptr);
+        vkDestroyBuffer(IS.Device, IS.VertexBuffer->Host.Buffer, nullptr);
+        vkFreeMemory(IS.Device, IS.VertexBuffer->Host.Memory, nullptr);
+      }
+      for (auto &ResRef : IS.FrameBufferResource.ResourceRefs) {
+        // We know the device resource is an image, so no need to check it.
+        vkDestroyImage(IS.Device, ResRef.Image.Image, nullptr);
+        vkFreeMemory(IS.Device, ResRef.Image.Memory, nullptr);
+        vkDestroyBuffer(IS.Device, ResRef.Host.Buffer, nullptr);
+        vkFreeMemory(IS.Device, ResRef.Host.Memory, nullptr);
+      }
+      vkDestroyImage(IS.Device, IS.DepthStencil.Image, nullptr);
+      vkFreeMemory(IS.Device, IS.DepthStencil.Memory, nullptr);
+      vkDestroyFramebuffer(IS.Device, IS.FrameBuffer, nullptr);
+      vkDestroyRenderPass(IS.Device, IS.RenderPass, nullptr);
+    }
+
     vkDestroyPipeline(IS.Device, IS.Pipeline, nullptr);
 
-    vkDestroyShaderModule(IS.Device, IS.Shader, nullptr);
+    for (auto &S : IS.Shaders)
+      vkDestroyShaderModule(IS.Device, S.Shader, nullptr);
 
     vkDestroyPipelineCache(IS.Device, IS.PipelineCache, nullptr);
 
@@ -1163,7 +1688,8 @@ public:
     for (auto &L : IS.DescriptorSetLayouts)
       vkDestroyDescriptorSetLayout(IS.Device, L, nullptr);
 
-    vkDestroyDescriptorPool(IS.Device, IS.Pool, nullptr);
+    if (IS.Pool)
+      vkDestroyDescriptorPool(IS.Device, IS.Pool, nullptr);
 
     vkDestroyCommandPool(IS.Device, IS.CmdPool, nullptr);
     vkDestroyDevice(IS.Device, nullptr);
@@ -1175,11 +1701,22 @@ public:
     if (auto Err = createDevice(State))
       return Err;
     llvm::outs() << "Physical device created.\n";
+    if (auto Err = createShaderModules(P, State))
+      return Err;
+    llvm::outs() << "Shader module created.\n";
     if (auto Err = createCommandBuffer(State))
       return Err;
     llvm::outs() << "Copy command buffer created.\n";
     if (auto Err = createBuffers(P, State))
       return Err;
+    if (P.isGraphics()) {
+      if (auto Err = createRenderPass(P, State))
+        return Err;
+      llvm::outs() << "Render pass created.\n";
+      if (auto Err = createFrameBuffer(P, State))
+        return Err;
+      llvm::outs() << "Frame buffer created.\n";
+    }
     llvm::outs() << "Memory buffers created.\n";
     if (auto Err = executeCommandBuffer(State))
       return Err;
@@ -1193,15 +1730,12 @@ public:
     if (auto Err = createDescriptorSets(P, State))
       return Err;
     llvm::outs() << "Descriptor sets created.\n";
-    if (auto Err = createShaderModule(P.Shaders[0].Shader->getBuffer(), State))
-      return Err;
-    llvm::outs() << "Shader module created.\n";
     if (auto Err = createPipeline(P, State))
       return Err;
     llvm::outs() << "Compute pipeline created.\n";
-    if (auto Err = createComputeCommands(P, State))
+    if (auto Err = createCommands(P, State))
       return Err;
-    llvm::outs() << "Compute commands created.\n";
+    llvm::outs() << "Commands created.\n";
     if (auto Err = executeCommandBuffer(State, VK_PIPELINE_STAGE_TRANSFER_BIT))
       return Err;
     llvm::outs() << "Executed compute command buffer.\n";

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -29,6 +29,7 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
   I.mapRequired("Buffers", P.Buffers);
   I.mapOptional("Results", P.Results);
   I.mapRequired("DescriptorSets", P.Sets);
+  I.mapOptional("Bindings", P.Bindings);
 
   if (!I.outputting()) {
     for (auto &D : P.Sets) {
@@ -38,6 +39,7 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
           I.setError(Twine("Referenced buffer ") + R.Name + " not found!");
       }
     }
+
     // Initialize result Buffers
     for (auto &R : P.Results) {
       R.ActualPtr = P.getBuffer(R.Actual);
@@ -85,6 +87,20 @@ void MappingTraits<offloadtest::Pipeline>::mapping(IO &I,
       I.setError(Twine("Expected ") + std::to_string(P.Sets.size()) +
                  " DescriptorTable root parameters, found " +
                  std::to_string(DescriptorTableCount));
+
+    if (!P.Bindings.VertexBuffer.empty()) {
+      P.Bindings.VertexBufferPtr = P.getBuffer(P.Bindings.VertexBuffer);
+      if (!P.Bindings.VertexBufferPtr)
+        I.setError(Twine("Referenced vertex buffer ") +
+                   P.Bindings.VertexBuffer + " not found!");
+    }
+
+    if (!P.Bindings.RenderTarget.empty()) {
+      P.Bindings.RTargetBufferPtr = P.getBuffer(P.Bindings.RenderTarget);
+      if (!P.Bindings.RTargetBufferPtr)
+        I.setError(Twine("Referenced render target buffer ") +
+                   P.Bindings.RenderTarget + " not found!");
+    }
   }
 }
 
@@ -269,6 +285,21 @@ void MappingTraits<offloadtest::DirectXBinding>::mapping(
 void MappingTraits<offloadtest::VulkanBinding>::mapping(
     IO &I, offloadtest::VulkanBinding &B) {
   I.mapRequired("Binding", B.Binding);
+}
+
+void MappingTraits<offloadtest::VertexAttribute>::mapping(
+    IO &I, offloadtest::VertexAttribute &A) {
+  I.mapRequired("Format", A.Format);
+  I.mapRequired("Channels", A.Channels);
+  I.mapRequired("Offset", A.Offset);
+  I.mapRequired("Name", A.Name);
+}
+
+void MappingTraits<offloadtest::IOBindings>::mapping(
+    IO &I, offloadtest::IOBindings &B) {
+  I.mapOptional("VertexBuffer", B.VertexBuffer);
+  I.mapOptional("VertexAttributes", B.VertexAttributes);
+  I.mapOptional("RenderTarget", B.RenderTarget);
 }
 
 void MappingTraits<offloadtest::OutputProperties>::mapping(

--- a/test/Graphics/SimpleTriangle.test
+++ b/test/Graphics/SimpleTriangle.test
@@ -1,0 +1,80 @@
+#--- vertex.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+PSInput main(float4 position : POSITION, float4 color : COLOR)
+{
+    PSInput result;
+
+    result.position = position;
+    result.color = color;
+
+    return result;
+}
+
+
+#--- pixel.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color;
+}
+#--- pipeline.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: VertexData
+    Format: Float32
+    Stride: 28 # 32 bytes per vertex
+    Data: [ 0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 1.0,
+            0.25, -0.25, 0.0, 0.0, 1.0, 0.0, 1.0,
+           -0.25, -0.25, 0.0, 0.0, 0.0, 1.0, 1.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    ZeroInitSize: 1048576 # 256x256 @ 16 bytes per pixel
+    OutputProps:
+      Height: 256
+      Width: 256
+      Depth: 16
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 3
+      Offset: 0
+      Name: POSITION
+    - Format: Float32
+      Channels: 4
+      Offset: 12
+      Name: COLOR
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- rules.yaml
+---
+- Type: PixelPercent
+  Val: 0.2 # No more than 0.2% of pixels may be visibly different.
+...
+#--- end
+
+# UNSUPPORTED: Clang
+# REQUIRES: goldenimage
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %offloader %t/pipeline.yaml %t-vertex.o %t-pixel.o -r Output -o %t/Output.png
+# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/SimpleTriangle.png -rules %t/rules.yaml


### PR DESCRIPTION
This PR adds support for simple graphics pipelines comprised of a vertex shader and a pixel shader.

The added test case generates an image added in the golden image suite as https://github.com/llvm/offload-golden-images/pull/1.

Additions to the YAML pipeline description include a new Binding structure which enables specifying a vertex buffer and associated vertex attributes as well as a buffer to serve as the render target.

The shader stage enumeration has been extended to support `Vertex` and `Pixel` stages (`Pixel` mapping to "Fragment" in the MTL and VK APIs).