### PR TITLE
Add `InterlockedCompareExchangeFloatBitwise` tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
@@ -2,7 +2,7 @@
 
 // Tests InterlockedCompareExchangeFloatBitwise on groupshared destinations.
 // 256 threads run at the same time. Each test value is exact in float, thus
-// the shader compares floats directly. There are four checks:
+// the shader compares floats directly. There are three checks:
 //
 //   1. Private slots. A compare that does not match must not store. A later
 //      compare that matches must store. Both report the initial value.
@@ -14,24 +14,17 @@
 //   3. Bit patterns. +0.0 against -0.0 must not store. A NaN against the
 //      same NaN bits must store. A buffer supplies the NaN, because HLSL
 //      has no NaN literal.
-//   4. CounterZero. Thread `i` moves the counter from `i` to `i+1` only.
-//      The shader makes 256 attempts, with a barrier between them. Each
-//      thread wins one time, the counter stops at 256, and the counter must
-//      never decrease.
 
-RWStructuredBuffer<uint> OutMono : register(u0);
-RWStructuredBuffer<uint> OutSlots : register(u1);
-RWStructuredBuffer<uint> OutOrig : register(u2);
-RWStructuredBuffer<uint> OutWins : register(u3);
-RWStructuredBuffer<float> OutFinal : register(u4);
-RWStructuredBuffer<float> NanIn : register(u5);
+RWStructuredBuffer<uint> OutSlots : register(u0);
+RWStructuredBuffer<uint> OutOrig : register(u1);
+RWStructuredBuffer<float> OutFinal : register(u2);
+RWStructuredBuffer<float> NanIn : register(u3);
 
 groupshared float SlotsMinusTwoPointFive[256]; // per-thread slots, each -2.5
 groupshared float MatchMinusFive;              // contended, compare matches
 groupshared float NoMatchSeventySeven;         // contended, never matches
 groupshared float ZeroPositive;                // +0.0, compared against -0.0
 groupshared float NanQuiet;                    // NaN, compared against NaN
-groupshared float CounterZero;                 // stepped from 0.0 to 256.0
 groupshared float ClaimZero;                   // 0.0, claimed by the winner
 
 [numthreads(256, 1, 1)]
@@ -42,7 +35,6 @@ void main(uint3 GTID : SV_GroupThreadID) {
     NoMatchSeventySeven = 77.0f;
     ZeroPositive = 0.0f;
     NanQuiet = NanIn[0];
-    CounterZero = 0.0f;
     ClaimZero = 0.0f;
   }
   GroupMemoryBarrierWithGroupSync();
@@ -84,36 +76,14 @@ void main(uint3 GTID : SV_GroupThreadID) {
                      OrigNoMatch == 77.0f && OrigZero == 0.0f &&
                      Claim == 0.0f) ? 1u : 0u;
 
-  // Check 4.
-  float CompareValue = (float)GTID.x;
-  float NewValue = (float)GTID.x + 1.0f;
-  float Prev = 0.0f;
-  uint Mono = 1u;
-  uint Wins = 0u;
-  for (uint I = 0; I < 256; ++I) {
-    float Orig;
-    InterlockedCompareExchangeFloatBitwise(CounterZero, CompareValue, NewValue,
-                                           Orig);
-    if (Orig == CompareValue)
-      ++Wins;
-    GroupMemoryBarrierWithGroupSync();
-    float Cur = CounterZero;
-    if (Cur < Prev)
-      Mono = 0u;
-    Prev = Cur;
-  }
-  OutMono[GTID.x] = Mono;
-  OutWins[GTID.x] = Wins;
-
   GroupMemoryBarrierWithGroupSync();
 
   if (GTID.x == 0) {
-    OutFinal[0] = CounterZero;         // 256.0
-    OutFinal[1] = MatchMinusFive;      // 42.0
-    OutFinal[2] = NoMatchSeventySeven; // 77.0
-    OutFinal[3] = ZeroPositive;        // +0.0, -0.0 must not have matched
-    OutFinal[4] = NanQuiet;            // 7.0, the NaN must have matched
-    OutFinal[5] = ClaimZero;           // 1.0, exactly one thread claimed
+    OutFinal[0] = MatchMinusFive;      // 42.0
+    OutFinal[1] = NoMatchSeventySeven; // 77.0
+    OutFinal[2] = ZeroPositive;        // +0.0, -0.0 must not have matched
+    OutFinal[3] = NanQuiet;            // 7.0, the NaN must have matched
+    OutFinal[4] = ClaimZero;           // 1.0, exactly one thread claimed
   }
 }
 
@@ -124,10 +94,6 @@ Shaders:
   - Stage: Compute
     Entry: main
 Buffers:
-  - Name: OutMono
-    Format: UInt32
-    Stride: 4
-    FillSize: 1024
   - Name: ExpectedOnes
     Format: UInt32
     Stride: 4
@@ -155,27 +121,19 @@ Buffers:
     Format: UInt32
     Stride: 4
     FillSize: 1024
-  - Name: OutWins
-    Format: UInt32
-    Stride: 4
-    FillSize: 1024
   - Name: OutFinal
     Format: Float32
     Stride: 4
-    FillSize: 24
+    FillSize: 20
   - Name: ExpectedFinal
     Format: Float32
     Stride: 4
-    Data: [ 256.0, 42.0, 77.0, 0.0, 7.0, 1.0 ]
+    Data: [ 42.0, 77.0, 0.0, 7.0, 1.0 ]
   - Name: NanIn
     Format: Float32
     Stride: 4
     Data: [ nan ]
 Results:
-  - Result: TestMono
-    Rule: BufferExact
-    Actual: OutMono
-    Expected: ExpectedOnes
   - Result: TestSlots
     Rule: BufferExact
     Actual: OutSlots
@@ -184,58 +142,40 @@ Results:
     Rule: BufferExact
     Actual: OutOrig
     Expected: ExpectedOnes
