### PR TITLE
Remove all XFAILs (DO NOT MERGE)

### DIFF
--- a/test/Basic/Matrix/matrix_elementwise_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_cast.test
@@ -100,7 +100,7 @@ DescriptorSets:
 ...
 #--- end
 # Unimplemented: https://github.com/llvm/llvm-project/issues/170534
-# XFAIL: Vulkan && Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_elementwise_vector_cast.test
+++ b/test/Basic/Matrix/matrix_elementwise_vector_cast.test
@@ -74,7 +74,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented: https://github.com/llvm/llvm-project/issues/170538
-# XFAIL: Vulkan && Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_scalar_arithmetic.test
+++ b/test/Basic/Matrix/matrix_scalar_arithmetic.test
@@ -84,7 +84,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/538
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_scalar_constructor.test
+++ b/test/Basic/Matrix/matrix_scalar_constructor.test
@@ -57,7 +57,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/538
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_single_subscript_load.test
+++ b/test/Basic/Matrix/matrix_single_subscript_load.test
@@ -64,7 +64,7 @@ DescriptorSets:
 ...
 #--- end
 
-# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_single_subscript_store.test
+++ b/test/Basic/Matrix/matrix_single_subscript_store.test
@@ -65,7 +65,7 @@ DescriptorSets:
 ...
 #--- end
 
-# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_trunc_cast.test
+++ b/test/Basic/Matrix/matrix_trunc_cast.test
@@ -57,7 +57,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented: https://github.com/llvm/llvm-project/issues/170538
-# XFAIL: Vulkan && Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -63,7 +63,7 @@ DescriptorSets:
 # LLVM's load-store optimization performs correct optimizations that hide the
 # problem.
 # Bug https://github.com/llvm/offload-test-suite/issues/226
-# XFAIL: Intel-Memory-Coherence-Issue-226 && !Clang
+
 
 # https://github.com/microsoft/DirectXShaderCompiler/issues/7494
 # https://github.com/llvm/llvm-project/issues/142677

--- a/test/Bugs/UAV-Sequental-Consistency.yaml
+++ b/test/Bugs/UAV-Sequental-Consistency.yaml
@@ -63,7 +63,7 @@ DescriptorSets:
 # This test fails randomly but inconsistently without validation enabled. With
 # validation enabled it fails consistently every time.
 # Bug https://github.com/llvm/offload-test-suite/issues/226
-# XFAIL: Intel-Memory-Coherence-Issue-226 && !Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit.test
@@ -89,7 +89,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/108058
-# XFAIL: Clang
+
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-64bit.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-64bit.test
@@ -89,7 +89,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/108058
-# XFAIL: Clang
+
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers.test
@@ -149,7 +149,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/108058
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ByteAddressBuffer/GetDimensions.test
+++ b/test/Feature/ByteAddressBuffer/GetDimensions.test
@@ -80,7 +80,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164008
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/array-of-structs.test
+++ b/test/Feature/CBuffer/array-of-structs.test
@@ -75,7 +75,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/159602
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/arrays-16bit.test
+++ b/test/Feature/CBuffer/arrays-16bit.test
@@ -86,7 +86,7 @@ DescriptorSets:
 # REQUIRES: Half, Int16
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/159602
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/arrays-64bit.test
+++ b/test/Feature/CBuffer/arrays-64bit.test
@@ -94,9 +94,9 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/7819
-# XFAIL: Vulkan
+
 # Unimplemented https://github.com/llvm/llvm-project/issues/147352
-# XFAIL: Clang
+
 
 # REQUIRES: Double, Int64
 # RUN: split-file %s %t

--- a/test/Feature/CBuffer/arrays.test
+++ b/test/Feature/CBuffer/arrays.test
@@ -94,9 +94,9 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/microsoft/DirectXShaderCompiler/issues/7819
-# XFAIL: DXC && Vulkan
+
 # Unimplemented https://github.com/llvm/llvm-project/issues/159602
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/dynamic-struct.test
+++ b/test/Feature/CBuffer/dynamic-struct.test
@@ -108,7 +108,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/164517
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/structs.test
+++ b/test/Feature/CBuffer/structs.test
@@ -100,10 +100,10 @@ DescriptorSets:
 
 # Clang trips on 2-element vectors in structs:
 # Bug https://github.com/llvm/llvm-project/issues/123968
