### PR TITLE
Add InterlockedCompareStore tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedCompareStore.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.32.test
@@ -1,0 +1,174 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareStore on groupshared destinations, int and uint,
+// with 256 concurrent threads. Three checks:
+//
+//   1. Per-thread private slots: a mismatching compare must not store, a
+//      following matching compare must.
+//   2. Contended locations: every thread proposes the same new value, so
+//      only one store can take effect and the final value is deterministic,
+//      for both a matching and a never-matching compare.
+//   3. Counter: thread `i` only advances `Counter` from `i` to `i+1`, so
+//      exactly one thread can succeed per step. All threads make 256
+//      attempts with a barrier per iteration, so every step is taken and
+//      the counter must end at 256. Monotonicity: the counter only moves
+//      up, so each thread's fresh re-read must never be below the previous
+//      one. A racy implementation can write back a stale value, which both
+//      lowers the counter and leaves steps untaken.
+
+RWStructuredBuffer<uint> OutMono : register(u0);
+RWStructuredBuffer<uint> OutSlots : register(u1);
+RWStructuredBuffer<int> OutFinal : register(u2);
+
+groupshared uint Counter;        // stepped from 0 to 256, one thread per step
+groupshared int  SlotsInt[256];  // per-thread slots, signed
+groupshared uint SlotsUInt[256]; // per-thread slots, unsigned
+groupshared int  MatchInt;       // contended, compare matches
+groupshared int  NoMatchInt;     // contended, compare never matches
+groupshared uint MatchUInt;      // contended, compare matches
+groupshared uint NoMatchUInt;    // contended, compare never matches
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  SlotsInt[GTID.x] = (int)GTID.x - 128;
+  SlotsUInt[GTID.x] = GTID.x + 7u;
+  if (GTID.x == 0) {
+    Counter = 0u;
+    MatchInt = -5;
+    NoMatchInt = 77;
+    MatchUInt = 0xFFFFFFFFu;
+    NoMatchUInt = 5u;
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // Per-thread private slots, signed.
+  InterlockedCompareStore(SlotsInt[GTID.x], (int)GTID.x - 127, 0);
+  InterlockedCompareStore(SlotsInt[GTID.x], (int)GTID.x - 128,
+                          (int)GTID.x + 1000);
+
+  // Per-thread private slots, unsigned.
+  InterlockedCompareStore(SlotsUInt[GTID.x], GTID.x + 8u, 0u);
+  InterlockedCompareStore(SlotsUInt[GTID.x], GTID.x + 7u, GTID.x + 2000u);
+
+  OutSlots[GTID.x] = (SlotsInt[GTID.x] == (int)GTID.x + 1000 &&
+                      SlotsUInt[GTID.x] == GTID.x + 2000u) ? 1u : 0u;
+
+  // Contended locations.
+  InterlockedCompareStore(MatchInt, -5, 42);
+  InterlockedCompareStore(NoMatchInt, 78, -1);
+  InterlockedCompareStore(MatchUInt, 0xFFFFFFFFu, 1234u);
+  InterlockedCompareStore(NoMatchUInt, 6u, 999u);
+
+  // Counter, checked for monotonic non-decrease.
+  uint CompareValue = GTID.x;
+  uint NewValue = GTID.x + 1u;
+  uint Prev = 0u;
+  uint Mono = 1u;
+  for (uint I = 0; I < 256; ++I) {
+    InterlockedCompareStore(Counter, CompareValue, NewValue);
+    GroupMemoryBarrierWithGroupSync();
+    uint Cur = Counter;
+    if (Cur < Prev)
+      Mono = 0u;
+    Prev = Cur;
+  }
+  OutMono[GTID.x] = Mono;
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = (int)Counter;     // 256
+    OutFinal[1] = MatchInt;         // 42
+    OutFinal[2] = NoMatchInt;       // 77
+    OutFinal[3] = (int)MatchUInt;   // 1234
+    OutFinal[4] = (int)NoMatchUInt; // 5
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMono
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedOnes
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutSlots
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutFinal
+    Format: Int32
+    Stride: 4
+    FillSize: 20
+  - Name: ExpectedFinal
+    Format: Int32
+    Stride: 4
+    Data: [ 256, 42, 77, 1234, 5 ]
+Results:
+  - Result: TestMono
+    Rule: BufferExact
+    Actual: OutMono
+    Expected: ExpectedOnes
+  - Result: TestSlots
+    Rule: BufferExact
+    Actual: OutSlots
+    Expected: ExpectedOnes
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMono
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutSlots
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99128
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareStore.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.int64.test
@@ -1,0 +1,180 @@
+#--- source.hlsl
+
+// The 64-bit version of InterlockedCompareStore.32.test; see that file for
+// a description of the checks. Additionally covers compares that differ
+// from the destination only in the upper 32 bits, which must not store.
+
+RWStructuredBuffer<uint> OutMono : register(u0);
+RWStructuredBuffer<uint> OutSlots : register(u1);
+RWStructuredBuffer<int64_t> OutFinal : register(u2);
+
+groupshared uint64_t Counter;        // stepped 0 to 256, one thread per step
+groupshared int64_t  SlotsInt[256];  // per-thread slots, signed
+groupshared uint64_t SlotsUInt[256]; // per-thread slots, unsigned
+groupshared int64_t  MatchInt;       // contended, compare matches
+groupshared int64_t  NoMatchInt;     // contended, compare never matches
+groupshared uint64_t MatchUInt;      // contended, compare matches
+groupshared uint64_t NoMatchUInt;    // contended, compare never matches
+groupshared uint64_t LargeCounter;   // value exercising the upper 32 bits
+groupshared uint64_t HighBits;       // compare differing only in high bits
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  SlotsInt[GTID.x] = (int64_t)GTID.x - 128;
+  SlotsUInt[GTID.x] = 0x100000000ull + (uint64_t)GTID.x;
+  if (GTID.x == 0) {
+    Counter = 0;
+    MatchInt = -5;
+    NoMatchInt = 77;
+    MatchUInt = 0xFFFFFFFFFFFFFFFFull;
+    NoMatchUInt = 5;
+    LargeCounter = 0x100000000ull;  // 2^32
+    HighBits = 0x100000007ull;      // 2^32 + 7
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // Per-thread private slots, signed.
+  InterlockedCompareStore(SlotsInt[GTID.x], (int64_t)GTID.x - 127, 0);
+  InterlockedCompareStore(SlotsInt[GTID.x], (int64_t)GTID.x - 128,
+                          (int64_t)GTID.x + 1000);
+
+  // Per-thread private slots, unsigned. Fail due to mismatching
+  // bits in upper 32 bits, pass later.
+  InterlockedCompareStore(SlotsUInt[GTID.x], (uint64_t)GTID.x, 0);
+  InterlockedCompareStore(SlotsUInt[GTID.x], 0x100000000ull + (uint64_t)GTID.x,
+                          (uint64_t)GTID.x + 2000);
+
+  OutSlots[GTID.x] = (SlotsInt[GTID.x] == (int64_t)GTID.x + 1000 &&
+                      SlotsUInt[GTID.x] == (uint64_t)GTID.x + 2000) ? 1u : 0u;
+
+  // Contended locations.
+  InterlockedCompareStore(MatchInt, -5, 42);
+  InterlockedCompareStore(NoMatchInt, 78, -1);
+  InterlockedCompareStore(MatchUInt, 0xFFFFFFFFFFFFFFFFull, 1234);
+  InterlockedCompareStore(NoMatchUInt, 6, 999);
+  // Compare and stored value exercise the upper 32 bits.
+  InterlockedCompareStore(LargeCounter, 0x100000000ull, 0x1000000000ull);
+  // The compare matches the low 32 bits only, so it must not store.
+  InterlockedCompareStore(HighBits, 7, 0);
+
+  // Counter, checked for monotonic non-decrease.
+  uint64_t CompareValue = (uint64_t)GTID.x;
+  uint64_t NewValue = (uint64_t)GTID.x + 1;
+  uint64_t Prev = 0;
+  uint Mono = 1u;
+  for (uint I = 0; I < 256; ++I) {
+    InterlockedCompareStore(Counter, CompareValue, NewValue);
+    GroupMemoryBarrierWithGroupSync();
+    uint64_t Cur = Counter;
+    if (Cur < Prev)
+      Mono = 0u;
+    Prev = Cur;
+  }
+  OutMono[GTID.x] = Mono;
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = (int64_t)Counter;      // 256
+    OutFinal[1] = MatchInt;              // 42
+    OutFinal[2] = NoMatchInt;            // 77
+    OutFinal[3] = (int64_t)MatchUInt;    // 1234
+    OutFinal[4] = (int64_t)NoMatchUInt;  // 5
+    OutFinal[5] = (int64_t)LargeCounter; // 2^36 = 68719476736
+    OutFinal[6] = (int64_t)HighBits;     // 2^32 + 7 = 4294967303
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMono
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedOnes
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutSlots
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutFinal
+    Format: Int64
+    Stride: 8
+    FillSize: 56
+  - Name: ExpectedFinal
+    Format: Int64
+    Stride: 8
+    Data: [ 256, 42, 77, 1234, 5, 68719476736, 4294967303 ]
+
+Results:
+  - Result: TestMono
+    Rule: BufferExact
+    Actual: OutMono
+    Expected: ExpectedOnes
+  - Result: TestSlots
+    Rule: BufferExact
+    Actual: OutSlots
+    Expected: ExpectedOnes
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMono
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutSlots
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99128
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: DXC && Metal
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
@@ -252,6 +252,9 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1418
+# UNIMPLEMENTED: WARP && DXC
+
 # RUN: split-file %s %t
-# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
@@ -1,0 +1,257 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareStore on the HLSL-legal non-groupshared
+// (resource) destination types.
+//
+// Every destination covers both a matching and a never-matching compare.
+// RWStructuredBuffer and RWByteAddressBuffer additionally run the stepped
+// counter and monotonicity check described in
+// InterlockedCompareStore.32.test.
+
+RWStructuredBuffer<uint> SBufU : register(u0);
+RWStructuredBuffer<int>  SBufI : register(u1);
+RWBuffer<uint>           TBufU : register(u2);
+RWTexture2D<uint>        Tex2D : register(u3);
+RWByteAddressBuffer      BABuf : register(u4);
+
+RWStructuredBuffer<uint> OutMonoSBufU : register(u5);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u6);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0u;             // stepped counter
+    SBufU[1] = 9u;             // compare never matches
+    SBufI[0] = 1000;           // compare matches
+    SBufI[1] = 55;             // compare never matches
+    TBufU[0] = 0xFFFFFFFFu;    // compare matches
+    TBufU[1] = 9u;             // compare never matches
+    Tex2D[uint2(0, 0)] = 0xFFFFFFFFu; // compare matches
+    Tex2D[uint2(1, 0)] = 9u;          // compare never matches
+    BABuf.Store(0, 0xFFFFFFFFu); // compare matches
+    BABuf.Store(4, 44u);         // compare never matches
+    BABuf.Store(8, 0u);          // stepped counter
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint>: the compare never matches.
+  InterlockedCompareStore(SBufU[1], 10u, 0u);
+
+  // RWStructuredBuffer<int> (signed).
+  InterlockedCompareStore(SBufI[0], 1000, -31);
+  InterlockedCompareStore(SBufI[1], 56, -1);
+
+  // RWBuffer<uint> (typed buffer UAV).
+  InterlockedCompareStore(TBufU[0], 0xFFFFFFFFu, 77u);
+  InterlockedCompareStore(TBufU[1], 10u, 0u);
+
+  // RWTexture2D<uint> (typed texture UAV).
+  InterlockedCompareStore(Tex2D[uint2(0, 0)], 0xFFFFFFFFu, 88u);
+  InterlockedCompareStore(Tex2D[uint2(1, 0)], 10u, 0u);
+
+  // RWByteAddressBuffer method form.
+  BABuf.InterlockedCompareStore(0, 0xFFFFFFFFu, 123u);
+  BABuf.InterlockedCompareStore(4, 45u, 0u);
+
+  // Stepped counters on the structured buffer and the byte address buffer,
+  // both checked for monotonic non-decrease.
+  uint CompareValue = GTID.x;
+  uint NewValue = GTID.x + 1u;
+  uint PrevS = 0u, PrevB = 0u;
+  uint MonoS = 1u, MonoB = 1u;
+  for (uint I = 0; I < 256; ++I) {
+    InterlockedCompareStore(SBufU[0], CompareValue, NewValue);
+    BABuf.InterlockedCompareStore(8, CompareValue, NewValue);
+    DeviceMemoryBarrierWithGroupSync();
+    uint CurS = SBufU[0];
+    uint CurB = BABuf.Load(8);
+    if (CurS < PrevS)
+      MonoS = 0u;
+    if (CurB < PrevB)
+      MonoB = 0u;
+    PrevS = CurS;
+    PrevB = CurB;
+  }
+  OutMonoSBufU[GTID.x] = MonoS;
+  OutMonoBABuf[GTID.x] = MonoB;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedSBufU
+    Format: UInt32
+    Stride: 4
+    Data: [ 256, 9 ]
+  - Name: SBufI
+    Format: Int32
+    Stride: 4
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedSBufI
+    Format: Int32
+    Stride: 4
+    Data: [ -31, 55 ]
+  - Name: TBufU
+    Format: UInt32
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufU
+    Format: UInt32
+    Channels: 1
+    Data: [ 77, 9 ]
+  - Name: Tex2D
+    Format: UInt32
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+    OutputProps:
+      Height: 1
+      Width: 2
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: UInt32
+    Channels: 1
+    Data: [ 88, 9 ]
+    OutputProps:
+      Height: 1
+      Width: 2
+      Depth: 1
+  - Name: BABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 12
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedBABuf
+    Format: UInt32
+    Stride: 4
+    Data: [ 123, 44, 256 ]
+  - Name: OutMonoSBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufU
+    Rule: BufferExact
+    Actual: OutMonoSBufU
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: OutMonoSBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99128
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
@@ -253,7 +253,7 @@ DescriptorSets:
 # XFAIL: Metal && DXC
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
-# UNIMPLEMENTED: WARP && DXC
+# UNSUPPORTED: WARP && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.int64.test
@@ -199,7 +199,7 @@ DescriptorSets:
 # XFAIL: Vulkan && DXC
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
-# UNIMPLEMENTED: WARP && DXC
+# UNSUPPORTED: WARP && DXC
 
 # REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.int64.test
@@ -1,0 +1,204 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareStore on the HLSL-legal 64-bit non-groupshared
+// (resource) destination types. 64-bit UAV atomics require Shader Model
+// 6.6.
+//
+// 64-bit atomics on typed RWBuffer / RWTexture need the optional
+// "AtomicInt64OnTypedResource" capability and are covered separately by
+// InterlockedCompareStore.resources.typed.int64.test.
+//
+// Every destination covers both a matching and a never-matching compare
+// (one of which differs only in the upper 32 bits), plus the stepped
+// counter and monotonicity check described in InterlockedCompareStore.32.test.
+
+RWStructuredBuffer<uint64_t> SBufU : register(u0);
+RWStructuredBuffer<int64_t>  SBufI : register(u1);
+RWByteAddressBuffer          BABuf : register(u2);
+
+RWStructuredBuffer<uint> OutMonoSBufU : register(u3);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u4);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufU[0] = 0;                 // stepped counter
+    SBufU[1] = 0x100000007ull;    // compare matches the low 32 bits only
+    SBufI[0] = 1000;              // compare matches
+    SBufI[1] = 55;                // compare never matches
+    BABuf.Store<uint64_t>(0, 0xFFFFFFFFFFFFFFFFull); // compare matches
+    BABuf.Store<uint64_t>(8, 44);                    // compare never matches
+    BABuf.Store<uint64_t>(16, 0);                    // stepped counter
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<uint64_t>: the compare differs only in the upper 32
+  // bits, so it must not store.
+  InterlockedCompareStore(SBufU[1], (uint64_t)7, (uint64_t)0);
+
+  // RWStructuredBuffer<int64_t> (signed).
+  InterlockedCompareStore(SBufI[0], (int64_t)1000, (int64_t)-63);
+  InterlockedCompareStore(SBufI[1], (int64_t)56, (int64_t)-1);
+
+  // RWByteAddressBuffer 64-bit method form.
+  BABuf.InterlockedCompareStore64(0, 0xFFFFFFFFFFFFFFFFull, (uint64_t)123);
+  BABuf.InterlockedCompareStore64(8, (uint64_t)45, (uint64_t)0);
+
+  // Stepped counters on the structured buffer and the byte address buffer,
+  // both checked for monotonic non-decrease.
+  uint64_t CompareValue = (uint64_t)GTID.x;
+  uint64_t NewValue = (uint64_t)GTID.x + 1;
+  uint64_t PrevS = 0, PrevB = 0;
+  uint MonoS = 1u, MonoB = 1u;
+  for (uint I = 0; I < 256; ++I) {
+    InterlockedCompareStore(SBufU[0], CompareValue, NewValue);
+    BABuf.InterlockedCompareStore64(16, CompareValue, NewValue);
+    DeviceMemoryBarrierWithGroupSync();
+    uint64_t CurS = SBufU[0];
+    uint64_t CurB = BABuf.Load<uint64_t>(16);
+    if (CurS < PrevS)
+      MonoS = 0u;
+    if (CurB < PrevB)
+      MonoB = 0u;
+    PrevS = CurS;
+    PrevB = CurB;
+  }
+  OutMonoSBufU[GTID.x] = MonoS;
+  OutMonoBABuf[GTID.x] = MonoB;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufU
+    Format: UInt64
+    Stride: 8
+    FillSize: 16
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedSBufU
+    Format: UInt64
+    Stride: 8
+    Data: [ 256, 4294967303 ]
+  - Name: SBufI
+    Format: Int64
+    Stride: 8
+    FillSize: 16
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedSBufI
+    Format: Int64
+    Stride: 8
+    Data: [ -63, 55 ]
+  - Name: BABuf
+    Format: UInt64
+    Stride: 8
+    FillSize: 24
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedBABuf
+    Format: UInt64
+    Stride: 8
+    Data: [ 123, 44, 256 ]
+  - Name: OutMonoSBufU
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+Results:
+  - Result: TestSBufU
+    Rule: BufferExact
+    Actual: SBufU
+    Expected: ExpectedSBufU
+  - Result: TestSBufI
+    Rule: BufferExact
+    Actual: SBufI
+    Expected: ExpectedSBufI
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufU
+    Rule: BufferExact
+    Actual: OutMonoSBufU
+    Expected: ExpectedMono
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: SBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: SBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutMonoSBufU
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99128
+# XFAIL: Clang
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
+# XFAIL: Vulkan && DXC
+
+# REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.int64.test
@@ -198,6 +198,9 @@ DescriptorSets:
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
 # XFAIL: Vulkan && DXC
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1418
+# UNIMPLEMENTED: WARP && DXC
+
 # REQUIRES: Int64 && SM_6_6 && (!Vulkan || VulkanInt64BufferAtomics)
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.typed.int64.test
@@ -144,6 +144,9 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99128
 # XFAIL: Clang
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1418
+# UNIMPLEMENTED: WARP && DXC
+
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.typed.int64.test
@@ -145,7 +145,7 @@ DescriptorSets:
 # XFAIL: Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
