### PR TITLE
Amend matrix_bool_* tests

### DIFF
--- a/test/Basic/Matrix/matrix_bool_and_operator.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator.test
@@ -87,35 +87,35 @@ Results:
 DescriptorSets:
   - Resources:
     - Name: In
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
       VulkanBinding:
         Binding: 0
     - Name: AndTrueTrueOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
     - Name: AndTrueFalseOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
     - Name: AndTrueMixOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
     - Name: AndTrueMix2Out
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0

--- a/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
@@ -86,35 +86,35 @@ Results:
 DescriptorSets:
   - Resources:
     - Name: In
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
       VulkanBinding:
         Binding: 0
     - Name: AndTrueTrueOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
     - Name: AndTrueFalseOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
     - Name: AndTrueMixOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
     - Name: AndTrueMix2Out
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0

--- a/test/Basic/Matrix/matrix_bool_or_operator.test
+++ b/test/Basic/Matrix/matrix_bool_or_operator.test
@@ -100,42 +100,42 @@ Results:
 DescriptorSets:
   - Resources:
     - Name: In
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
       VulkanBinding:
         Binding: 0
     - Name: OrTrueTrueOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
     - Name: OrTrueFalseOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
     - Name: OrTrueMixOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
     - Name: OrTrueMix2Out
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
     - Name: OrFalseFalseOut
-      Kind: RWBuffer
+      Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 5
         Space: 0


### PR DESCRIPTION
The matrix_bool_* tests had a mis-match between the buffer type used in the HLSL (RWStructuredBuffer) and the buffer Kind used in the bindings (RWBuffer). When run on Linux using the AMD driver this led to incorrect accesses to the buffer resulting in incorrect results values.

This commit simply changes the Kind to RWStructuredBuffer to match the HLSL buffers.

Fixes #1423