### PR TITLE
Enable typed int64 resource tests on interlocked offload tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -128,9 +128,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
 # XFAIL: Intel && Clang && Vulkan
 
-# Bug: https://github.com/llvm/llvm-project/issues/116148
-# XFAIL: Clang 
-
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
@@ -143,9 +143,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
 # XFAIL: Intel && Clang && Vulkan
 
-# Bug: https://github.com/llvm/llvm-project/issues/116148
-# XFAIL: Clang && DirectX
-
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This PR enables some typed resource int64 tests after https://github.com/llvm/llvm-project/pull/212869 merged.
These tests should now begin to pass, so we should remove the XFAILs.