### PR TITLE
[SPIRV][Vulkan] Enable the Atan2 tests

### DIFF
--- a/test/Feature/HLSLLib/atan2_mat.16.test
+++ b/test/Feature/HLSLLib/atan2_mat.16.test
@@ -166,9 +166,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/186864
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/atan2_mat.32.test
+++ b/test/Feature/HLSLLib/atan2_mat.32.test
@@ -145,9 +145,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/186864
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Now that PR https://github.com/llvm/llvm-project/pull/213785 has merged we can enable these tests.