-# XFAIL: Clang
+
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7968
-# XFAIL: DXC && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/vectors-16bit.test
+++ b/test/Feature/CBuffer/vectors-16bit.test
@@ -58,7 +58,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/159602
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Half, Int16
 

--- a/test/Feature/CBuffer/vectors-64bit.test
+++ b/test/Feature/CBuffer/vectors-64bit.test
@@ -66,11 +66,11 @@ DescriptorSets:
 # REQUIRES: Double, Int64
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/471
-# XFAIL: Vulkan && Intel
+
 
 # Clang trips on 3-element vectors in structs:
 # Bug https://github.com/llvm/llvm-project/issues/123968
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/CBuffer/vectors.test
+++ b/test/Feature/CBuffer/vectors.test
@@ -66,7 +66,7 @@ DescriptorSets:
 
 # Clang trips on 3-element vectors in structs:
 # Bug https://github.com/llvm/llvm-project/issues/123968
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fvk-use-dx-layout -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/Groupshared/GSVector.test
+++ b/test/Feature/Groupshared/GSVector.test
@@ -47,7 +47,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/PartiallyMappedResources.test
+++ b/test/Feature/HLSLLib/PartiallyMappedResources.test
@@ -138,15 +138,15 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/514
-# XFAIL: Vulkan
+
 # Unimplemented https://github.com/llvm/llvm-project/issues/166954
-# XFAIL: Clang-Vulkan
+
 
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/515
-# XFAIL: Metal
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/485
-# XFAIL: Intel
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/abs.32.test
+++ b/test/Feature/HLSLLib/abs.32.test
@@ -135,7 +135,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/abs.int16.test
+++ b/test/Feature/HLSLLib/abs.int16.test
@@ -95,7 +95,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/abs.int64.test
+++ b/test/Feature/HLSLLib/abs.int64.test
@@ -95,7 +95,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/adduint64.test
+++ b/test/Feature/HLSLLib/adduint64.test
@@ -64,10 +64,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/292
-# XFAIL: DXC && Metal
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/344
-# XFAIL: Clang && Metal
+
 
 # UNSUPPORTED: DXC && Vulkan
 

--- a/test/Feature/HLSLLib/all.bool.test
+++ b/test/Feature/HLSLLib/all.bool.test
@@ -57,7 +57,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/140824
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/and.test
+++ b/test/Feature/HLSLLib/and.test
@@ -68,7 +68,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/140824
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/any.bool.test
+++ b/test/Feature/HLSLLib/any.bool.test
@@ -57,7 +57,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/140824
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/any.fp64.test
+++ b/test/Feature/HLSLLib/any.fp64.test
@@ -57,7 +57,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/370
-# XFAIL: DXC && DirectX && Intel
+
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/any.int64.test
+++ b/test/Feature/HLSLLib/any.int64.test
@@ -98,7 +98,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/370
-# XFAIL: DXC && DirectX && Intel
+
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/asdouble.32.test
+++ b/test/Feature/HLSLLib/asdouble.32.test
@@ -83,10 +83,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/153513
-# XFAIL: Clang && Vulkan
+
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7699
-# XFAIL: DXC && Vulkan
+
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/asin.16.test
+++ b/test/Feature/HLSLLib/asin.16.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/578
-# XFAIL: AMD && Vulkan
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/asint.test
+++ b/test/Feature/HLSLLib/asint.test
@@ -137,7 +137,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/154214
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/asuint.64.test
+++ b/test/Feature/HLSLLib/asuint.64.test
@@ -82,7 +82,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7666
-# XFAIL: DXC && Vulkan
+
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/cos.32.test
+++ b/test/Feature/HLSLLib/cos.32.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && Darwin
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/cosh.16.test
+++ b/test/Feature/HLSLLib/cosh.16.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2507
-# XFAIL: Vulkan && Darwin
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/countbits.32.test
+++ b/test/Feature/HLSLLib/countbits.32.test
@@ -91,7 +91,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/dot.int64.test
+++ b/test/Feature/HLSLLib/dot.int64.test
@@ -132,7 +132,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/570
-# XFAIL: AMD && DirectX
+
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/dot2add.test
+++ b/test/Feature/HLSLLib/dot2add.test
@@ -87,10 +87,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/341
-# XFAIL: Metal
+
 
 # Bug https://github.com/llvm/llvm-project/issues/149561 and https://github.com/llvm/offload-test-suite/issues/568
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/firstbithigh.16.test
+++ b/test/Feature/HLSLLib/firstbithigh.16.test
@@ -83,9 +83,9 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Bug: No bit set terminal is returned as 4294901776 instead of 4294967295
-# XFAIL: DXC && Metal
+
 # Bug: Fails with 'gpu-exec: error: Failed to materializeAll.:'
