### PR TITLE
Vulkan: Add support for counter buffers

### DIFF
--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -65,6 +65,7 @@ struct DirectXBinding {
 
 struct VulkanBinding {
   uint32_t Binding;
+  std::optional<uint32_t> CounterBinding;
 };
 
 struct OutputProperties {

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -285,6 +285,7 @@ void MappingTraits<offloadtest::DirectXBinding>::mapping(
 void MappingTraits<offloadtest::VulkanBinding>::mapping(
     IO &I, offloadtest::VulkanBinding &B) {
   I.mapRequired("Binding", B.Binding);
+  I.mapOptional("CounterBinding", B.CounterBinding);
 }
 
 void MappingTraits<offloadtest::VertexAttribute>::mapping(

--- a/test/Feature/StructuredBuffer/inc_counter.test
+++ b/test/Feature/StructuredBuffer/inc_counter.test
@@ -28,12 +28,14 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
+        CounterBinding: 1
 ...
 #--- end
 
-# Offload tests are missing support for counters on Vulcan
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/303
-# XFAIL: Vulkan
+# Unimplemented https://github.com/llvm/llvm-project/issues/137032
+# XFAIL: Clang && Vulkan
 
 # Offload tests are missing support for counters on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304

--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -8,9 +8,21 @@ RWStructuredBuffer<int> Out[4] : register(u0);
 [numthreads(4,1,1)]
 void main(uint GI : SV_GroupIndex) {
   for (int i = 0; i < GI; i++)
-    Out[GI].IncrementCounter();
-  
-  Out[GI][0] = Out[GI].IncrementCounter();
+    Out[i].IncrementCounter();
+  switch(GI) {
+    case 0:
+      Out[0][0] = Out[0].IncrementCounter();
+      break;
+    case 1:
+      Out[1][0] = Out[1].IncrementCounter();
+      break;
+    case 2:
+      Out[2][0] = Out[2].IncrementCounter();
+      break;
+    case 3:
+      Out[3][0] = Out[3].IncrementCounter();
+      break;
+  }
 }
 
 //--- pipeline.yaml
@@ -34,33 +46,31 @@ DescriptorSets:
       DirectXBinding:
         Register: 0
         Space: 0
+      VulkanBinding:
+        Binding: 0
+        CounterBinding: 1
 ...
 #--- end
 
-# Offload tests are missing support for counters on Vulkan
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/303
-# XFAIL: Vulkan
+# Unimplemented https://github.com/llvm/llvm-project/issues/137032
+# XFAIL: Clang && Vulkan
 
 # Offload tests are missing support for counters and resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
 # XFAIL: Metal
 
-# Intel has an issue with counters in resource arrays
-# Bug https://github.com/llvm/offload-test-suite/issues/376
-# XFAIL: DirectX && Intel
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
+# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s %if DirectX %{ --check-prefixes=CHECK,DX-CHECK %}
 
-# CHECK: Creating UAV: { Size = 4100, Register = u0, Space = 0, HasCounter = 1 }
-# CHECK: UAV: HeapIdx = 0 EltSize = 4 NumElts = 1 HasCounter = 1
+# DX-CHECK: Creating UAV: { Size = 4100, Register = u0, Space = 0, HasCounter = 1 }
+# DX-CHECK: UAV: HeapIdx = 0 EltSize = 4 NumElts = 1 HasCounter = 1
 
 # CHECK: Name: Out
-# CHECK: Counters: [ 1, 2, 3, 4 ]
+# CHECK: Counters: [ 4, 3, 2, 1 ]
 # CHECK: Data:
-      - [ 0x0 ]
-      - [ 0x1 ]
-      - [ 0x2 ]
       - [ 0x3 ]
+      - [ 0x2 ]
+      - [ 0x1 ]
+      - [ 0x0 ]

--- a/test/Tools/Offloader/missing-counter-binding.test
+++ b/test/Tools/Offloader/missing-counter-binding.test
@@ -1,15 +1,13 @@
 #--- source.hlsl
-RWStructuredBuffer<uint> Out : register(u0);
+RWStructuredBuffer<int> Out : register(u0);
 
 [numthreads(1,1,1)]
 void main(uint GI : SV_GroupIndex) {
-  Out.DecrementCounter();
-  Out.DecrementCounter();
-  Out.DecrementCounter();
-  Out[GI] = Out.DecrementCounter();
+  Out.IncrementCounter();
+  Out[GI] = 0;
 }
 
-//--- pipeline.yaml
+#--- pipeline.yaml
 ---
 Shaders:
   - Stage: Compute
@@ -30,23 +28,14 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 0
-        CounterBinding: 1
 ...
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/137032
 # XFAIL: Clang && Vulkan
 
-# Offload tests are missing support for counters on Metal
-# Unimplemented https://github.com/llvm/offload-test-suite/issues/304
-# XFAIL: Metal
-
+# REQUIRES: Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
-# RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s
-
-# CHECK: Name: Out
-# CHECK: Counter: 4294967292
-# CHECK: Data: [
-# CHECK: 0xFFFFFFFC
-# CHECK: ]
+# RUN: not %offloader %t/pipeline.yaml %t.o 2>&1 | FileCheck %s
+# CHECK: No CounterBinding provided for resource 'Out' with a counter


### PR DESCRIPTION
This commit introduces support for counter buffers in the Vulkan backend.

The changes include:
- Extending the VulkanBinding struct to include an optional CounterBinding.
- Implementing the necessary logic in the Vulkan device code to handle the creation, management, and cleanup of counter buffers.
- Updating the descriptor set layout and write processes to correctly handle counter buffers.
- Enabling the inc_counter.test for Vulkan, as it is now expected to pass.
- Adding a new test case to verify that an error is correctly reported when a resource with a counter is missing the required CounterBinding.
