### PR TITLE
Migrate NVIDIA SKU over to frequent build path

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -13,6 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # windows-nvidia runs on the frequent builder instead; see
+  # Exec-Tests-Windows-NVIDIA below and docs/frequent-builder.md.
   Exec-Tests-Windows:
     permissions:
       contents: read
@@ -21,11 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-intel, windows-nvidia]
+        SKU: [windows-intel]
         TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
-        exclude:
-          - { SKU: windows-nvidia, TestTarget: check-hlsl-vk }
-          - { SKU: windows-nvidia, TestTarget: check-hlsl-clang-vk }
 
     uses: ./.github/workflows/build-and-test-callable.yaml
     with:
@@ -35,6 +34,39 @@ jobs:
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+
+  # Resolved once per PR so every frequent-builder cell tests the same
+  # toolchain. See docs/frequent-builder.md.
+  Resolve-Frequent-Builds:
+    permissions:
+      contents: read
+      actions: read
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable-default-tests') }}
+    uses: ./.github/workflows/resolve-frequent-builds.yaml
+
+  # Consumes prebuilt LLVM/DXC rather than compiling them per cell, so these
+  # cells take no generic build-pool capacity.
+  Exec-Tests-Windows-NVIDIA:
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable-default-tests') }}
+    needs: Resolve-Frequent-Builds
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
+
+    uses: ./.github/workflows/test-callable.yaml
+    with:
+      OS: windows
+      Arch: x64
+      SKU: windows-nvidia
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      LlvmRunId: ${{ needs.Resolve-Frequent-Builds.outputs.LlvmRunId }}
+      DxcRunId: ${{ needs.Resolve-Frequent-Builds.outputs.DxcRunId }}
 
   Exec-Tests-Windows-Warp:
     permissions:

--- a/.github/workflows/resolve-frequent-builds.yaml
+++ b/.github/workflows/resolve-frequent-builds.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   resolve:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/resolve-frequent-builds.yaml
+++ b/.github/workflows/resolve-frequent-builds.yaml
@@ -1,0 +1,77 @@
+name: Resolve Frequent Builds
+
+permissions:
+  contents: read
+
+# Picks the frequent-build runs whose artifacts a set of test cells consume.
+# Shared by pr-matrix.yaml and validate-frequent-builder.yaml so every caller
+# resolves identically. See docs/frequent-builder.md.
+
+on:
+  workflow_call:
+    inputs:
+      LlvmRunId:
+        description: 'Pin a frequent-build-llvm.yaml run. Blank resolves the newest successful run on main.'
+        required: false
+        default: ''
+        type: string
+      DxcRunId:
+        description: 'Pin a frequent-build-dxc.yaml run. Blank resolves the newest successful run on main.'
+        required: false
+        default: ''
+        type: string
+    outputs:
+      LlvmRunId:
+        description: 'Resolved frequent-build-llvm.yaml run ID.'
+        value: ${{ jobs.resolve.outputs.LlvmRunId }}
+      DxcRunId:
+        description: 'Resolved frequent-build-dxc.yaml run ID.'
+        value: ${{ jobs.resolve.outputs.DxcRunId }}
+
+jobs:
+  resolve:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      LlvmRunId: ${{ steps.resolve.outputs.llvm_run_id }}
+      DxcRunId: ${{ steps.resolve.outputs.dxc_run_id }}
+    steps:
+      - name: Resolve frequent build runs
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PINNED_LLVM: ${{ inputs.LlvmRunId }}
+          PINNED_DXC: ${{ inputs.DxcRunId }}
+        run: |
+          set -euo pipefail
+          # Trust only schedule/dispatch runs from this repo: a fork PR
+          # branch named `main` also matches `branch=main`.
+          resolve() {
+            gh api \
+              "/repos/$REPO/actions/workflows/$1/runs?status=success&branch=main&per_page=50" \
+              --jq '[.workflow_runs[]
+                     | select((.event == "schedule" or .event == "workflow_dispatch")
+                              and .head_repository.full_name == env.REPO)][0].id // empty'
+          }
+          llvm_run_id="$PINNED_LLVM"
+          if [ -z "$llvm_run_id" ]; then
+            llvm_run_id=$(resolve frequent-build-llvm.yaml)
+          fi
+          if [ -z "$llvm_run_id" ]; then
+            echo "::error::No successful frequent-build-llvm.yaml run on main. Dispatch it once to seed the artifacts."
+            exit 1
+          fi
+          dxc_run_id="$PINNED_DXC"
+          if [ -z "$dxc_run_id" ]; then
+            dxc_run_id=$(resolve frequent-build-dxc.yaml)
+          fi
+          if [ -z "$dxc_run_id" ]; then
+            echo "::error::No successful frequent-build-dxc.yaml run on main. Dispatch it once to seed the artifacts."
+            exit 1
+          fi
+          echo "Using LLVM run $llvm_run_id and DXC run $dxc_run_id"
+          echo "llvm_run_id=$llvm_run_id" >> "$GITHUB_OUTPUT"
+          echo "dxc_run_id=$dxc_run_id"   >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-callable.yaml
+++ b/.github/workflows/test-callable.yaml
@@ -5,9 +5,9 @@ permissions:
 
 # Runs one lit suite on a GPU runner against distributions built by earlier
 # frequent-build-llvm.yaml and frequent-build-dxc.yaml runs, rebuilding the