-  - Result: TestWins
-    Rule: BufferExact
-    Actual: OutWins
-    Expected: ExpectedOnes
   - Result: TestFinal
     Rule: BufferExact
     Actual: OutFinal
     Expected: ExpectedFinal
 DescriptorSets:
   - Resources:
-    - Name: OutMono
+    - Name: OutSlots
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 0
         Space: 0
       VulkanBinding:
         Binding: 0
-    - Name: OutSlots
+    - Name: OutOrig
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 1
         Space: 0
       VulkanBinding:
         Binding: 1
-    - Name: OutOrig
+    - Name: OutFinal
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 2
         Space: 0
       VulkanBinding:
         Binding: 2
-    - Name: OutWins
+    - Name: NanIn
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 3
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: OutFinal
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 4
-        Space: 0
-      VulkanBinding:
-        Binding: 4
-    - Name: NanIn
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 5
-        Space: 0
-      VulkanBinding:
-        Binding: 5
 ...
 #--- end
 

--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
@@ -1,29 +1,30 @@
 #--- source.hlsl
 
-// Tests InterlockedCompareExchangeFloatBitwise on groupshared destinations
-// with 256 concurrent threads. Comparison is on the bit pattern, not the
-// numeric value, so all checks use asuint(). Four checks:
+// Tests InterlockedCompareExchangeFloatBitwise on groupshared destinations.
+// 256 threads run at the same time. Each test value is exact in float, thus
+// the shader compares floats directly. There are four checks:
 //
-//   1. Private slots: a mismatching compare must not store, a following
-//      matching compare must, and both must report the original value.
-//   2. Contended locations: every thread proposes the same new value, so
-//      exactly one thread may observe the original compare value. A
-//      never-matching compare must leave the destination alone.
-//   3. Bitwise semantics: +0.0 compared against -0.0 must not store even
-//      though the two are numerically equal, and a NaN compared against an
-//      identical NaN bit pattern must store even though NaN != NaN.
-//   4. CounterZero: thread `i` only advances the counter from `i` to `i+1`,
-//      so over 256 barrier-separated attempts each thread succeeds exactly
-//      once and the counter ends at 256. It must never decrease.
+//   1. Private slots. A compare that does not match must not store. A later
+//      compare that matches must store. Both report the initial value.
+//   2. Contended locations. All threads propose the same value. Each thread
+//      reports the value that the winner replaced, or the value that the
+//      winner stored. Only one thread can report the replaced value. That
+//      thread claims a second location to prove that it is the only winner.
+//      A compare that never matches must not change the destination.
+//   3. Bit patterns. +0.0 against -0.0 must not store. A NaN against the
+//      same NaN bits must store. A buffer supplies the NaN, because HLSL
+//      has no NaN literal.
+//   4. CounterZero. Thread `i` moves the counter from `i` to `i+1` only.
+//      The shader makes 256 attempts, with a barrier between them. Each
+//      thread wins one time, the counter stops at 256, and the counter must
+//      never decrease.
 
 RWStructuredBuffer<uint> OutMono : register(u0);
 RWStructuredBuffer<uint> OutSlots : register(u1);
 RWStructuredBuffer<uint> OutOrig : register(u2);
 RWStructuredBuffer<uint> OutWins : register(u3);
-RWStructuredBuffer<uint> OutFinal : register(u4);
-
-static const uint NanBits = 0x7FC00000u; // quiet NaN
-static const uint NegZeroBits = 0x80000000u;
+RWStructuredBuffer<float> OutFinal : register(u4);
+RWStructuredBuffer<float> NanIn : register(u5);
 
 groupshared float SlotsMinusTwoPointFive[256]; // per-thread slots, each -2.5
 groupshared float MatchMinusFive;              // contended, compare matches
@@ -31,8 +32,7 @@ groupshared float NoMatchSeventySeven;         // contended, never matches
 groupshared float ZeroPositive;                // +0.0, compared against -0.0
 groupshared float NanQuiet;                    // NaN, compared against NaN
 groupshared float CounterZero;                 // stepped from 0.0 to 256.0