-# XFAIL: Clang && Metal
+
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
 # Unsupported https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl

--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -83,14 +83,14 @@ DescriptorSets:
 # REQUIRES: Int64
 
 # Bug: Fails with 'gpu-exec: error: Failed to materializeAll.:'
-# XFAIL: Metal
+
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
 # https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
 # UNSUPPORTED: DXC && Vulkan
 
 # Bug https://github.com/llvm/llvm-project/issues/143171
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/firstbitlow.16.test
+++ b/test/Feature/HLSLLib/firstbitlow.16.test
@@ -77,7 +77,7 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Fails with 'gpu-exec: error: Failed to materializeAll.:'
-# XFAIL: Metal
+
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering
 # https://github.com/microsoft/DirectXShaderCompiler/blob/48d6e3c635f0ab3ae79580c37003e6faeca6c671/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl#L5

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -77,14 +77,14 @@ DescriptorSets:
 # REQUIRES: Int64
 
 # Fails with 'gpu-exec: error: Failed to materializeAll.:'
-# XFAIL: Metal
+
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering
 # https://github.com/microsoft/DirectXShaderCompiler/blob/48d6e3c635f0ab3ae79580c37003e6faeca6c671/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl#L5
 # UNSUPPORTED: DXC && Vulkan
 
 # Bug https://github.com/llvm/llvm-project/issues/143003
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/frac.16.test
+++ b/test/Feature/HLSLLib/frac.16.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && Darwin
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/isinf.16.test
+++ b/test/Feature/HLSLLib/isinf.16.test
@@ -56,7 +56,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # A bug in the Metal Shader Converter caused it to mis-translate this operation.
 # Version 3 fixes this issue.

--- a/test/Feature/HLSLLib/isinf.32.test
+++ b/test/Feature/HLSLLib/isinf.32.test
@@ -56,7 +56,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/log10.16.test
+++ b/test/Feature/HLSLLib/log10.16.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/145073
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/mad.32.test
+++ b/test/Feature/HLSLLib/mad.32.test
@@ -208,7 +208,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7706
-# XFAIL: DXC && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/mad.fp16.test
+++ b/test/Feature/HLSLLib/mad.fp16.test
@@ -84,7 +84,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/563
-# XFAIL: NV && Vulkan
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/or.test
+++ b/test/Feature/HLSLLib/or.test
@@ -68,7 +68,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/140824
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/reflect.16.test
+++ b/test/Feature/HLSLLib/reflect.16.test
@@ -187,7 +187,7 @@ DescriptorSets:
 # REQUIRES: Half
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2524
-# XFAIL: Vulkan && Darwin
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -enable-16bit-types -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/refract.16.test
+++ b/test/Feature/HLSLLib/refract.16.test
@@ -188,7 +188,7 @@ DescriptorSets:
 # REQUIRES: Half
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2524
-# XFAIL: Vulkan && Darwin
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -enable-16bit-types -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/reversebits.16.test
+++ b/test/Feature/HLSLLib/reversebits.16.test
@@ -58,7 +58,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/518
-# XFAIL: Clang && Vulkan && QC
+
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/saturate.32.test
+++ b/test/Feature/HLSLLib/saturate.32.test
@@ -47,7 +47,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.32.test
+++ b/test/Feature/HLSLLib/select.32.test
@@ -351,7 +351,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/166642
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/select.fp16.test
+++ b/test/Feature/HLSLLib/select.fp16.test
@@ -132,7 +132,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/166642
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/select.fp64.test
+++ b/test/Feature/HLSLLib/select.fp64.test
@@ -125,7 +125,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/166642
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/select.int16.test
+++ b/test/Feature/HLSLLib/select.int16.test
@@ -205,7 +205,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/166642
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/select.int64.test
+++ b/test/Feature/HLSLLib/select.int64.test
@@ -204,7 +204,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/166642
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/sign.32.test
+++ b/test/Feature/HLSLLib/sign.32.test
@@ -174,12 +174,12 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # We're generating invalid SPIRV for this. I have _no_ idea why this isn't
 # failing on all Clang Vulkan tests.
 # Bug https://github.com/llvm/llvm-project/issues/149722