-# offload-test-suite tools standalone from the PR head. No caller is wired
-# up yet; see the commented-out template in pr-matrix.yaml and
-# docs/frequent-builder.md.
+# offload-test-suite tools standalone from the PR head. Called by
+# pr-matrix.yaml for windows-nvidia and by validate-frequent-builder.yaml;
+# see docs/frequent-builder.md.
 
 on:
   workflow_call:

--- a/.github/workflows/validate-frequent-builder.yaml
+++ b/.github/workflows/validate-frequent-builder.yaml
@@ -91,51 +91,13 @@ on:
 
 jobs:
   Resolve-Frequent-Builds:
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
       actions: read
-    outputs:
-      LlvmRunId: ${{ steps.resolve.outputs.llvm_run_id }}
-      DxcRunId: ${{ steps.resolve.outputs.dxc_run_id }}
-    steps:
-      - name: Resolve frequent build runs
-        id: resolve
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PINNED_LLVM: ${{ inputs.LlvmRunId }}
-          PINNED_DXC: ${{ inputs.DxcRunId }}
-        run: |
-          set -euo pipefail
-          # Trust only schedule/dispatch runs from this repo: a fork PR
-          # branch named `main` also matches `branch=main`.
-          resolve() {
-            gh api \
-              "/repos/$REPO/actions/workflows/$1/runs?status=success&branch=main&per_page=50" \
-              --jq '[.workflow_runs[]
-                     | select((.event == "schedule" or .event == "workflow_dispatch")
-                              and .head_repository.full_name == env.REPO)][0].id // empty'
-          }
-          llvm_run_id="$PINNED_LLVM"
-          if [ -z "$llvm_run_id" ]; then
-            llvm_run_id=$(resolve frequent-build-llvm.yaml)
-          fi
-          if [ -z "$llvm_run_id" ]; then
-            echo "::error::No successful frequent-build-llvm.yaml run on main. Dispatch it once to seed the artifacts."
-            exit 1
-          fi
-          dxc_run_id="$PINNED_DXC"
-          if [ -z "$dxc_run_id" ]; then
-            dxc_run_id=$(resolve frequent-build-dxc.yaml)
-          fi
-          if [ -z "$dxc_run_id" ]; then
-            echo "::error::No successful frequent-build-dxc.yaml run on main. Dispatch it once to seed the artifacts."
-            exit 1
-          fi
-          echo "Using LLVM run $llvm_run_id and DXC run $dxc_run_id"
-          echo "llvm_run_id=$llvm_run_id" >> "$GITHUB_OUTPUT"
-          echo "dxc_run_id=$dxc_run_id"   >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/resolve-frequent-builds.yaml
+    with:
+      LlvmRunId: ${{ inputs.LlvmRunId }}
+      DxcRunId: ${{ inputs.DxcRunId }}
 
   Exec-Test:
     permissions:

--- a/docs/frequent-builder.md
+++ b/docs/frequent-builder.md
@@ -11,6 +11,12 @@ LLVM and DXC are built by two independent schedules:
 
 Test cells consume both through `test-callable.yaml`.
 
+Migration is incremental. Today `pr-matrix.yaml` routes only the
+`windows-nvidia` x64 cells (`check-hlsl-d3d12` and `check-hlsl-clang-d3d12`)
+this way; every other cell still builds its own toolchain via
+`build-and-test-callable.yaml` with `SplitBuild: true`. So "PRs never build
+LLVM or DXC" below describes the end state, not the current one.
+
 The two are separate for **failure isolation**: with a single builder, a
 broken LLVM `main` also withholds the DXC artifact, and vice versa. Split,
 each component ages independently. The cadences follow how fast each
@@ -93,11 +99,12 @@ by `<arch>`.
 
 ### Choosing which build to consume
 
-PR test cells do not hardcode a run. A resolver job queries the API for
-the newest successful run of each schedule and passes the two IDs to every
-cell as `LlvmRunId` and `DxcRunId`, so all cells in a PR test against one
-identical toolchain rather than some cells using one build and some
-another.
+PR test cells do not hardcode a run. `resolve-frequent-builds.yaml` queries
+the API for the newest successful run of each schedule and passes the two
+IDs to every cell as `LlvmRunId` and `DxcRunId`, so all cells in a PR test
+against one identical toolchain rather than some cells using one build and
+some another. It is a reusable workflow so `pr-matrix.yaml` and
+`validate-frequent-builder.yaml` resolve identically.
 
 The resolver accepts only `schedule` and `workflow_dispatch` runs
 originating from this repository, and neither event can be raised from a


### PR DESCRIPTION
The frequent build path has been validated and it is time to slowly migrate existing SKUs over to using the more efficient path.
This PR starts by moving the existing NVIDIA SKU default tests over to the frequent build path.
It sets up a shared resolve workflow that the legacy path and the new frequent build path can both use.

Assisted by: Github Copilot
Addresses: https://github.com/llvm/offload-test-suite/issues/1388