### PR TITLE
Adding lavapipe to FMA XFAIL

### DIFF
--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -92,7 +92,7 @@ DescriptorSets:
         Binding: 3
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/1026
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8330
 # XFAIL: Intel && Vulkan && DXC
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8330

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -98,7 +98,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8330
 # XFAIL: Lavapipe && DXC
 
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -98,6 +98,7 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8330
 # XFAIL: Lavapipe && DXC
 
+
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -94,6 +94,8 @@ DescriptorSets:
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1026
 # XFAIL: Intel && Vulkan && DXC
+
+# Bug https://github.com/llvm/offload-test-suite/issues/1026
 # XFAIL: Lavapipe && DXC
 
 

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -98,7 +98,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/1026
 # XFAIL: Lavapipe && DXC
 
-
 # REQUIRES: Double
 # RUN: split-file %s %t
 # RUN: %dxc_target -Gis -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -95,7 +95,7 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/1026
 # XFAIL: Intel && Vulkan && DXC
 
-# Bug https://github.com/llvm/offload-test-suite/issues/1026
+# Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8330
 # XFAIL: Lavapipe && DXC
 
 # REQUIRES: Double

--- a/test/Feature/HLSLLib/fma.test
+++ b/test/Feature/HLSLLib/fma.test
@@ -56,8 +56,8 @@ Buffers:
     # last two rows: 2^-26, -(2^-26), 2^-104, -3
 Results:
   - Result: Result
-    Rule: BufferFloatEpsilon 
-    Epsilon: 0.0001
+    Rule: BufferFloatULP
+    ULPT: 1
     Actual: Out
     Expected: Expected
 DescriptorSets:
@@ -94,6 +94,8 @@ DescriptorSets:
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1026
 # XFAIL: Intel && Vulkan && DXC
+# XFAIL: Lavapipe && DXC
+
 
 # REQUIRES: Double
 # RUN: split-file %s %t


### PR DESCRIPTION
This patch, rolls back a previous relaxation of FMA, so it keeps the ULP check and XFAIL due to an existing DXC issue.