### PR TITLE
Remove Clang XFAILs from `pow` matrix tests

### DIFF
--- a/test/Feature/HLSLLib/pow_mat.16.test
+++ b/test/Feature/HLSLLib/pow_mat.16.test
@@ -123,9 +123,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184513
-# XFAIL: Clang
-
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/pow_mat.32.test
+++ b/test/Feature/HLSLLib/pow_mat.32.test
@@ -107,9 +107,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184513
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The `pow` matrix implementation has been merged, so these now pass.