### PR TITLE
Fix validation workflow build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,20 @@ if (OFFLOADTEST_BUILT_STANDALONE)
   set(CMAKE_CXX_STANDARD_REQUIRED YES)
   set(CMAKE_CXX_EXTENSIONS NO)
 
+  # In-tree builds get these from LLVM's HandleLLVMOptions.cmake. Standalone
+  # builds do not include it, so repeat the CRT deprecation opt-outs here or
+  # MSVC flags calls like fopen as deprecated.
+  if (MSVC)
+    add_compile_definitions(
+      _CRT_SECURE_NO_DEPRECATE
+      _CRT_SECURE_NO_WARNINGS
+      _CRT_NONSTDC_NO_DEPRECATE
+      _CRT_NONSTDC_NO_WARNINGS
+      _SCL_SECURE_NO_DEPRECATE
+      _SCL_SECURE_NO_WARNINGS
+      )
+  endif()
+
   # They are used as destination of target generators.
   set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
   set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib${LLVM_LIBDIR_SUFFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,26 +15,26 @@ if (OFFLOADTEST_BUILT_STANDALONE)
 
   include(AddLLVM)
 
+  if (NOT LLVM_MAIN_SRC_DIR OR NOT EXISTS "${LLVM_MAIN_SRC_DIR}")
+    message(FATAL_ERROR "LLVM_MAIN_SRC_DIR is not set or invalid. Please set it to the root of the LLVM source tree.")
+  endif()
+
+  # HandleLLVMOptions caches LLVM_THIRD_PARTY_DIR against the top-level source
+  # directory, which is this project when standalone, so point it at LLVM's
+  # copy first.
+  set(LLVM_THIRD_PARTY_DIR "${LLVM_MAIN_SRC_DIR}/../third-party" CACHE STRING
+      "Directory containing third party software used by LLVM (e.g. googletest)")
+
+  # Apply the same compile settings that in-tree builds get,
+  # including deprecation opt-outs and assertions.
+  include(HandleLLVMOptions)
+
   find_package(Python3 ${LLVM_MINIMUM_PYTHON_VERSION} REQUIRED
     COMPONENTS Interpreter)
 
   set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
   set(CMAKE_CXX_STANDARD_REQUIRED YES)
   set(CMAKE_CXX_EXTENSIONS NO)
-
-  # In-tree builds get these from LLVM's HandleLLVMOptions.cmake. Standalone
-  # builds do not include it, so repeat the CRT deprecation opt-outs here or
-  # MSVC flags calls like fopen as deprecated.
-  if (MSVC)
-    add_compile_definitions(
-      _CRT_SECURE_NO_DEPRECATE
-      _CRT_SECURE_NO_WARNINGS
-      _CRT_NONSTDC_NO_DEPRECATE
-      _CRT_NONSTDC_NO_WARNINGS
-      _SCL_SECURE_NO_DEPRECATE
-      _SCL_SECURE_NO_WARNINGS
-      )
-  endif()
 
   # They are used as destination of target generators.
   set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
@@ -50,10 +50,6 @@ if (OFFLOADTEST_BUILT_STANDALONE)
   include_directories(${LLVM_INCLUDE_DIRS})
   link_directories("${LLVM_LIBRARY_DIR}")
 
-  if (NOT LLVM_MAIN_SRC_DIR OR NOT EXISTS "${LLVM_MAIN_SRC_DIR}")
-    message(FATAL_ERROR "LLVM_MAIN_SRC_DIR is not set or invalid. Please set it to the root of the LLVM source tree.")
-  endif()
-
   # Seek installed Lit.
   find_program(LLVM_LIT
                 NAMES llvm-lit lit.py lit
@@ -67,9 +63,6 @@ if (OFFLOADTEST_BUILT_STANDALONE)
   endif()
   endif()
 
-  if (NOT LLVM_THIRD_PARTY_DIR)
-    set(LLVM_THIRD_PARTY_DIR "${LLVM_MAIN_SRC_DIR}/../third-party")
-  endif()
   if (NOT TARGET llvm_gtest)
       add_subdirectory(${LLVM_THIRD_PARTY_DIR}/unittest ${CMAKE_CURRENT_BINARY_DIR}/third-party/unittest)
   endif()

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -806,7 +806,7 @@ class DXComputeEncoder : public offloadtest::ComputeEncoder {
   }
 
 public:
-  DXComputeEncoder(DXCommandBuffer &CB)
+  explicit DXComputeEncoder(DXCommandBuffer &CB)
       : ComputeEncoder(GPUAPI::DirectX), CB(CB) {}
 
   ~DXComputeEncoder() override { endEncoding(); }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -1030,7 +1030,7 @@ class VKComputeEncoder : public offloadtest::ComputeEncoder {
   }
 
 public:
-  VKComputeEncoder(VulkanCommandBuffer &CB)
+  explicit VKComputeEncoder(VulkanCommandBuffer &CB)
       : ComputeEncoder(GPUAPI::Vulkan), CB(CB) {}
 
   ~VKComputeEncoder() override { endEncoding(); }


### PR DESCRIPTION
This PR fixes some errors in the validation workflow that were discovered when manually dispatching it.
Has to do with the fact that building the offloadtest suite standalone makes things slightly different than building through the legacy in-tree path.

For one, we are missing `HandleLLVMOptions`, which opts out of errors for deprecated code like `fopen`.

Another issue is that we are using upstream clang-tidy instead of whatever clang-tidy is built in to the build machines.
Latest clang-tidy will warn on declaring constructors with one argument without the `explicit` keyword, and will treat the warning as an error.
This PR resolves both issues, to turn the validation workflow back to green.


Assisted by: Github Copilot
Addresses: https://github.com/llvm/offload-test-suite/issues/1425
Link to a successful test run of the validation pipeline: https://github.com/llvm/offload-test-suite/actions/runs/31058724325/job/92481811942