-groupshared uint  MatchWinCountZero;           // threads that saw -5.0
-groupshared uint  NanWinCountZero;             // threads that saw the NaN
+groupshared float ClaimZero;                   // 0.0, claimed by the winner
 
 [numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
@@ -41,50 +41,48 @@ void main(uint3 GTID : SV_GroupThreadID) {
     MatchMinusFive = -5.0f;
     NoMatchSeventySeven = 77.0f;
     ZeroPositive = 0.0f;
-    NanQuiet = asfloat(NanBits);
+    NanQuiet = NanIn[0];
     CounterZero = 0.0f;
-    MatchWinCountZero = 0u;
-    NanWinCountZero = 0u;
+    ClaimZero = 0.0f;
   }
   GroupMemoryBarrierWithGroupSync();
 
-  // Check 1: both calls report the initial value, only the second stores.
+  // Check 1. Both calls report the initial value. Only the second stores.
   float OrigNoStore, OrigStore;
   InterlockedCompareExchangeFloatBitwise(SlotsMinusTwoPointFive[GTID.x], 1.0f,
                                          99.0f, OrigNoStore);
   InterlockedCompareExchangeFloatBitwise(SlotsMinusTwoPointFive[GTID.x], -2.5f,
                                          (float)GTID.x + 1000.0f, OrigStore);
 
-  OutSlots[GTID.x] = (asuint(OrigNoStore) == asuint(-2.5f) &&
-                      asuint(OrigStore) == asuint(-2.5f) &&
-                      asuint(SlotsMinusTwoPointFive[GTID.x]) ==
-                          asuint((float)GTID.x + 1000.0f)) ? 1u : 0u;
+  OutSlots[GTID.x] = (OrigNoStore == -2.5f && OrigStore == -2.5f &&
+                      SlotsMinusTwoPointFive[GTID.x] ==
+                          (float)GTID.x + 1000.0f) ? 1u : 0u;
 
-  // Check 2: a matching compare reports either the value the winner replaced
-  // or the value it stored; a never-matching compare reports it untouched.
+  // Check 2. A compare that matches reports the value that the winner
+  // replaced, or the value that the winner stored. A compare that never
+  // matches reports the unchanged destination.
   float OrigMatch, OrigNoMatch;
   InterlockedCompareExchangeFloatBitwise(MatchMinusFive, -5.0f, 42.0f,
                                          OrigMatch);
   InterlockedCompareExchangeFloatBitwise(NoMatchSeventySeven, 78.0f, -1.0f,
                                          OrigNoMatch);
-  if (asuint(OrigMatch) == asuint(-5.0f))
-    InterlockedAdd(MatchWinCountZero, 1u);
 
-  // Check 3: -0.0 must not match +0.0, and NaN must match its own bits.
+  // Only the thread that received the original tries to claim. Thus a
+  // second claim shows that the exchange reported the original to more
+  // than one thread.
+  float Claim = 0.0f;
+  if (OrigMatch == -5.0f)
+    InterlockedCompareExchangeFloatBitwise(ClaimZero, 0.0f, 1.0f, Claim);
+
+  // Check 3. The final value shows whether each compare matched. A compare
+  // of NaN against NaN gives false, thus the reported value cannot show it.
   float OrigZero, OrigNan;
-  InterlockedCompareExchangeFloatBitwise(ZeroPositive, asfloat(NegZeroBits),
-                                         99.0f, OrigZero);
-  InterlockedCompareExchangeFloatBitwise(NanQuiet, asfloat(NanBits), 7.0f,
-                                         OrigNan);
-  if (asuint(OrigNan) == NanBits)
-    InterlockedAdd(NanWinCountZero, 1u);
+  InterlockedCompareExchangeFloatBitwise(ZeroPositive, -0.0f, 99.0f, OrigZero);
+  InterlockedCompareExchangeFloatBitwise(NanQuiet, NanIn[0], 7.0f, OrigNan);
 
-  OutOrig[GTID.x] = ((asuint(OrigMatch) == asuint(-5.0f) ||
-                      asuint(OrigMatch) == asuint(42.0f)) &&
-                     asuint(OrigNoMatch) == asuint(77.0f) &&
-                     asuint(OrigZero) == 0u &&
-                     (asuint(OrigNan) == NanBits ||
-                      asuint(OrigNan) == asuint(7.0f))) ? 1u : 0u;
+  OutOrig[GTID.x] = ((OrigMatch == -5.0f || OrigMatch == 42.0f) &&
+                     OrigNoMatch == 77.0f && OrigZero == 0.0f &&
+                     Claim == 0.0f) ? 1u : 0u;
 
   // Check 4.
   float CompareValue = (float)GTID.x;
@@ -96,7 +94,7 @@ void main(uint3 GTID : SV_GroupThreadID) {
     float Orig;
     InterlockedCompareExchangeFloatBitwise(CounterZero, CompareValue, NewValue,
                                            Orig);
-    if (asuint(Orig) == asuint(CompareValue))
+    if (Orig == CompareValue)
       ++Wins;
     GroupMemoryBarrierWithGroupSync();
     float Cur = CounterZero;
@@ -110,13 +108,12 @@ void main(uint3 GTID : SV_GroupThreadID) {
   GroupMemoryBarrierWithGroupSync();
 
   if (GTID.x == 0) {
-    OutFinal[0] = asuint(CounterZero);         // 256.0
-    OutFinal[1] = asuint(MatchMinusFive);      // 42.0
-    OutFinal[2] = asuint(NoMatchSeventySeven); // 77.0
-    OutFinal[3] = asuint(ZeroPositive);        // +0.0, never stored
-    OutFinal[4] = asuint(NanQuiet);            // 7.0
-    OutFinal[5] = MatchWinCountZero;           // 1
-    OutFinal[6] = NanWinCountZero;             // 1
+    OutFinal[0] = CounterZero;         // 256.0
+    OutFinal[1] = MatchMinusFive;      // 42.0
+    OutFinal[2] = NoMatchSeventySeven; // 77.0
+    OutFinal[3] = ZeroPositive;        // +0.0, -0.0 must not have matched
+    OutFinal[4] = NanQuiet;            // 7.0, the NaN must have matched
+    OutFinal[5] = ClaimZero;           // 1.0, exactly one thread claimed
   }
 }
 
@@ -163,13 +160,17 @@ Buffers:
     Stride: 4
     FillSize: 1024
   - Name: OutFinal
-    Format: UInt32
+    Format: Float32
     Stride: 4
-    FillSize: 28
+    FillSize: 24
   - Name: ExpectedFinal
-    Format: Hex32
+    Format: Float32
     Stride: 4
-    Data: [ 0x43800000, 0x42280000, 0x429A0000, 0x0, 0x40E00000, 0x1, 0x1 ]
+    Data: [ 256.0, 42.0, 77.0, 0.0, 7.0, 1.0 ]
+  - Name: NanIn
+    Format: Float32
+    Stride: 4
+    Data: [ nan ]
 Results:
   - Result: TestMono
     Rule: BufferExact
@@ -228,6 +229,13 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 4
+    - Name: NanIn
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
 ...
 #--- end
 

--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
@@ -1,0 +1,242 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareExchangeFloatBitwise on groupshared destinations
+// with 256 concurrent threads. Comparison is on the bit pattern, not the
+// numeric value, so all checks use asuint(). Four checks:
+//
+//   1. Private slots: a mismatching compare must not store, a following
+//      matching compare must, and both must report the original value.
+//   2. Contended locations: every thread proposes the same new value, so
+//      exactly one thread may observe the original compare value. A
+//      never-matching compare must leave the destination alone.
+//   3. Bitwise semantics: +0.0 compared against -0.0 must not store even
+//      though the two are numerically equal, and a NaN compared against an
+//      identical NaN bit pattern must store even though NaN != NaN.
+//   4. CounterZero: thread `i` only advances the counter from `i` to `i+1`,
+//      so over 256 barrier-separated attempts each thread succeeds exactly
+//      once and the counter ends at 256. It must never decrease.
+
+RWStructuredBuffer<uint> OutMono : register(u0);
+RWStructuredBuffer<uint> OutSlots : register(u1);
+RWStructuredBuffer<uint> OutOrig : register(u2);
+RWStructuredBuffer<uint> OutWins : register(u3);
+RWStructuredBuffer<uint> OutFinal : register(u4);
+
+static const uint NanBits = 0x7FC00000u; // quiet NaN
+static const uint NegZeroBits = 0x80000000u;
+
+groupshared float SlotsMinusTwoPointFive[256]; // per-thread slots, each -2.5
+groupshared float MatchMinusFive;              // contended, compare matches
+groupshared float NoMatchSeventySeven;         // contended, never matches
+groupshared float ZeroPositive;                // +0.0, compared against -0.0
+groupshared float NanQuiet;                    // NaN, compared against NaN
+groupshared float CounterZero;                 // stepped from 0.0 to 256.0
+groupshared uint  MatchWinCountZero;           // threads that saw -5.0
+groupshared uint  NanWinCountZero;             // threads that saw the NaN
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  SlotsMinusTwoPointFive[GTID.x] = -2.5f;
+  if (GTID.x == 0) {
+    MatchMinusFive = -5.0f;
+    NoMatchSeventySeven = 77.0f;
+    ZeroPositive = 0.0f;
+    NanQuiet = asfloat(NanBits);
+    CounterZero = 0.0f;
+    MatchWinCountZero = 0u;
+    NanWinCountZero = 0u;
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // Check 1: both calls report the initial value, only the second stores.
+  float OrigNoStore, OrigStore;
+  InterlockedCompareExchangeFloatBitwise(SlotsMinusTwoPointFive[GTID.x], 1.0f,
+                                         99.0f, OrigNoStore);
+  InterlockedCompareExchangeFloatBitwise(SlotsMinusTwoPointFive[GTID.x], -2.5f,
+                                         (float)GTID.x + 1000.0f, OrigStore);
+
+  OutSlots[GTID.x] = (asuint(OrigNoStore) == asuint(-2.5f) &&
+                      asuint(OrigStore) == asuint(-2.5f) &&
+                      asuint(SlotsMinusTwoPointFive[GTID.x]) ==
+                          asuint((float)GTID.x + 1000.0f)) ? 1u : 0u;
+
+  // Check 2: a matching compare reports either the value the winner replaced
+  // or the value it stored; a never-matching compare reports it untouched.
+  float OrigMatch, OrigNoMatch;
+  InterlockedCompareExchangeFloatBitwise(MatchMinusFive, -5.0f, 42.0f,
+                                         OrigMatch);
+  InterlockedCompareExchangeFloatBitwise(NoMatchSeventySeven, 78.0f, -1.0f,
+                                         OrigNoMatch);
+  if (asuint(OrigMatch) == asuint(-5.0f))
+    InterlockedAdd(MatchWinCountZero, 1u);
+
+  // Check 3: -0.0 must not match +0.0, and NaN must match its own bits.
+  float OrigZero, OrigNan;
+  InterlockedCompareExchangeFloatBitwise(ZeroPositive, asfloat(NegZeroBits),
+                                         99.0f, OrigZero);
+  InterlockedCompareExchangeFloatBitwise(NanQuiet, asfloat(NanBits), 7.0f,
+                                         OrigNan);
+  if (asuint(OrigNan) == NanBits)
+    InterlockedAdd(NanWinCountZero, 1u);
+
+  OutOrig[GTID.x] = ((asuint(OrigMatch) == asuint(-5.0f) ||
+                      asuint(OrigMatch) == asuint(42.0f)) &&
+                     asuint(OrigNoMatch) == asuint(77.0f) &&
+                     asuint(OrigZero) == 0u &&
+                     (asuint(OrigNan) == NanBits ||
+                      asuint(OrigNan) == asuint(7.0f))) ? 1u : 0u;
+
+  // Check 4.
+  float CompareValue = (float)GTID.x;
+  float NewValue = (float)GTID.x + 1.0f;
+  float Prev = 0.0f;
+  uint Mono = 1u;
+  uint Wins = 0u;
+  for (uint I = 0; I < 256; ++I) {
+    float Orig;
+    InterlockedCompareExchangeFloatBitwise(CounterZero, CompareValue, NewValue,
+                                           Orig);
+    if (asuint(Orig) == asuint(CompareValue))
+      ++Wins;
+    GroupMemoryBarrierWithGroupSync();
+    float Cur = CounterZero;
+    if (Cur < Prev)
+      Mono = 0u;
+    Prev = Cur;
+  }
+  OutMono[GTID.x] = Mono;
+  OutWins[GTID.x] = Wins;
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = asuint(CounterZero);         // 256.0
+    OutFinal[1] = asuint(MatchMinusFive);      // 42.0
+    OutFinal[2] = asuint(NoMatchSeventySeven); // 77.0
+    OutFinal[3] = asuint(ZeroPositive);        // +0.0, never stored
+    OutFinal[4] = asuint(NanQuiet);            // 7.0
+    OutFinal[5] = MatchWinCountZero;           // 1
+    OutFinal[6] = NanWinCountZero;             // 1
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: OutMono
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedOnes
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutSlots
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutOrig
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutWins
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutFinal
+    Format: UInt32
+    Stride: 4
+    FillSize: 28
+  - Name: ExpectedFinal
+    Format: Hex32
+    Stride: 4
+    Data: [ 0x43800000, 0x42280000, 0x429A0000, 0x0, 0x40E00000, 0x1, 0x1 ]
+Results:
+  - Result: TestMono
+    Rule: BufferExact
+    Actual: OutMono
+    Expected: ExpectedOnes
+  - Result: TestSlots
+    Rule: BufferExact
+    Actual: OutSlots
+    Expected: ExpectedOnes
+  - Result: TestOrig
+    Rule: BufferExact
+    Actual: OutOrig
+    Expected: ExpectedOnes
+  - Result: TestWins
+    Rule: BufferExact
+    Actual: OutWins
+    Expected: ExpectedOnes
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutMono
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutSlots
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: OutOrig
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: OutWins
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99203
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/7782
+# XFAIL: Vulkan && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
@@ -1,0 +1,307 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareExchangeFloatBitwise on the HLSL-legal
+// non-groupshared (resource) destination types:
+//
+//   * RWStructuredBuffer<float>[i]                          (free function)
+//   * RWBuffer<float>[i]                                    (typed UAV)
+//   * RWTexture2D<float>[coord]                             (typed UAV)
+//   * RWByteAddressBuffer::InterlockedCompareExchangeFloatBitwise  (method)
+//
+// Every destination covers a matching and a never-matching compare and
+// checks the reported original. RWStructuredBuffer and RWByteAddressBuffer
+// additionally run the stepped counter, per-thread success count and
+// monotonicity check described in
+// InterlockedCompareExchangeFloatBitwise.32.test, which is also where the
+// bit-pattern semantics (-0.0 vs +0.0, NaN) are covered.
+
+RWStructuredBuffer<float> SBufF : register(u0);
+RWBuffer<float>           TBufF : register(u1);
+RWTexture2D<float>        Tex2D : register(u2);
+RWByteAddressBuffer       BABuf : register(u3);
+
+RWStructuredBuffer<uint> OutMonoSBufF : register(u4);
+RWStructuredBuffer<uint> OutMonoBABuf : register(u5);
+RWStructuredBuffer<uint> OutOrig : register(u6);
+RWStructuredBuffer<uint> OutWins : register(u7);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufF[0] = 0.0f;                  // stepped counter
+    SBufF[1] = 9.0f;                  // compare never matches
+    TBufF[0] = -5.0f;                 // compare matches
+    TBufF[1] = 9.0f;                  // compare never matches
+    Tex2D[uint2(0, 0)] = -5.0f;       // compare matches
+    Tex2D[uint2(1, 0)] = 9.0f;        // compare never matches
+    BABuf.Store(0, asuint(-5.0f));    // compare matches
+    BABuf.Store(4, asuint(44.0f));    // compare never matches
+    BABuf.Store(8, asuint(0.0f));     // stepped counter
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<float>: the compare never matches.
+  float OrigSBufF;
+  InterlockedCompareExchangeFloatBitwise(SBufF[1], 10.0f, 0.0f, OrigSBufF);
+
+  // RWBuffer<float> (typed buffer UAV).
+  float OrigTBufFMatch, OrigTBufFNoMatch;
+  InterlockedCompareExchangeFloatBitwise(TBufF[0], -5.0f, 77.0f,
+                                         OrigTBufFMatch);
+  InterlockedCompareExchangeFloatBitwise(TBufF[1], 10.0f, 0.0f,
+                                         OrigTBufFNoMatch);
+
+  // RWTexture2D<float> (typed texture UAV).
+  float OrigTexMatch, OrigTexNoMatch;
+  InterlockedCompareExchangeFloatBitwise(Tex2D[uint2(0, 0)], -5.0f, 88.0f,
+                                         OrigTexMatch);
+  InterlockedCompareExchangeFloatBitwise(Tex2D[uint2(1, 0)], 10.0f, 0.0f,
+                                         OrigTexNoMatch);
+
+  // RWByteAddressBuffer method form.
+  float OrigBABufMatch, OrigBABufNoMatch;
+  BABuf.InterlockedCompareExchangeFloatBitwise(0, -5.0f, 123.0f,
+                                               OrigBABufMatch);
+  BABuf.InterlockedCompareExchangeFloatBitwise(4, 45.0f, -1.0f,
+                                               OrigBABufNoMatch);
+
+  OutOrig[GTID.x] = (asuint(OrigSBufF) == asuint(9.0f) &&
+                     (asuint(OrigTBufFMatch) == asuint(-5.0f) ||
+                      asuint(OrigTBufFMatch) == asuint(77.0f)) &&
+                     asuint(OrigTBufFNoMatch) == asuint(9.0f) &&
+                     (asuint(OrigTexMatch) == asuint(-5.0f) ||
+                      asuint(OrigTexMatch) == asuint(88.0f)) &&
+                     asuint(OrigTexNoMatch) == asuint(9.0f) &&
+                     (asuint(OrigBABufMatch) == asuint(-5.0f) ||
+                      asuint(OrigBABufMatch) == asuint(123.0f)) &&
+                     asuint(OrigBABufNoMatch) == asuint(44.0f)) ? 1u : 0u;
+
+  // Stepped counter on both a structured and a byte-address destination.
+  float CompareValue = (float)GTID.x;
+  float NewValue = (float)GTID.x + 1.0f;
+  float PrevSBufF = 0.0f;
+  float PrevBABuf = 0.0f;
+  uint MonoSBufF = 1u;
+  uint MonoBABuf = 1u;
+  uint WinsSBufF = 0u;
+  uint WinsBABuf = 0u;
+  for (uint I = 0; I < 256; ++I) {
+    float OrigS, OrigB;
+    InterlockedCompareExchangeFloatBitwise(SBufF[0], CompareValue, NewValue,
+                                           OrigS);
+    if (asuint(OrigS) == asuint(CompareValue))
+      ++WinsSBufF;
+    BABuf.InterlockedCompareExchangeFloatBitwise(8, CompareValue, NewValue,
+                                                 OrigB);
+    if (asuint(OrigB) == asuint(CompareValue))
+      ++WinsBABuf;
+    DeviceMemoryBarrierWithGroupSync();
+    float CurS = SBufF[0];
+    if (CurS < PrevSBufF)
+      MonoSBufF = 0u;
+    PrevSBufF = CurS;
+    float CurB = asfloat(BABuf.Load(8));
+    if (CurB < PrevBABuf)
+      MonoBABuf = 0u;
+    PrevBABuf = CurB;
+  }
+  OutMonoSBufF[GTID.x] = MonoSBufF;
+  OutMonoBABuf[GTID.x] = MonoBABuf;
+  OutWins[GTID.x] = (WinsSBufF == 1u && WinsBABuf == 1u) ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufF
+    Format: Float32
+    Stride: 4
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedSBufF
+    Format: Float32
+    Stride: 4
+    Data: [ 256.0, 9.0 ]
+  - Name: TBufF
+    Format: Float32
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufF
+    Format: Float32
+    Channels: 1
+    Data: [ 77.0, 9.0 ]
+  - Name: Tex2D
+    Format: Float32
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+    OutputProps:
+      Height: 1
+      Width: 2
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: Float32
+    Channels: 1
+    Data: [ 88.0, 9.0 ]
+    OutputProps:
+      Height: 1
+      Width: 2
+      Depth: 1
+  - Name: BABuf
+    Format: Float32
+    Stride: 4
+    FillSize: 12
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedBABuf
+    Format: Float32
+    Stride: 4
+    Data: [ 123.0, 44.0, 256.0 ]
+  - Name: OutMonoSBufF
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: ExpectedOnes
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutMonoBABuf
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutOrig
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutWins
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+Results:
+  - Result: TestSBufF
+    Rule: BufferExact
+    Actual: SBufF
+    Expected: ExpectedSBufF
+  - Result: TestTBufF
+    Rule: BufferExact
+    Actual: TBufF
+    Expected: ExpectedTBufF
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+  - Result: TestMonoSBufF
+    Rule: BufferExact
+    Actual: OutMonoSBufF
+    Expected: ExpectedOnes
+  - Result: TestMonoBABuf
+    Rule: BufferExact
+    Actual: OutMonoBABuf
+    Expected: ExpectedOnes
+  - Result: TestOrig
+    Rule: BufferExact
+    Actual: OutOrig
+    Expected: ExpectedOnes
+  - Result: TestWins
+    Rule: BufferExact
+    Actual: OutWins
+    Expected: ExpectedOnes
+DescriptorSets:
+  - Resources:
+    - Name: SBufF
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufF
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+    - Name: OutMonoSBufF
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 4
+        Space: 0
+      VulkanBinding:
+        Binding: 4
+    - Name: OutMonoBABuf
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 5
+        Space: 0
+      VulkanBinding:
+        Binding: 5
+    - Name: OutOrig
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 6
+        Space: 0
+      VulkanBinding:
+        Binding: 6
+    - Name: OutWins
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 7
+        Space: 0
+      VulkanBinding:
+        Binding: 7
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99203
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/7782
+# XFAIL: Vulkan && DXC
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1164
+# XFAIL: Metal && DXC
+
+# Bug: https://github.com/llvm/offload-test-suite/issues/1418
+# UNSUPPORTED: WARP && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
@@ -296,9 +296,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/7782
 # XFAIL: Vulkan && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
 # UNSUPPORTED: WARP && DXC
 

--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
@@ -1,20 +1,19 @@
 #--- source.hlsl
 
-// Tests InterlockedCompareExchangeFloatBitwise on the HLSL-legal
-// non-groupshared (resource) destination types:
+// Tests InterlockedCompareExchangeFloatBitwise on the resource destination
+// types that HLSL permits:
 //
 //   * RWStructuredBuffer<float>[i]                          (free function)
 //   * RWBuffer<float>[i]                                    (typed UAV)
 //   * RWTexture2D<float>[coord]                             (typed UAV)
 //   * RWByteAddressBuffer::InterlockedCompareExchangeFloatBitwise  (method)
 //
-// Every destination covers a matching and a never-matching compare and
-// checks the reported original. RWStructuredBuffer and RWByteAddressBuffer
-// additionally run the stepped counter, per-thread success count and
-// monotonicity check described in
-// InterlockedCompareExchangeFloatBitwise.32.test, which is also where the
-// bit-pattern semantics (-0.0 vs +0.0, NaN) are covered.
-
+// For each type, the shader makes one compare that matches and one compare
+// that never matches. It then checks the reported original value.
+// RWStructuredBuffer and RWByteAddressBuffer also run the stepped counter,
+// the count of wins for each thread, and the monotonicity check. The file
+// InterlockedCompareExchangeFloatBitwise.32.test describes these checks. It
+// also covers the bit patterns (-0.0 against +0.0, and NaN).
 RWStructuredBuffer<float> SBufF : register(u0);
 RWBuffer<float>           TBufF : register(u1);
 RWTexture2D<float>        Tex2D : register(u2);
@@ -34,9 +33,9 @@ void main(uint3 GTID : SV_GroupThreadID) {
     TBufF[1] = 9.0f;                  // compare never matches
     Tex2D[uint2(0, 0)] = -5.0f;       // compare matches
     Tex2D[uint2(1, 0)] = 9.0f;        // compare never matches
-    BABuf.Store(0, asuint(-5.0f));    // compare matches
-    BABuf.Store(4, asuint(44.0f));    // compare never matches
-    BABuf.Store(8, asuint(0.0f));     // stepped counter
+    BABuf.Store<float>(0, -5.0f);     // compare matches
+    BABuf.Store<float>(4, 44.0f);     // compare never matches
+    BABuf.Store<float>(8, 0.0f);      // stepped counter
   }
   DeviceMemoryBarrierWithGroupSync();
 
@@ -65,16 +64,13 @@ void main(uint3 GTID : SV_GroupThreadID) {
   BABuf.InterlockedCompareExchangeFloatBitwise(4, 45.0f, -1.0f,
                                                OrigBABufNoMatch);
 
-  OutOrig[GTID.x] = (asuint(OrigSBufF) == asuint(9.0f) &&
-                     (asuint(OrigTBufFMatch) == asuint(-5.0f) ||
-                      asuint(OrigTBufFMatch) == asuint(77.0f)) &&
-                     asuint(OrigTBufFNoMatch) == asuint(9.0f) &&
-                     (asuint(OrigTexMatch) == asuint(-5.0f) ||
-                      asuint(OrigTexMatch) == asuint(88.0f)) &&
-                     asuint(OrigTexNoMatch) == asuint(9.0f) &&
-                     (asuint(OrigBABufMatch) == asuint(-5.0f) ||
-                      asuint(OrigBABufMatch) == asuint(123.0f)) &&
-                     asuint(OrigBABufNoMatch) == asuint(44.0f)) ? 1u : 0u;
+  OutOrig[GTID.x] = (OrigSBufF == 9.0f &&
+                     (OrigTBufFMatch == -5.0f || OrigTBufFMatch == 77.0f) &&
+                     OrigTBufFNoMatch == 9.0f &&
+                     (OrigTexMatch == -5.0f || OrigTexMatch == 88.0f) &&
+                     OrigTexNoMatch == 9.0f &&
+                     (OrigBABufMatch == -5.0f || OrigBABufMatch == 123.0f) &&
+                     OrigBABufNoMatch == 44.0f) ? 1u : 0u;
 
   // Stepped counter on both a structured and a byte-address destination.
   float CompareValue = (float)GTID.x;
@@ -89,18 +85,18 @@ void main(uint3 GTID : SV_GroupThreadID) {
     float OrigS, OrigB;
     InterlockedCompareExchangeFloatBitwise(SBufF[0], CompareValue, NewValue,
                                            OrigS);
-    if (asuint(OrigS) == asuint(CompareValue))
+    if (OrigS == CompareValue)
       ++WinsSBufF;
     BABuf.InterlockedCompareExchangeFloatBitwise(8, CompareValue, NewValue,
                                                  OrigB);
-    if (asuint(OrigB) == asuint(CompareValue))
+    if (OrigB == CompareValue)
       ++WinsBABuf;
     DeviceMemoryBarrierWithGroupSync();
     float CurS = SBufF[0];
     if (CurS < PrevSBufF)
       MonoSBufF = 0u;
     PrevSBufF = CurS;
-    float CurB = asfloat(BABuf.Load(8));
+    float CurB = BABuf.Load<float>(8);
     if (CurB < PrevBABuf)
       MonoBABuf = 0u;
     PrevBABuf = CurB;

--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.resources.32.test
@@ -9,25 +9,22 @@
 //   * RWByteAddressBuffer::InterlockedCompareExchangeFloatBitwise  (method)
 //
 // For each type, the shader makes one compare that matches and one compare
-// that never matches. It then checks the reported original value.
-// RWStructuredBuffer and RWByteAddressBuffer also run the stepped counter,
-// the count of wins for each thread, and the monotonicity check. The file
-// InterlockedCompareExchangeFloatBitwise.32.test describes these checks. It
-// also covers the bit patterns (-0.0 against +0.0, and NaN).
+// that never matches. It then checks the reported original value and the
+// final contents of the destination. All 256 threads make the same calls,
+// thus the compare that matches is contended. The file
+// InterlockedCompareExchangeFloatBitwise.32.test covers the bit patterns
+// (-0.0 against +0.0, and NaN) and the count of winners.
 RWStructuredBuffer<float> SBufF : register(u0);
 RWBuffer<float>           TBufF : register(u1);
 RWTexture2D<float>        Tex2D : register(u2);
 RWByteAddressBuffer       BABuf : register(u3);
 
-RWStructuredBuffer<uint> OutMonoSBufF : register(u4);
-RWStructuredBuffer<uint> OutMonoBABuf : register(u5);
-RWStructuredBuffer<uint> OutOrig : register(u6);
-RWStructuredBuffer<uint> OutWins : register(u7);
+RWStructuredBuffer<uint> OutOrig : register(u4);
 
 [numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
-    SBufF[0] = 0.0f;                  // stepped counter
+    SBufF[0] = -5.0f;                 // compare matches
     SBufF[1] = 9.0f;                  // compare never matches
     TBufF[0] = -5.0f;                 // compare matches
     TBufF[1] = 9.0f;                  // compare never matches
@@ -35,13 +32,15 @@ void main(uint3 GTID : SV_GroupThreadID) {
     Tex2D[uint2(1, 0)] = 9.0f;        // compare never matches
     BABuf.Store<float>(0, -5.0f);     // compare matches
     BABuf.Store<float>(4, 44.0f);     // compare never matches
-    BABuf.Store<float>(8, 0.0f);      // stepped counter
   }
   DeviceMemoryBarrierWithGroupSync();
 
-  // RWStructuredBuffer<float>: the compare never matches.
-  float OrigSBufF;
-  InterlockedCompareExchangeFloatBitwise(SBufF[1], 10.0f, 0.0f, OrigSBufF);
+  // RWStructuredBuffer<float> (free function).
+  float OrigSBufFMatch, OrigSBufFNoMatch;
+  InterlockedCompareExchangeFloatBitwise(SBufF[0], -5.0f, 66.0f,
+                                         OrigSBufFMatch);
+  InterlockedCompareExchangeFloatBitwise(SBufF[1], 10.0f, 0.0f,
+                                         OrigSBufFNoMatch);
 
   // RWBuffer<float> (typed buffer UAV).
   float OrigTBufFMatch, OrigTBufFNoMatch;
@@ -64,46 +63,14 @@ void main(uint3 GTID : SV_GroupThreadID) {
   BABuf.InterlockedCompareExchangeFloatBitwise(4, 45.0f, -1.0f,
                                                OrigBABufNoMatch);
 
-  OutOrig[GTID.x] = (OrigSBufF == 9.0f &&
+  OutOrig[GTID.x] = ((OrigSBufFMatch == -5.0f || OrigSBufFMatch == 66.0f) &&
+                     OrigSBufFNoMatch == 9.0f &&
                      (OrigTBufFMatch == -5.0f || OrigTBufFMatch == 77.0f) &&
                      OrigTBufFNoMatch == 9.0f &&
                      (OrigTexMatch == -5.0f || OrigTexMatch == 88.0f) &&
                      OrigTexNoMatch == 9.0f &&
                      (OrigBABufMatch == -5.0f || OrigBABufMatch == 123.0f) &&
                      OrigBABufNoMatch == 44.0f) ? 1u : 0u;
-
-  // Stepped counter on both a structured and a byte-address destination.
-  float CompareValue = (float)GTID.x;
-  float NewValue = (float)GTID.x + 1.0f;
-  float PrevSBufF = 0.0f;
-  float PrevBABuf = 0.0f;
-  uint MonoSBufF = 1u;
-  uint MonoBABuf = 1u;
-  uint WinsSBufF = 0u;
-  uint WinsBABuf = 0u;
-  for (uint I = 0; I < 256; ++I) {
-    float OrigS, OrigB;
-    InterlockedCompareExchangeFloatBitwise(SBufF[0], CompareValue, NewValue,
-                                           OrigS);
-    if (OrigS == CompareValue)
-      ++WinsSBufF;
-    BABuf.InterlockedCompareExchangeFloatBitwise(8, CompareValue, NewValue,
-                                                 OrigB);
-    if (OrigB == CompareValue)
-      ++WinsBABuf;
-    DeviceMemoryBarrierWithGroupSync();
-    float CurS = SBufF[0];
-    if (CurS < PrevSBufF)
-      MonoSBufF = 0u;
-    PrevSBufF = CurS;
-    float CurB = BABuf.Load<float>(8);
-    if (CurB < PrevBABuf)
-      MonoBABuf = 0u;
-    PrevBABuf = CurB;
-  }
-  OutMonoSBufF[GTID.x] = MonoSBufF;
-  OutMonoBABuf[GTID.x] = MonoBABuf;
-  OutWins[GTID.x] = (WinsSBufF == 1u && WinsBABuf == 1u) ? 1u : 0u;
 }
 
 //--- pipeline.yaml
@@ -121,7 +88,7 @@ Buffers:
   - Name: ExpectedSBufF
     Format: Float32
     Stride: 4
-    Data: [ 256.0, 9.0 ]
+    Data: [ 66.0, 9.0 ]
   - Name: TBufF
     Format: Float32
     Channels: 1
@@ -151,16 +118,12 @@ Buffers:
   - Name: BABuf
     Format: Float32
     Stride: 4
-    FillSize: 12
+    FillSize: 8
     FillValue: 137  # trash non-zero initialization data
   - Name: ExpectedBABuf
     Format: Float32
     Stride: 4
-    Data: [ 123.0, 44.0, 256.0 ]
-  - Name: OutMonoSBufF
-    Format: UInt32
-    Stride: 4
-    FillSize: 1024
+    Data: [ 123.0, 44.0 ]
   - Name: ExpectedOnes
     Format: UInt32
     Stride: 4
@@ -180,15 +143,7 @@ Buffers:
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
-  - Name: OutMonoBABuf
-    Format: UInt32
-    Stride: 4
-    FillSize: 1024
   - Name: OutOrig
-    Format: UInt32
-    Stride: 4
-    FillSize: 1024
-  - Name: OutWins
     Format: UInt32
     Stride: 4
     FillSize: 1024
@@ -209,21 +164,9 @@ Results:
     Rule: BufferExact
     Actual: BABuf
     Expected: ExpectedBABuf
-  - Result: TestMonoSBufF
-    Rule: BufferExact
-    Actual: OutMonoSBufF
-    Expected: ExpectedOnes
-  - Result: TestMonoBABuf
-    Rule: BufferExact
-    Actual: OutMonoBABuf
-    Expected: ExpectedOnes
   - Result: TestOrig
     Rule: BufferExact
     Actual: OutOrig
-    Expected: ExpectedOnes
-  - Result: TestWins
-    Rule: BufferExact
-    Actual: OutWins
     Expected: ExpectedOnes
 DescriptorSets:
   - Resources:
@@ -255,34 +198,13 @@ DescriptorSets:
         Space: 0
       VulkanBinding:
         Binding: 3
-    - Name: OutMonoSBufF
+    - Name: OutOrig
       Kind: RWStructuredBuffer
       DirectXBinding:
         Register: 4
         Space: 0
       VulkanBinding:
         Binding: 4
-    - Name: OutMonoBABuf
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 5
-        Space: 0
-      VulkanBinding:
-        Binding: 5
-    - Name: OutOrig
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 6
-        Space: 0
-      VulkanBinding:
-        Binding: 6
-    - Name: OutWins
-      Kind: RWStructuredBuffer
-      DirectXBinding:
-        Register: 7
-        Space: 0
-      VulkanBinding:
-        Binding: 7
 ...
 #--- end
 
@@ -291,9 +213,6 @@ DescriptorSets:
 
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/7782
 # XFAIL: Vulkan && DXC
-
-# Bug: https://github.com/llvm/offload-test-suite/issues/1418
-# UNSUPPORTED: WARP && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
This PR adds the `InterlockedCompareExchangeFloatBitwise` tests.
Since the function does not have any 64 bit overloads, there are fewer tests, but they should cover all use cases of this function.

Resolves: https://github.com/llvm/offload-test-suite/issues/851
Assisted by: Github Copilot