### PR TITLE
Update XFAILs of `matrix_bool_*` tests

### DIFF
--- a/test/Basic/Matrix/matrix_bool_and_operator.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator.test
@@ -127,15 +127,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/703
-# XFAIL: Clang && NV && Vulkan
-
-# Bug https://github.com/llvm/offload-test-suite/issues/704
-# XFAIL: Clang && Intel && Vulkan
-
-# Bug https://github.com/llvm/offload-test-suite/issues/1341
-# XFAIL: Intel-Gen-Current && DirectX
-
 # Note: Metal does not support boolean matrix types. For
 # Vulkan KosmicKrisp and MoltenVK the output is always False.
 # UNSUPPORTED: Metal || KosmicKrisp || MoltenVK

--- a/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
@@ -126,6 +126,9 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/696
+# XFAIL: Clang && Intel-Gen-Current && DirectX
+
 # Note: Metal does not support boolean matrix types. For
 # Vulkan KosmicKrisp and MoltenVK the output is always False.
 # UNSUPPORTED: Metal || KosmicKrisp || MoltenVK

--- a/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
@@ -126,15 +126,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/703
-# XFAIL: Clang && NV && Vulkan
-
-# Bug https://github.com/llvm/offload-test-suite/issues/704
-# XFAIL: Clang && Intel && Vulkan
-
-# Bug: https://github.com/llvm/offload-test-suite/issues/696
-# XFAIL: Intel-Gen-Current && DirectX
-
 # Note: Metal does not support boolean matrix types. For
 # Vulkan KosmicKrisp and MoltenVK the output is always False.
 # UNSUPPORTED: Metal || KosmicKrisp || MoltenVK

--- a/test/Basic/Matrix/matrix_bool_or_operator.test
+++ b/test/Basic/Matrix/matrix_bool_or_operator.test
@@ -147,15 +147,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Bug https://github.com/llvm/offload-test-suite/issues/703
-# XFAIL: Clang && NV && Vulkan
-
-# Bug https://github.com/llvm/offload-test-suite/issues/704
-# XFAIL: Clang && Intel && Vulkan
-
-# Bug https://github.com/llvm/offload-test-suite/issues/1341
-# XFAIL: Intel-Gen-Current && DirectX
-
 # Note: Metal does not support boolean matrix types. For
 # Vulkan KosmicKrisp and MoltenVK the output is always False.
 # UNSUPPORTED: Metal || KosmicKrisp || MoltenVK


### PR DESCRIPTION
Updates XFAILs for `matrix_bool_*` tests that are now XPASSing.
<img width="2167" height="553" alt="image" src="https://github.com/user-attachments/assets/c714550e-dd27-4967-b8dd-e499f20ad9f4" />
