### PR TITLE
Update a few out of date XFAILs

### DIFF
--- a/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_one_based.test
@@ -113,9 +113,6 @@ DescriptorSets:
 # BUG https://github.com/llvm/llvm-project/issues/180258
 # XFAIL: Vulkan && Clang
 
-# BUG https://github.com/llvm/llvm-project/issues/191511
-# XFAIL: (Metal || DirectX) && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_groupthread_swizzle_zero_based.test
@@ -113,9 +113,6 @@ DescriptorSets:
 # BUG Vulkan  https://github.com/llvm/llvm-project/issues/180258
 # XFAIL: Vulkan && Clang
 
-# BUG https://github.com/llvm/llvm-project/issues/191511
-# XFAIL: (Metal || DirectX) && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_one_based.test
@@ -112,6 +112,9 @@ DescriptorSets:
 ...
 #--- end
 
+# BUG https://github.com/llvm/llvm-project/issues/180258
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_zero_based.test
@@ -112,6 +112,9 @@ DescriptorSets:
 ...
 #--- end
 
+# BUG https://github.com/llvm/llvm-project/issues/180258
+# XFAIL: Vulkan && Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/CalculateLevelOfDetail.test
+++ b/test/Feature/Textures/CalculateLevelOfDetail.test
@@ -136,12 +136,6 @@ Results:
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe
 
-# OpImageSampleImplicitLod is illegally sunk into control flow, but it seems
-# that intel drivers can handle this.
-#
-# Bug: https://github.com/llvm/llvm-project/issues/212365
-# XFAIL: Clang && Vulkan && !Intel
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_6 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_6 -E mainPS -Fo %t-ps.o %t/pixel.hlsl

--- a/test/Feature/Textures/Sample.test
+++ b/test/Feature/Textures/Sample.test
@@ -169,12 +169,6 @@ Results:
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe
 
-# OpImageSampleImplicitLod is illegally sunk into control flow, but it seems
-# that intel drivers can handle this.
-#
-# Bug: https://github.com/llvm/llvm-project/issues/212365
-# XFAIL: Clang && Vulkan && !Intel
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl

--- a/test/Feature/Textures/SampleBias.test
+++ b/test/Feature/Textures/SampleBias.test
@@ -163,12 +163,6 @@ Results:
 # Lavapipe (llvmpipe) intermittently crashes (0xc0000005 / SIGSEGV, no output). 
 # UNSUPPORTED: Lavapipe
 
-# OpImageSampleImplicitLod is illegally sunk into control flow, but it seems
-# that intel drivers can handle this.
-#
-# Bug: https://github.com/llvm/llvm-project/issues/212365
-# XFAIL: Clang && Vulkan && !Intel
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
 # RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl


### PR DESCRIPTION
These are a few tests that need updates here:

1. These Matrix tests work on DirectX after llvm/llvm-project#211346, since they no longer end up with a constant PHI node.
2. The Matrix groupthread swizzle tests now fail on Vulkan in the same way as the non-groupthread versions.
3. The Textures tests now work after llvm/llvm-project#211256, since the intrinsics are now correctly marked as convergent.