### PR TITLE
[ci_results] Work around `gh` stale data issues

### DIFF
--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -413,6 +413,8 @@ def runid_index(runids, runid):
 
 def get_last_run(workflow, status="completed"):
     last_run = get_last_run_internal(workflow, status)
+    if not last_run:
+        return None
 
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
@@ -452,6 +454,8 @@ def get_last_run_internal(workflow, status):
 
 def get_recent_runs(workflow, *, run_limit):
     recent_runs = get_recent_runs_internal(workflow, run_limit=run_limit)
+    if not recent_runs:
+        return None
 
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
@@ -459,7 +463,7 @@ def get_recent_runs(workflow, *, run_limit):
         ran_at = dt.datetime.fromisoformat(recent_runs[0]["createdAt"])
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
-        last_run = get_recent_runs_internal(workflow, run_limit=run_limit)
+        recent_runs = get_recent_runs_internal(workflow, run_limit=run_limit)
 
     return recent_runs
 

--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -4,6 +4,7 @@
 
 import argparse
 import bisect
+import datetime as dt
 import json
 import pathlib
 import re
@@ -411,6 +412,20 @@ def runid_index(runids, runid):
 
 
 def get_last_run(workflow, status="completed"):
+    last_run = get_last_run_internal(workflow, status)
+
+    for _ in range(5):
+        # The gh cli seems to sometimes just return results from a month ago.
+        # Work around it by trying again a few times if the results seem stale.
+        ran_at = dt.datetime.fromisoformat(last_run['createdAt'])
+        if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
+            break
+        last_run = get_last_run_internal(workflow, status)
+
+    return last_run
+
+
+def get_last_run_internal(workflow, status):
     output = subprocess.run(
         [
             "gh",
@@ -436,6 +451,20 @@ def get_last_run(workflow, status="completed"):
 
 
 def get_recent_runs(workflow, *, run_limit):
+    recent_runs = get_recent_runs_internal(workflow, run_limit=run_limit)
+
+    for _ in range(5):
+        # The gh cli seems to sometimes just return results from a month ago.
+        # Work around it by trying again a few times if the results seem stale.
+        ran_at = dt.datetime.fromisoformat(recent_runs[0]['createdAt'])
+        if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
+            break
+        last_run = get_recent_runs_internal(workflow, run_limit=run_limit)
+
+    return recent_runs
+
+
+def get_recent_runs_internal(workflow, *, run_limit):
     output = subprocess.run(
         [
             "gh",

--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -417,7 +417,7 @@ def get_last_run(workflow, status="completed"):
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
         # Work around it by trying again a few times if the results seem stale.
-        ran_at = dt.datetime.fromisoformat(last_run['createdAt'])
+        ran_at = dt.datetime.fromisoformat(last_run["createdAt"])
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
         last_run = get_last_run_internal(workflow, status)
@@ -456,7 +456,7 @@ def get_recent_runs(workflow, *, run_limit):
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
         # Work around it by trying again a few times if the results seem stale.
-        ran_at = dt.datetime.fromisoformat(recent_runs[0]['createdAt'])
+        ran_at = dt.datetime.fromisoformat(recent_runs[0]["createdAt"])
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
         last_run = get_recent_runs_internal(workflow, run_limit=run_limit)


### PR DESCRIPTION
Calling `gh` has started to return data from a month or so ago fairly frequently. Trying again seems to help, and experimentally it generally only takes a couple of tries to get the correct data.

This is presumably a bug in github's API, but it makes it very hard to use the ci_results script. Implement a workaround that just tries over repeatedly.