-# XFAIL: Clang && Vulkan && Darwin
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sign.fp16.test
+++ b/test/Feature/HLSLLib/sign.fp16.test
@@ -98,7 +98,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/sign.fp64.test
+++ b/test/Feature/HLSLLib/sign.fp64.test
@@ -93,7 +93,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Double
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/sign.int16.test
+++ b/test/Feature/HLSLLib/sign.int16.test
@@ -95,10 +95,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
-# XFAIL: DXC && Vulkan
+
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/sign.int64.test
+++ b/test/Feature/HLSLLib/sign.int64.test
@@ -95,10 +95,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7755
-# XFAIL: DXC && Vulkan
+
 
 # REQUIRES: Int64
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/sin.32.test
+++ b/test/Feature/HLSLLib/sin.32.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && Darwin
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/sinh.16.test
+++ b/test/Feature/HLSLLib/sinh.16.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2507
-# XFAIL: Vulkan && Darwin
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/tanh.16.test
+++ b/test/Feature/HLSLLib/tanh.16.test
@@ -62,7 +62,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2507
-# XFAIL: Vulkan && Darwin
+
 
 # REQUIRES: Half
 # RUN: split-file %s %t

--- a/test/Feature/MaximalReconvergence/loop_peeling.test
+++ b/test/Feature/MaximalReconvergence/loop_peeling.test
@@ -37,16 +37,16 @@ DescriptorSets:
 # UNSUPPORTED: Vulkan && !VK_KHR_shader_maximal_reconvergence
 
 # BUG: https://github.com/llvm/offload-test-suite/issues/490
-# XFAIL: WARP && DirectX && Clang
+
 
 # BUG: https://github.com/llvm/llvm-project/issues/165288
-# XFAIL: !WARP && Clang && (DirectX || Metal)
+
 
 # BUG: https://github.com/llvm/offload-test-suite/issues/520
-# XFAIL: QC
+
 
 # BUG: https://github.com/llvm/offload-test-suite/issues/521
-# XFAIL: NV && DirectX
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fspv-enable-maximal-reconvergence -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourceArrays/array-global.test
+++ b/test/Feature/ResourceArrays/array-global.test
@@ -136,7 +136,7 @@ DescriptorSets:
 
 # Offload tests are missing support for resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourceArrays/array-local.test
+++ b/test/Feature/ResourceArrays/array-local.test
@@ -83,11 +83,11 @@ DescriptorSets:
 # UNSUPPORTED: Metal
 
 # Bug https://github.com/llvm/llvm-project/issues/154669
-# XFAIL: Clang && Vulkan
+
 
 # DXC-Vulkan support for arrays of RWStructuredBuffer are pretty broken.
 # Tracked by https://github.com/microsoft/DirectXShaderCompiler/issues/7727
-# XFAIL: DXC && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourceArrays/array-local2.test
+++ b/test/Feature/ResourceArrays/array-local2.test
@@ -77,17 +77,17 @@ DescriptorSets:
 # DXC-DirectX has a bug here because it does not create a local copy
 # of a function argument if the type is resource or resource array.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7678
-# XFAIL: DXC && DirectX
+
 
 # DXC-Vulkan support for arrays of RWStructuredBuffer are pretty broken.
 # Tracked by https://github.com/microsoft/DirectXShaderCompiler/issues/7727