-# UNIMPLEMENTED: WARP && DXC
+# UNSUPPORTED: WARP && DXC
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.typed.int64.test
@@ -1,0 +1,150 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareStore on 64-bit typed RWBuffer resources.
+// 64-bit atomics on typed UAVs are an optional Shader Model 6.6 capability,
+// surfaced to lit as `Int64TypedResourceAtomics`:
+//
+//   * DirectX: cap AtomicInt64OnTypedResourceSupported
+//   * Vulkan:  shaderImageInt64Atomics, from the (non-core) extension
+//              VK_EXT_shader_image_atomic_int64. RWBuffer<T> maps to a
+//              SPIR-V image (not an SSBO), so RWBuffer atomics need this
+//              image-atomics extension, not shaderBufferInt64Atomics.
+//
+// Covers RWBuffer<uint64_t> and RWBuffer<int64_t> with a matching and a
+// never-matching compare (one differing only in the upper 32 bits), plus
+// the stepped counter and monotonicity check described in
+// InterlockedCompareStore.32.test.
+
+RWBuffer<uint64_t> TBufU : register(u0);
+RWBuffer<int64_t>  TBufI : register(u1);
+
+RWStructuredBuffer<uint> OutMonoTBufI : register(u2);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    TBufU[0] = 0xFFFFFFFFFFFFFFFFull; // compare matches
+    TBufU[1] = 0x100000007ull;        // compare matches the low 32 bits only
+    TBufI[0] = 0;                     // stepped counter
+    TBufI[1] = 55;                    // compare never matches
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWBuffer<uint64_t>: the second compare differs only in the upper 32
+  // bits, so it must not store.
+  InterlockedCompareStore(TBufU[0], 0xFFFFFFFFFFFFFFFFull, (uint64_t)77);
+  InterlockedCompareStore(TBufU[1], (uint64_t)7, (uint64_t)0);
+
+  // RWBuffer<int64_t> (signed): the compare never matches.
+  InterlockedCompareStore(TBufI[1], (int64_t)56, (int64_t)-1);
+
+  // Stepped counter, checked for monotonic non-decrease.
+  int64_t CompareValue = (int64_t)GTID.x;
+  int64_t NewValue = (int64_t)GTID.x + 1;
+  int64_t Prev = 0;
+  uint Mono = 1u;
+  for (uint I = 0; I < 256; ++I) {
+    InterlockedCompareStore(TBufI[0], CompareValue, NewValue);
+    DeviceMemoryBarrierWithGroupSync();
+    int64_t Cur = TBufI[0];
+    if (Cur < Prev)
+      Mono = 0u;
+    Prev = Cur;
+  }
+  OutMonoTBufI[GTID.x] = Mono;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: TBufU
+    Format: UInt64
+    Channels: 1
+    FillSize: 16
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufU
+    Format: UInt64
+    Channels: 1
+    Data: [ 77, 4294967303 ]
+  - Name: TBufI
+    Format: Int64
+    Channels: 1
+    FillSize: 16
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufI
+    Format: Int64
+    Channels: 1
+    Data: [ 256, 55 ]
+  - Name: OutMonoTBufI
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedMono
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+Results:
+  - Result: TestTBufU
+    Rule: BufferExact
+    Actual: TBufU
+    Expected: ExpectedTBufU
+  - Result: TestTBufI
+    Rule: BufferExact
+    Actual: TBufI
+    Expected: ExpectedTBufI
+  - Result: TestMonoTBufI
+    Rule: BufferExact
+    Actual: OutMonoTBufI
+    Expected: ExpectedMono
+DescriptorSets:
+  - Resources:
+    - Name: TBufU
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufI
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutMonoTBufI
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99128
+# XFAIL: Clang
+
+# REQUIRES: Int64TypedResourceAtomics && SM_6_6
+# RUN: split-file %s %t
+# RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR adds tests for InterlockedCompareStore.
It includes monotonicity tests, and tests across resource member methods and standalone functions.

Assisted by: Github Copilot
Fixes: https://github.com/llvm/offload-test-suite/issues/852