### PR TITLE
Introduce global timeout for individual lit tests.

### DIFF
--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -424,31 +424,11 @@ jobs:
           arch: arm64
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - name: Install lit, pyyaml and psutil
-        # The test runner needs lit, pyyaml and psutil. We install from the
-        # requirements.txt that the build job ships inside the install
-        # prefix (test/CMakeLists.txt installs it under the
-        # offload-test-suite component). That keeps a single source of
-        # truth for pinned versions and avoids drift between this step
-        # and OffloadTest/test/requirements.txt.
-        #
+      - name: Install python dependencies
+        # The test runner needs lit, pyyaml and psutil.
         # We invoke pip explicitly here instead of relying on
         # setup-python's `pip-install:` input, which was observed to
         # silently no-op on our self-hosted Windows runners.
-        #
-        # When pip can't write to the interpreter's system site-packages
-        # (e.g. on self-hosted Windows runners running as NetworkService,
-        # which can't write under C:\Program Files\Python313; or on a
-        # POSIX host where the system Python is owned by root), pip
-        # falls back to a --user install. The console script wrappers
-        # (e.g. lit.exe on Windows, lit on POSIX) then land in the
-        # user-scheme scripts dir, which is NOT on PATH by default:
-        #   - Windows: %APPDATA%\Python\PythonXY\Scripts
-        #   - Linux:   ~/.local/bin
-        #   - macOS:   ~/Library/Python/X.Y/bin
-        # We compute that dir from sysconfig (portable across all three
-        # platforms) and prepend it to PATH for all subsequent steps so
-        # `lit` resolves correctly regardless of where pip put it.
         shell: bash
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -191,8 +191,13 @@ jobs:
         run: echo TEST_CLANG=On >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          pip-install: -r ${{ github.workspace }}/OffloadTest/test/requirements.txt
+      - name: Install lit, pyyaml and psutil
+        # setup-python's `pip-install:` input silently no-ops on our
+        # self-hosted Windows runners, and lit needs psutil to not abort.
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r "$GITHUB_WORKSPACE/OffloadTest/test/requirements.txt"
       - name: Build DXC
         run: |
             cd DXC
@@ -424,8 +429,8 @@ jobs:
           arch: arm64
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - name: Install lit and pyyaml
-        # The test runner needs only lit + pyyaml. We install from the
+      - name: Install lit, pyyaml and psutil
+        # The test runner needs lit, pyyaml and psutil. We install from the
         # requirements.txt that the build job ships inside the install
         # prefix (test/CMakeLists.txt installs it under the
         # offload-test-suite component). That keeps a single source of

--- a/.github/workflows/build-and-test-callable.yaml
+++ b/.github/workflows/build-and-test-callable.yaml
@@ -191,13 +191,8 @@ jobs:
         run: echo TEST_CLANG=On >> $GITHUB_OUTPUT
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - name: Install lit, pyyaml and psutil
-        # setup-python's `pip-install:` input silently no-ops on our
-        # self-hosted Windows runners, and lit needs psutil to not abort.
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r "$GITHUB_WORKSPACE/OffloadTest/test/requirements.txt"
+        with:
+          pip-install: -r ${{ github.workspace }}/OffloadTest/test/requirements.txt
       - name: Build DXC
         run: |
             cd DXC

--- a/.github/workflows/test-callable.yaml
+++ b/.github/workflows/test-callable.yaml
@@ -129,13 +129,8 @@ jobs:
           arch: arm64
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      - name: Install lit, pyyaml and psutil
-        # setup-python's `pip-install:` input silently no-ops on our
-        # self-hosted Windows runners, and lit needs psutil to not abort.
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r "$GITHUB_WORKSPACE/OffloadTest/test/requirements.txt"
+        with:
+          pip-install: -r ${{ github.workspace }}/OffloadTest/test/requirements.txt
       # OffloadTest is the top-level CMake project here; LLVM, Clang and
       # clang-tidy come from the downloaded install prefix.
       - name: Build offload test suite (standalone)

--- a/.github/workflows/test-callable.yaml
+++ b/.github/workflows/test-callable.yaml
@@ -129,8 +129,13 @@ jobs:
           arch: arm64
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          pip-install: -r ${{ github.workspace }}/OffloadTest/test/requirements.txt
+      - name: Install lit, pyyaml and psutil
+        # setup-python's `pip-install:` input silently no-ops on our
+        # self-hosted Windows runners, and lit needs psutil to not abort.
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r "$GITHUB_WORKSPACE/OffloadTest/test/requirements.txt"
       # OffloadTest is the top-level CMake project here; LLVM, Clang and
       # clang-tidy come from the downloaded install prefix.
       - name: Build offload test suite (standalone)

--- a/docs/offload-distribution.md
+++ b/docs/offload-distribution.md
@@ -109,7 +109,7 @@ tar cf dxc-prefix.tar  -C <dxc-dist>       .
 ## Test runner prerequisites
 
 - Python 3.6+
-- `pip install lit pyyaml`
+- `pip install lit pyyaml psutil`
 - GPU drivers appropriate for the suite (D3D12 / Vulkan / Metal).
 - The two extracted prefixes from the build runner.
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -30,8 +30,8 @@ config.suffixes = [".test", ".yaml"]
 # directories.
 config.excludes = ["Inputs", "CMakeLists.txt", "README.txt", "LICENSE.txt"]
 
-# Cap each test at 5 minutes so a GPU hang fails one test instead of wedging
-# the suite. Requires psutil; --timeout=N still overrides.
+# Cap each test so a GPU hang fails one test instead of getting the suite
+# stuck. Requires psutil; --timeout=N still overrides.
 if lit_config.maxIndividualTestTime == 0:
     lit_config.maxIndividualTestTime = 300
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -30,6 +30,11 @@ config.suffixes = [".test", ".yaml"]
 # directories.
 config.excludes = ["Inputs", "CMakeLists.txt", "README.txt", "LICENSE.txt"]
 
+# Cap each test at 5 minutes so a GPU hang fails one test instead of wedging
+# the suite. Requires psutil; --timeout=N still overrides.
+if lit_config.maxIndividualTestTime == 0:
+    lit_config.maxIndividualTestTime = 300
+
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,4 @@
 pyyaml==6.0.2
 lit==18.1.8
+# Required by lit to enforce maxIndividualTestTime in test/lit.cfg.py.
+psutil==7.2.2

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,3 @@
 pyyaml==6.0.2
 lit==18.1.8
-# Required by lit to enforce maxIndividualTestTime in test/lit.cfg.py.
 psutil==7.2.2


### PR DESCRIPTION
This issue: https://github.com/llvm/offload-test-suite/issues/1418
Created the need to introduce a timeout for tests.
The github actions runners will currently spin up to 6 hours on hung tests, which steals resources from other PRs.
This PR introduces a global max timeout limit of 5 minutes per individual test.
Lit should also usefully report TIMEOUT as a test result status if this time limit is hit.

Assisted by: Github Copilot
Fixes: https://github.com/llvm/offload-test-suite/issues/1420