### PR TITLE
Add pack_, pack_clamp_ and unpack_ tests

### DIFF
--- a/test/Feature/HLSLLib/pack_clamp_s8.16.test
+++ b/test/Feature/HLSLLib/pack_clamp_s8.16.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<uint16_t> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int16_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  int8_t4_packed packedVals = pack_clamp_s8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: Int16
+    Stride: 2
+    Data: [ -129, -128, 127, 128 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 2139062400 ] # Values clamped to -128 -128 127 127
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99229
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -enable-16bit-types -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_clamp_s8.32.test
+++ b/test/Feature/HLSLLib/pack_clamp_s8.32.test
@@ -1,0 +1,66 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int32_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  int8_t4_packed packedVals = pack_clamp_s8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: Int32
+    Stride: 4
+    Data: [ -129, -128, 127, 128 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 2139062400 ] # Values clamped to -128 -128 127 127
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99229
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_clamp_u8.16.test
+++ b/test/Feature/HLSLLib/pack_clamp_u8.16.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<uint16_t> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int16_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  uint8_t4_packed packedVals = pack_clamp_u8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: Int16
+    Stride: 2
+    Data: [ -1, 0, 255, 256 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 4294901760 ] # Values clamped to 0 0 255 255
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99230
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -enable-16bit-types -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_clamp_u8.32.test
+++ b/test/Feature/HLSLLib/pack_clamp_u8.32.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int32_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  uint8_t4_packed packedVals = pack_clamp_u8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: Int32
+    Stride: 4
+    Data: [ -1, 0, 255, 256 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 4294901760 ] # Values clamped to 0 0 255 255
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99230
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_s8.16.test
+++ b/test/Feature/HLSLLib/pack_s8.16.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<int16_t> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int16_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  int8_t4_packed packedVals = pack_s8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: Int16
+    Stride: 2
+    Data: [ -256, -127, 127, 128 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 2155839744 ] # Values packed to 0 -127 127 -128
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99227
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -enable-16bit-types -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_s8.32.test
+++ b/test/Feature/HLSLLib/pack_s8.32.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<int> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int32_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  int8_t4_packed packedVals = pack_s8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: Int32
+    Stride: 4
+    Data: [ -256, -127, 127, 128 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 2155839744 ] # Values packed to 0 -127 127 -128
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99227
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_u8.16.test
+++ b/test/Feature/HLSLLib/pack_u8.16.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<uint16_t> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  uint16_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  uint8_t4_packed packedVals = pack_u8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: UInt16
+    Stride: 2
+    Data: [ 256, 255, 0, 1 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 16842496 ] # Values packed to 0 255 0 1
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99228
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -enable-16bit-types -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/pack_u8.32.test
+++ b/test/Feature/HLSLLib/pack_u8.32.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  uint32_t4 unpackedVals;
+  unpackedVals.x = In[0];
+  unpackedVals.y = In[1];
+  unpackedVals.z = In[2];
+  unpackedVals.w = In[3];
+  uint8_t4_packed packedVals = pack_u8(unpackedVals);
+  Out[0] = packedVals;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: UInt32
+    Stride: 4
+    Data: [ 256, 255, 0, 1 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 16842496 ] # Values packed to 0 255 0 1
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99228
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/unpack_s8s16.test
+++ b/test/Feature/HLSLLib/unpack_s8s16.test
@@ -1,0 +1,65 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<int16_t> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int8_t4_packed packedVals = In[0];
+  int16_t4 unpackedVals = unpack_s8s16(packedVals);
+  Out[0] = unpackedVals.x;
+  Out[1] = unpackedVals.y;
+  Out[2] = unpackedVals.z;
+  Out[3] = unpackedVals.w;
+}
+
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: UInt32
+    Stride: 4
+    Data: [ 2155839744 ]
+  - Name: Out
+    Format: Int16
+    Stride: 2
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: Int16
+    Stride: 2
+    Data: [ 0, -127, 127, -128 ]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99222
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -enable-16bit-types -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/unpack_s8s32.test
+++ b/test/Feature/HLSLLib/unpack_s8s32.test
@@ -1,0 +1,64 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<int> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  int8_t4_packed packedVals = In[0];
+  int32_t4 unpackedVals = unpack_s8s32(packedVals);
+  Out[0] = unpackedVals.x;
+  Out[1] = unpackedVals.y;
+  Out[2] = unpackedVals.z;
+  Out[3] = unpackedVals.w;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: UInt32
+    Stride: 4
+    Data: [ 2155839744 ]
+  - Name: Out
+    Format: Int32
+    Stride: 4
+    FillSize: 16
+  - Name: ExpectedOut
+    Format: Int32
+    Stride: 4
+    Data: [ 0, -127, 127, -128 ]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99224
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/unpack_u8u16.test
+++ b/test/Feature/HLSLLib/unpack_u8u16.test
@@ -1,0 +1,64 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<uint16_t> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  uint8_t4_packed packedVals = In[0];
+  uint16_t4 unpackedVals = unpack_u8u16(packedVals);
+  Out[0] = unpackedVals.x;
+  Out[1] = unpackedVals.y;
+  Out[2] = unpackedVals.z;
+  Out[3] = unpackedVals.w;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: UInt32
+    Stride: 4
+    Data: [ 16842496 ]
+  - Name: Out
+    Format: UInt16
+    Stride: 2
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt16
+    Stride: 2
+    Data: [ 0, 255, 0, 1 ]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99223
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -enable-16bit-types -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/unpack_u8u32.test
+++ b/test/Feature/HLSLLib/unpack_u8u32.test
@@ -1,0 +1,64 @@
+#--- source.hlsl
+
+StructuredBuffer<uint> In : register(t0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(1, 1, 1)]
+void main() {
+  uint8_t4_packed packedVals = In[0];
+  uint32_t4 unpackedVals = unpack_u8u32(packedVals);
+  Out[0] = unpackedVals.x;
+  Out[1] = unpackedVals.y;
+  Out[2] = unpackedVals.z;
+  Out[3] = unpackedVals.w;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: In
+    Format: UInt32
+    Stride: 4
+    Data: [ 16842496 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 16
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 0, 255, 0, 1 ]
+Results:
+  - Result: Test1
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: In
+      Kind: StructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99226
+# XFAIL: Clang
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds tests covering a matrix of signed, unsigned, 16, and 32 bit pack, pack_clamp, and unpack intrinsics.

As the intrinsics/tests are all simple in nature and related in function, I've packaged together all of the pack and unpack variants.

Closes #863, #864, #865, #866, #891, #892, #893, #894, 