-# XFAIL: DXC && Vulkan
+
 
 # Resource arrays are not yet supported on Metal
 # UNSUPPORTED: Metal
 
 # Bug https://github.com/llvm/llvm-project/issues/154669
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourceArrays/array-of-constant-buffers.test
+++ b/test/Feature/ResourceArrays/array-of-constant-buffers.test
@@ -68,11 +68,11 @@ DescriptorSets:
 
 # Resource arrays are not yet implemented in Clang:
 # Unimplemented https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
+
 
 # Offload tests are missing support for resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourceArrays/multi-dim-array-subset-nuri.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset-nuri.test
@@ -67,7 +67,7 @@ DescriptorSets:
 
 # NURI not correctly propagated by DXC.
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7756
-# XFAIL: DirectX && AMD && DXC
+
 
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -70,10 +70,10 @@ DescriptorSets:
 # UNSUPPORTED: DXC && Vulkan
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164908
-# XFAIL: Clang && Vulkan
+
 
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourceArrays/multi-dim-unbounded-array.test
+++ b/test/Feature/ResourceArrays/multi-dim-unbounded-array.test
@@ -55,7 +55,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # Vulkan does not support multi-dimensional resource arrays
 # UNSUPPORTED: Vulkan

--- a/test/Feature/ResourceArrays/unbounded-array.test
+++ b/test/Feature/ResourceArrays/unbounded-array.test
@@ -55,7 +55,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/RootSignatures/StaticSamplers.test
+++ b/test/Feature/RootSignatures/StaticSamplers.test
@@ -131,7 +131,7 @@ DescriptorSets:
 #--- end
 
 # Unsupported: https://github.com/llvm/llvm-project/issues/101558
-# XFAIL: Clang
+
 
 # REQUIRES: DerivativesInCompute
 

--- a/test/Feature/SpecializationConstant/invalid_double.test
+++ b/test/Feature/SpecializationConstant/invalid_double.test
@@ -29,7 +29,7 @@ DescriptorSets:
 # REQUIRES: Vulkan
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7886
-# XFAIL: DXC
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_2 -Fo %t.o %t/invalid_double.hlsl

--- a/test/Feature/SpecializationConstant/invalid_int16.test
+++ b/test/Feature/SpecializationConstant/invalid_int16.test
@@ -29,7 +29,7 @@ DescriptorSets:
 # REQUIRES: Vulkan
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7886
-# XFAIL: DXC
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_2 -enable-16bit-types -Fo %t.o %t/invalid_int16.hlsl

--- a/test/Feature/SpecializationConstant/invalid_uint16.test
+++ b/test/Feature/SpecializationConstant/invalid_uint16.test
@@ -29,7 +29,7 @@ DescriptorSets:
 # REQUIRES: Vulkan
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7886
-# XFAIL: DXC
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_2 -enable-16bit-types -Fo %t.o %t/invalid_uint16.hlsl

--- a/test/Feature/SpecializationConstant/spec_const_other_sizes.test
+++ b/test/Feature/SpecializationConstant/spec_const_other_sizes.test
@@ -54,7 +54,7 @@ DescriptorSets:
 # REQUIRES: Vulkan
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/7886
-# XFAIL: DXC
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_2 -enable-16bit-types -Fo %t.o %t/simple_64bit.hlsl

--- a/test/Feature/StructuredBuffer/GetDimensions.test
+++ b/test/Feature/StructuredBuffer/GetDimensions.test
@@ -132,7 +132,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164008
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/dec_counter.test
+++ b/test/Feature/StructuredBuffer/dec_counter.test
@@ -36,7 +36,7 @@ DescriptorSets:
 
 # Offload tests are missing support for counters on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/inc_counter.test
+++ b/test/Feature/StructuredBuffer/inc_counter.test
@@ -36,7 +36,7 @@ DescriptorSets:
 
 # Offload tests are missing support for counters on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -41,19 +41,19 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/162841
-# XFAIL: Clang && Vulkan
+
 
 # Offload tests are missing support for counters and resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # Intel has an issue with counters in resource arrays
 # Bug https://github.com/llvm/offload-test-suite/issues/376
