### PR TITLE
Update GroupMemoryBarrierWithGroupSync xfail

### DIFF
--- a/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
+++ b/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
@@ -81,9 +81,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/955
 # XFAIL: Vulkan && Intel && Clang
 
-# Bug: https://github.com/llvm/llvm-project/issues/197557
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
+++ b/test/WaveOps/GroupMemoryBarrierWithGroupSync.test
@@ -78,9 +78,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/683
 # XFAIL: Vulkan && KosmicKrisp && Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/955
-# XFAIL: Vulkan && Intel && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The XFail can be removed since the linked issue has been resolved.
This test is now passing.