### PR TITLE
Repair failing Interlocked Xor/Or/Add tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -143,9 +143,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99122
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -143,6 +143,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# XFAIL: Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -144,7 +144,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Clang && DirectX
+# XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -125,9 +125,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1402
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1404
-# XFAIL: Intel && Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -123,7 +123,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Clang
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -123,7 +123,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Clang && DirectX
+# XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
@@ -168,7 +168,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: Intel && Clang && Vulkan
+# XFAIL: (Intel || AMD) && Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal

--- a/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
@@ -168,7 +168,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: (Intel || AMD) && Clang && Vulkan
+# XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal

--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -125,8 +125,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: Intel && Clang && Vulkan
+# Bug: https://github.com/llvm/offload-test-suite/issues/1438
+# XFAIL: Clang && Vulkan
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedXor.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.32.test
@@ -195,7 +195,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Clang && DirectX
+# XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedXor.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.32.test
@@ -194,9 +194,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.32.test
@@ -194,6 +194,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# XFAIL: Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -193,7 +193,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: (Intel || AMD) && Clang && Vulkan
+# XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -193,7 +193,7 @@ DescriptorSets:
 #--- end
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: Intel && Clang && Vulkan
+# XFAIL: (Intel || AMD) && Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal

--- a/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
@@ -140,8 +140,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1407
-# XFAIL: Intel && Clang && Vulkan
+# Bug: https://github.com/llvm/offload-test-suite/issues/1438
+# XFAIL: Clang && Vulkan
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t


### PR DESCRIPTION
This PR repairs a few failing InterlockedXor/Or/Add tests.
An issue has been made to track the typed resource tests: https://github.com/llvm/llvm-project/issues/217823
It was further discovered that the https://github.com/llvm/llvm-project/issues/217831 issue, and the new 1438 issue above, should be GPU agnostic, since this is a compile time error.
Another prevalent issue was new implementations being added to llvm main, which caused .32 tests to XPASS. We should remove the "unimplemented" XFails.

Assisted by: Github Copilot