-# XFAIL: Intel
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/337
-# XFAIL: AMD
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/inc_counter_array_imm_idx.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array_imm_idx.test
@@ -52,7 +52,7 @@ DescriptorSets:
 # Offload tests are missing support for counters and resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/304
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/StructuredBuffer/layout.test
+++ b/test/Feature/StructuredBuffer/layout.test
@@ -88,7 +88,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 %if Vulkan %{ -fvk-use-dx-layout %} -Fo %t.o %t/source.hlsl

--- a/test/Feature/Textures/SRVToUAV-array.test
+++ b/test/Feature/Textures/SRVToUAV-array.test
@@ -89,11 +89,11 @@ DescriptorSets:
 
 # Resource arrays are not yet implemented in Clang:
 # Unimplemented https://github.com/llvm/llvm-project/issues/133835
-# XFAIL: Clang
+
 
 # Offload tests are missing support for resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/TypedBuffer/GetDimensions.test
+++ b/test/Feature/TypedBuffer/GetDimensions.test
@@ -81,10 +81,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/469
-# XFAIL: DXC && Vulkan
+
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164008
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/WaveOps/WaveActiveCountBits.test
+++ b/test/Feature/WaveOps/WaveActiveCountBits.test
@@ -65,7 +65,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/549
-# XFAIL: QC && Vulkan && Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/WaveOps/WaveIsFirstLane.test
+++ b/test/Feature/WaveOps/WaveIsFirstLane.test
@@ -66,7 +66,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/320
-# XFAIL: NV-Reconvergence-Issue-320
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Tools/Offloader/BufferExact-error-array.test
+++ b/test/Tools/Offloader/BufferExact-error-array.test
@@ -48,7 +48,7 @@ DescriptorSets:
 
 # Offload tests are missing support for resource arrays on Metal
 # Unimplemented https://github.com/llvm/offload-test-suite/issues/305
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/UseCase/particle-life.test
+++ b/test/UseCase/particle-life.test
@@ -352,14 +352,14 @@ DescriptorSets:
 
 # Unimplemented: CBuffer not implemented in Clang's Vulkan implementation.
 # https://github.com/llvm/llvm-project/issues/124597
-# XFAIL: Clang && Vulkan
+
 
 # CBuffer bindings seem to be broken under metal
 # Bug https://github.com/llvm/offload-test-suite/issues/55
-# XFAIL: Metal
+
 
 # No idea what is going on here, but the results are _way_ off.
-# XFAIL: Vulkan && Darwin
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 %if Vulkan %{ -fvk-use-dx-layout %} -Fo %t.o %t/particle-life.hlsl

--- a/test/WaveOps/ComponentAccumulationDataRace.test
+++ b/test/WaveOps/ComponentAccumulationDataRace.test
@@ -61,13 +61,13 @@ DescriptorSets:
 
 # Clang introduces a data-race
 # Bug https://github.com/llvm/llvm-project/issues/160208
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/445
-# XFAIL: DirectX && Intel
+
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/452
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/ComponentDataRace.test
+++ b/test/WaveOps/ComponentDataRace.test
@@ -59,10 +59,10 @@ DescriptorSets:
 
 # Clang introduces a data-race
 # Bug https://github.com/llvm/llvm-project/issues/160208
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/452
-# XFAIL: DXC && Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveMax.fp16.test
+++ b/test/WaveOps/WaveActiveMax.fp16.test
@@ -305,10 +305,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveMax.fp32.test
+++ b/test/WaveOps/WaveActiveMax.fp32.test
@@ -305,10 +305,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveMax.fp64.test
+++ b/test/WaveOps/WaveActiveMax.fp64.test
@@ -305,13 +305,13 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/541
-# XFAIL: DirectX && AMD
+
 
 # REQUIRES: Double
 

