### PR TITLE
[NFC] Express GPU texture formats via CPUBuffer GpuFormat field

### DIFF
--- a/include/API/FormatConversion.h
+++ b/include/API/FormatConversion.h
@@ -80,13 +80,6 @@ inline llvm::Expected<Format> toFormat(DataFormat Format, int Channels) {
       return Format::RGBA32Float;
     }
     break;
-  case DataFormat::Depth32:
-    // D32FloatS8Uint is not expressible as DataFormat + Channels because the
-    // stencil component is uint8, not a second Depth32 channel. Once the
-    // pipeline uses Format directly, this limitation goes away.
-    if (Channels == 1)
-      return Format::D32Float;
-    break;
   case DataFormat::UInt64:
     // Only 1 and 2 channels of 64-bit integers are supported.
     switch (Channels) {

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -107,7 +107,6 @@ enum class DataFormat {
   Float16,
   Float32,
   Float64,
-  Depth32,
   Bool,
 };
 
@@ -198,7 +197,6 @@ static inline uint32_t getFormatSize(DataFormat Format) {
   case DataFormat::UInt32:
   case DataFormat::Int32:
   case DataFormat::Float32:
-  case DataFormat::Depth32:
   case DataFormat::Bool:
     return 4;
   case DataFormat::Hex64:
@@ -216,6 +214,11 @@ struct CPUBuffer {
   int Channels;
   int Stride;
   uint32_t ArraySize;
+  // When set, names the GPU texture format directly (e.g. D32Float) instead of
+  // inferring it from DataFormat + Channels via toFormat(). This lets depth
+  // buffers and other special formats be expressed without extending
+  // DataFormat.
+  std::optional<offloadtest::Format> GpuFormat;
   // Data can contain one block of data for a singular resource
   // or multiple blocks for a resource array.
   llvm::SmallVector<std::unique_ptr<char[]>> Data;
@@ -931,7 +934,6 @@ template <> struct ScalarEnumerationTraits<offloadtest::DataFormat> {
     ENUM_CASE(Float16);
     ENUM_CASE(Float32);
     ENUM_CASE(Float64);
-    ENUM_CASE(Depth32);
     ENUM_CASE(Bool);
 #undef ENUM_CASE
   }

--- a/include/Support/Pipeline.h
+++ b/include/Support/Pipeline.h
@@ -218,7 +218,7 @@ struct CPUBuffer {
   // inferring it from DataFormat + Channels via toFormat(). This lets depth
   // buffers and other special formats be expressed without extending
   // DataFormat.
-  std::optional<offloadtest::Format> GpuFormat;
+  std::optional<offloadtest::Format> GPUFormat;
   // Data can contain one block of data for a singular resource
   // or multiple blocks for a resource array.
   llvm::SmallVector<std::unique_ptr<char[]>> Data;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2560,8 +2560,8 @@ public:
                                          "supported for DirectX textures.");
 
         auto FormatOrErr =
-            R.BufferPtr->GpuFormat
-                ? llvm::Expected<Format>(*R.BufferPtr->GpuFormat)
+            R.BufferPtr->GPUFormat
+                ? llvm::Expected<Format>(*R.BufferPtr->GPUFormat)
                 : toFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
         if (!FormatOrErr)
           return FormatOrErr.takeError();

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2565,7 +2565,6 @@ public:
                 : toFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
         if (!FormatOrErr)
           return FormatOrErr.takeError();
-        const Format Fmt = *FormatOrErr;
 
         LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
@@ -2576,7 +2575,7 @@ public:
         CreateDesc.Usage = TextureUsage::Sampled;
         if (R.Kind == ResourceKind::RWTexture2D)
           CreateDesc.Usage |= TextureUsage::Storage;
-        CreateDesc.Fmt = Fmt;
+        CreateDesc.Fmt = *FormatOrErr;
         CreateDesc.Width = R.BufferPtr->OutputProps.Width;
         CreateDesc.Height = R.BufferPtr->OutputProps.Height;
         CreateDesc.MipLevels = 1;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -2559,9 +2559,13 @@ public:
                                          "Multiple mip levels are not yet "
                                          "supported for DirectX textures.");
 
-        auto FormatOrErr = toFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
+        auto FormatOrErr =
+            R.BufferPtr->GpuFormat
+                ? llvm::Expected<Format>(*R.BufferPtr->GpuFormat)
+                : toFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
         if (!FormatOrErr)
           return FormatOrErr.takeError();
+        const Format Fmt = *FormatOrErr;
 
         LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
@@ -2572,7 +2576,7 @@ public:
         CreateDesc.Usage = TextureUsage::Sampled;
         if (R.Kind == ResourceKind::RWTexture2D)
           CreateDesc.Usage |= TextureUsage::Storage;
-        CreateDesc.Fmt = *FormatOrErr;
+        CreateDesc.Fmt = Fmt;
         CreateDesc.Width = R.BufferPtr->OutputProps.Width;
         CreateDesc.Height = R.BufferPtr->OutputProps.Height;
         CreateDesc.MipLevels = 1;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -3391,14 +3391,14 @@ public:
   llvm::Expected<ResourceRef> createImage(Resource &R, BufferRef &Host,
                                           int UsageOverride = 0) {
     const offloadtest::CPUBuffer &B = *R.BufferPtr;
-    const bool IsDepth = B.GpuFormat.has_value() && isDepthFormat(*B.GpuFormat);
+    const bool IsDepth = B.GPUFormat.has_value() && isDepthFormat(*B.GPUFormat);
     if (IsDepth && R.isReadWrite())
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Image memory allocation failed.");
     VkImageCreateInfo ImageCreateInfo = {};
     ImageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     ImageCreateInfo.imageType = getVKImageType(R.Kind);
-    ImageCreateInfo.format = B.GpuFormat ? getVulkanFormat(*B.GpuFormat)
+    ImageCreateInfo.format = B.GPUFormat ? getVulkanFormat(*B.GPUFormat)
                                          : getVKFormat(B.Format, B.Channels);
     ImageCreateInfo.mipLevels = B.OutputProps.MipLevels;
     ImageCreateInfo.arrayLayers = 1;
@@ -3821,14 +3821,14 @@ public:
           ViewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
           ViewCreateInfo.viewType = getImageViewType(R.Kind);
           ViewCreateInfo.format =
-              R.BufferPtr->GpuFormat
-                  ? getVulkanFormat(*R.BufferPtr->GpuFormat)
+              R.BufferPtr->GPUFormat
+                  ? getVulkanFormat(*R.BufferPtr->GPUFormat)
                   : getVKFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
           ViewCreateInfo.components = {
               VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
               VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
           ViewCreateInfo.subresourceRange.aspectMask =
-              (R.BufferPtr->GpuFormat && isDepthFormat(*R.BufferPtr->GpuFormat))
+              (R.BufferPtr->GPUFormat && isDepthFormat(*R.BufferPtr->GPUFormat))
                   ? VK_IMAGE_ASPECT_DEPTH_BIT
                   : VK_IMAGE_ASPECT_COLOR_BIT;
           ViewCreateInfo.subresourceRange.baseMipLevel = 0;
@@ -4087,7 +4087,7 @@ public:
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
       const bool IsDepth =
-          B.GpuFormat.has_value() && isDepthFormat(*B.GpuFormat);
+          B.GPUFormat.has_value() && isDepthFormat(*B.GPUFormat);
       llvm::SmallVector<VkBufferImageCopy> Regions;
       uint64_t CurrentOffset = 0;
       for (int I = 0; I < B.OutputProps.MipLevels; ++I) {
@@ -4233,7 +4233,7 @@ public:
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
       const bool IsDepth =
-          B.GpuFormat.has_value() && isDepthFormat(*B.GpuFormat);
+          B.GPUFormat.has_value() && isDepthFormat(*B.GPUFormat);
       VkImageSubresourceRange SubRange = {};
       SubRange.aspectMask =
           IsDepth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -60,10 +60,6 @@ static VkFormat getVKFormat(DataFormat Format, int Channels) {
     VKFormats(UINT, 64) break;
   case DataFormat::Float64:
     VKFormats(SFLOAT, 64) break;
-  case DataFormat::Depth32:
-    if (Channels != 1)
-      llvm_unreachable("Depth32 format only supports a single channel.");
-    return VK_FORMAT_D32_SFLOAT;
   default:
     llvm_unreachable("Unsupported Resource format specified");
   }
@@ -3395,13 +3391,15 @@ public:
   llvm::Expected<ResourceRef> createImage(Resource &R, BufferRef &Host,
                                           int UsageOverride = 0) {
     const offloadtest::CPUBuffer &B = *R.BufferPtr;
-    if (B.Format == DataFormat::Depth32 && R.isReadWrite())
+    const bool IsDepth = B.GpuFormat.has_value() && isDepthFormat(*B.GpuFormat);
+    if (IsDepth && R.isReadWrite())
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Image memory allocation failed.");
     VkImageCreateInfo ImageCreateInfo = {};
     ImageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     ImageCreateInfo.imageType = getVKImageType(R.Kind);
-    ImageCreateInfo.format = getVKFormat(B.Format, B.Channels);
+    ImageCreateInfo.format = B.GpuFormat ? getVulkanFormat(*B.GpuFormat)
+                                         : getVKFormat(B.Format, B.Channels);
     ImageCreateInfo.mipLevels = B.OutputProps.MipLevels;
     ImageCreateInfo.arrayLayers = 1;
     ImageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -3823,12 +3821,14 @@ public:
           ViewCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
           ViewCreateInfo.viewType = getImageViewType(R.Kind);
           ViewCreateInfo.format =
-              getVKFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
+              R.BufferPtr->GpuFormat
+                  ? getVulkanFormat(*R.BufferPtr->GpuFormat)
+                  : getVKFormat(R.BufferPtr->Format, R.BufferPtr->Channels);
           ViewCreateInfo.components = {
               VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G,
               VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
           ViewCreateInfo.subresourceRange.aspectMask =
-              R.BufferPtr->Format == DataFormat::Depth32
+              (R.BufferPtr->GpuFormat && isDepthFormat(*R.BufferPtr->GpuFormat))
                   ? VK_IMAGE_ASPECT_DEPTH_BIT
                   : VK_IMAGE_ASPECT_COLOR_BIT;
           ViewCreateInfo.subresourceRange.baseMipLevel = 0;
@@ -4086,13 +4086,14 @@ public:
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
+      const bool IsDepth =
+          B.GpuFormat.has_value() && isDepthFormat(*B.GpuFormat);
       llvm::SmallVector<VkBufferImageCopy> Regions;
       uint64_t CurrentOffset = 0;
       for (int I = 0; I < B.OutputProps.MipLevels; ++I) {
         VkBufferImageCopy Region = {};
-        Region.imageSubresource.aspectMask = B.Format == DataFormat::Depth32
-                                                 ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                                 : VK_IMAGE_ASPECT_COLOR_BIT;
+        Region.imageSubresource.aspectMask =
+            IsDepth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
         Region.imageSubresource.mipLevel = I;
         Region.imageSubresource.baseArrayLayer = 0;
         Region.imageSubresource.layerCount = 1;
@@ -4110,9 +4111,8 @@ public:
       }
 
       VkImageSubresourceRange SubRange = {};
-      SubRange.aspectMask = B.Format == DataFormat::Depth32
-                                ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                : VK_IMAGE_ASPECT_COLOR_BIT;
+      SubRange.aspectMask =
+          IsDepth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
       SubRange.baseMipLevel = 0;
       SubRange.levelCount = B.OutputProps.MipLevels;
       SubRange.layerCount = 1;
@@ -4232,10 +4232,11 @@ public:
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
+      const bool IsDepth =
+          B.GpuFormat.has_value() && isDepthFormat(*B.GpuFormat);
       VkImageSubresourceRange SubRange = {};
-      SubRange.aspectMask = B.Format == DataFormat::Depth32
-                                ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                : VK_IMAGE_ASPECT_COLOR_BIT;
+      SubRange.aspectMask =
+          IsDepth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
       SubRange.baseMipLevel = 0;
       SubRange.levelCount = B.OutputProps.MipLevels;
       SubRange.layerCount = 1;
@@ -4262,9 +4263,8 @@ public:
       uint64_t CurrentOffset = 0;
       for (int I = 0; I < B.OutputProps.MipLevels; ++I) {
         VkBufferImageCopy Region = {};
-        Region.imageSubresource.aspectMask = B.Format == DataFormat::Depth32
-                                                 ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                                 : VK_IMAGE_ASPECT_COLOR_BIT;
+        Region.imageSubresource.aspectMask =
+            IsDepth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
         Region.imageSubresource.mipLevel = I;
         Region.imageSubresource.baseArrayLayer = 0;
         Region.imageSubresource.layerCount = 1;

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -3391,7 +3391,7 @@ public:
   llvm::Expected<ResourceRef> createImage(Resource &R, BufferRef &Host,
                                           int UsageOverride = 0) {
     const offloadtest::CPUBuffer &B = *R.BufferPtr;
-    const bool IsDepth = B.GPUFormat.has_value() && isDepthFormat(*B.GPUFormat);
+    const bool IsDepth = B.GPUFormat && isDepthFormat(*B.GPUFormat);
     if (IsDepth && R.isReadWrite())
       return llvm::createStringError(std::errc::invalid_argument,
                                      "Image memory allocation failed.");
@@ -4086,8 +4086,7 @@ public:
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
-      const bool IsDepth =
-          B.GPUFormat.has_value() && isDepthFormat(*B.GPUFormat);
+      const bool IsDepth = B.GPUFormat && isDepthFormat(*B.GPUFormat);
       llvm::SmallVector<VkBufferImageCopy> Regions;
       uint64_t CurrentOffset = 0;
       for (int I = 0; I < B.OutputProps.MipLevels; ++I) {
@@ -4232,8 +4231,7 @@ public:
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
-      const bool IsDepth =
-          B.GPUFormat.has_value() && isDepthFormat(*B.GPUFormat);
+      const bool IsDepth = B.GPUFormat && isDepthFormat(*B.GPUFormat);
       VkImageSubresourceRange SubRange = {};
       SubRange.aspectMask =
           IsDepth ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;

--- a/lib/Support/Check.cpp
+++ b/lib/Support/Check.cpp
@@ -228,7 +228,6 @@ testBufferFloat(std::function<bool(const T &, const T &)> ComparisonFn,
   case offloadtest::DataFormat::Float64:
     return testAllArray<double>(ComparisonFn, B1, B2);
   case offloadtest::DataFormat::Float32:
-  case offloadtest::DataFormat::Depth32:
     return testAllArray<float>(ComparisonFn, B1, B2);
   case offloadtest::DataFormat::Float16: {
     return testAllArray<uint16_t>(ComparisonFn, B1, B2);
@@ -250,8 +249,7 @@ static bool testBufferFloatEpsilon(offloadtest::CPUBuffer *B1,
     };
     return testBufferFloat<double>(Fn, B1, B2);
   }
-  case offloadtest::DataFormat::Float32:
-  case offloadtest::DataFormat::Depth32: {
+  case offloadtest::DataFormat::Float32: {
     auto Fn = [Epsilon, DM](const float &FS, const float &FR) {
       return compareFloatEpsilon(FS, FR, (float)Epsilon, DM);
     };
@@ -280,8 +278,7 @@ static bool testBufferFloatULP(offloadtest::CPUBuffer *B1,
     };
     return testBufferFloat<double>(Fn, B1, B2);
   }
-  case offloadtest::DataFormat::Float32:
-  case offloadtest::DataFormat::Depth32: {
+  case offloadtest::DataFormat::Float32: {
     auto Fn = [ULPT, DM](const float &FS, const float &FR) {
       return compareFloatULP(FS, FR, ULPT, DM);
     };
@@ -379,7 +376,6 @@ static const std::string getBufferStr(offloadtest::CPUBuffer *B) {
   case DF::Float16:
     return formatBuffer<llvm::yaml::Hex16>(B); // assuming no native float16
   case DF::Float32:
-  case DF::Depth32:
     return formatBuffer<float>(B);
   case DF::Float64:
     return formatBuffer<double>(B);

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -363,6 +363,7 @@ void MappingTraits<offloadtest::CPUBuffer>::mapping(IO &I,
   I.mapRequired("Name", B.Name);
   I.mapRequired("Format", B.Format);
   I.mapOptional("Channels", B.Channels, 1);
+  I.mapOptional("GpuFormat", B.GpuFormat);
   I.mapOptional("Stride", B.Stride, 0);
   I.mapOptional("ArraySize", B.ArraySize, 1);
   setCounters(I, B);
@@ -405,9 +406,6 @@ void MappingTraits<offloadtest::CPUBuffer>::mapping(IO &I,
     setData<llvm::yaml::Hex16>(I, B); // assuming no native float16
     break;
   case DF::Float32:
-    setData<float>(I, B);
-    break;
-  case DF::Depth32:
     setData<float>(I, B);
     break;
   case DF::Float64:
@@ -527,8 +525,6 @@ void MappingTraits<offloadtest::PushConstantValue>::mapping(
   case DF::Float16:
     return setData<llvm::yaml::Hex16>(I, B); // assuming no native float16
   case DF::Float32:
-    return setData<float>(I, B);
-  case DF::Depth32:
     return setData<float>(I, B);
   case DF::Float64:
     return setData<double>(I, B);

--- a/lib/Support/Pipeline.cpp
+++ b/lib/Support/Pipeline.cpp
@@ -363,7 +363,7 @@ void MappingTraits<offloadtest::CPUBuffer>::mapping(IO &I,
   I.mapRequired("Name", B.Name);
   I.mapRequired("Format", B.Format);
   I.mapOptional("Channels", B.Channels, 1);
-  I.mapOptional("GpuFormat", B.GpuFormat);
+  I.mapOptional("GPUFormat", B.GPUFormat);
   I.mapOptional("Stride", B.Stride, 0);
   I.mapOptional("ArraySize", B.ArraySize, 1);
   setCounters(I, B);

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -69,7 +69,7 @@ Shaders:
 Buffers:
   - Name: Tex
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) R=0.2

--- a/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.GatherCmp.test.yaml
@@ -68,7 +68,8 @@ Shaders:
 
 Buffers:
   - Name: Tex
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) R=0.2

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -107,7 +107,8 @@ Shaders:
 
 Buffers:
   - Name: Tex
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) -> 0.2

--- a/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
+++ b/test/Feature/Textures/Texture2D.SampleCmp.test.yaml
@@ -108,7 +108,7 @@ Shaders:
 Buffers:
   - Name: Tex
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) -> 0.2

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GatherCmp.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GatherCmp.test.yaml
@@ -49,7 +49,8 @@ Shaders:
 
 Buffers:
   - Name: SampledTexLess
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) R=0.2
@@ -58,7 +59,8 @@ Buffers:
             0.8 ] # (1,1) R=0.8
 
   - Name: SampledTexGreater
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,
@@ -67,7 +69,8 @@ Buffers:
             0.8 ]
 
   - Name: SampledTexRepeat
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GatherCmp.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.GatherCmp.test.yaml
@@ -50,7 +50,7 @@ Shaders:
 Buffers:
   - Name: SampledTexLess
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) R=0.2
@@ -60,7 +60,7 @@ Buffers:
 
   - Name: SampledTexGreater
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,
@@ -70,7 +70,7 @@ Buffers:
 
   - Name: SampledTexRepeat
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.SampleCmp.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.SampleCmp.test.yaml
@@ -88,7 +88,8 @@ Shaders:
 
 Buffers:
   - Name: SampledTexLess
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) -> 0.2
@@ -97,7 +98,8 @@ Buffers:
             0.8 ] # (1,1) -> 0.8
 
   - Name: SampledTexGreater
-    Format: Depth32
+    Format: Float32
+    GpuFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,

--- a/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.SampleCmp.test.yaml
+++ b/test/Feature/Vk.SampledTextures/Vk.SampledTexture2D/Vk.SampledTexture2D.SampleCmp.test.yaml
@@ -89,7 +89,7 @@ Shaders:
 Buffers:
   - Name: SampledTexLess
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,  # (0,0) -> 0.2
@@ -99,7 +99,7 @@ Buffers:
 
   - Name: SampledTexGreater
     Format: Float32
-    GpuFormat: D32Float
+    GPUFormat: D32Float
     Channels: 1
     OutputProps: { Width: 2, Height: 2, Depth: 1 }
     Data: [ 0.2,


### PR DESCRIPTION
Resolves #1326.

Replaces the special-cased `DataFormat::Depth32` with an optional `CPUBuffer::GpuFormat` field that names a GPU `Format` directly. The Vulkan backend now derives the image/view format and depth/color aspect from `GpuFormat`; the `Check` path drops the unused `Depth32` cases. Existing `GatherCmp`/`SampleCmp` depth tests migrate from `Format: Depth32` to `Format: Float32` + `GpuFormat: D32Float`.

See #1326 for full motivation.