--- a/test/WaveOps/WaveActiveMax.int16.test
+++ b/test/WaveOps/WaveActiveMax.int16.test
@@ -305,10 +305,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveMax.int32.test
+++ b/test/WaveOps/WaveActiveMax.int32.test
@@ -305,10 +305,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveMax.int64.test
+++ b/test/WaveOps/WaveActiveMax.int64.test
@@ -307,10 +307,10 @@ DescriptorSets:
 # REQUIRES: Int64
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveMax.test
+++ b/test/WaveOps/WaveActiveMax.test
@@ -87,7 +87,7 @@ DescriptorSets:
 # DirectX driver implementations seem to match SPIR-V, except WARP, which does
 # not treat -INF as an identity.
 
-# XFAIL: DirectX && WARP
+
 
 # CHECK: Name: Nans
 # CHECK-NEXT: Format: Float32

--- a/test/WaveOps/WaveActiveSum.fp16.test
+++ b/test/WaveOps/WaveActiveSum.fp16.test
@@ -169,19 +169,19 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Vulkan && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang && DirectX
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/528
-# XFAIL: QC && Clang && DirectX
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # REQUIRES: Half
 

--- a/test/WaveOps/WaveActiveSum.fp32.test
+++ b/test/WaveOps/WaveActiveSum.fp32.test
@@ -169,16 +169,16 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Vulkan && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang && DirectX
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/526
-# XFAIL: Metal && Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.fp64.test
+++ b/test/WaveOps/WaveActiveSum.fp64.test
@@ -169,13 +169,13 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Vulkan && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang && DirectX
+
 
 # REQUIRES: Double
 

--- a/test/WaveOps/WaveActiveSum.int16.test
+++ b/test/WaveOps/WaveActiveSum.int16.test
@@ -323,16 +323,16 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Vulkan && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang && DirectX
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.int32.test
+++ b/test/WaveOps/WaveActiveSum.int32.test
@@ -321,16 +321,16 @@ DescriptorSets:
 
 
 # Bug https://github.com/llvm/offload-test-suite/issues/393
-# XFAIL: Metal
+
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Vulkan && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang && DirectX
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveSum.int64.test
+++ b/test/WaveOps/WaveActiveSum.int64.test
@@ -323,16 +323,16 @@ DescriptorSets:
 # REQUIRES: Int64
 
 # Bug https://github.com/llvm/llvm-project/issues/156775
-# XFAIL: Vulkan && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/524
-# XFAIL: WARP && Clang
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/525
-# XFAIL: NV && Clang && DirectX
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/355
-# XFAIL: Metal
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneAt.16.test
+++ b/test/WaveOps/WaveReadLaneAt.16.test
@@ -137,16 +137,16 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/351
-# XFAIL: Metal
+
 
 # Bug tracked by https://github.com/llvm/offload-test-suite/issues/396
-# XFAIL: DirectX && WARP
+
 
 # Bug https://github.com/llvm/offload-test-suite/issues/532
-# XFAIL: DirectX && QC
+
 
 # REQUIRES: Half, Int16
 

--- a/test/WaveOps/WaveReadLaneAt.32.test
+++ b/test/WaveOps/WaveReadLaneAt.32.test
@@ -173,10 +173,10 @@ DescriptorSets:
 ...
 #--- end
 # Bug https://github.com/llvm/offload-test-suite/issues/351
-# XFAIL: Metal
+
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Gis -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneAt.Bool.test
+++ b/test/WaveOps/WaveReadLaneAt.Bool.test
@@ -59,7 +59,7 @@ DescriptorSets:
 ...
 #--- end
 # Bug https://github.com/llvm/llvm-project/issues/140824
-# XFAIL: Clang
+
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneAt.Float.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Float.64.test
@@ -60,10 +60,10 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/llvm/offload-test-suite/issues/533
-# XFAIL: DirectX && AMD
+
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Double
 

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -101,10 +101,10 @@ DescriptorSets:
 # UNSUPPORTED: Metal
 
 # Bug https://github.com/llvm/offload-test-suite/issues/533
-# XFAIL: DirectX && AMD
+
 
 # Bug https://github.com/llvm/llvm-project/issues/170241
-# XFAIL: Clang && Vulkan
+
 
 # REQUIRES: Int64
 


### PR DESCRIPTION
This PR removes all XFAILs so the test results of previously-XFAILed tests can be seen in this PR's execution tests.

DO NOT MERGE THIS PR.