### PR TITLE
Correct atomic int64 XFAILs

### DIFF
--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -143,7 +143,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# Bug: https://github.com/llvm/llvm-project/issues/217196
 # XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -154,9 +154,6 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99122
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
 

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -155,7 +155,7 @@ DescriptorSets:
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
 # Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang
+# XFAIL: Clang && (DirectX || Metal)
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -154,6 +154,9 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
+# Bug: https://github.com/llvm/llvm-project/issues/217196
+# XFAIL: Clang
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
 

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -122,7 +122,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# Bug: https://github.com/llvm/llvm-project/issues/217196
 # XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedOr.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.int64.test
@@ -127,6 +127,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/217196
+# XFAIL: Clang && (DirectX || Metal)
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedOr.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.int64.test
@@ -127,9 +127,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Clang && !(Intel && !WARP)
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedXor.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.32.test
@@ -194,7 +194,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1402
+# Bug: https://github.com/llvm/llvm-project/issues/217196
 # XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedXor.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.int64.test
@@ -171,9 +171,6 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99127
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
 

--- a/test/Feature/HLSLLib/InterlockedXor.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.int64.test
@@ -171,6 +171,9 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
+# Bug: https://github.com/llvm/llvm-project/issues/217196
+# XFAIL: Clang && (DirectX || Metal)
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
 


### PR DESCRIPTION
Update these XFAILs to be specific to the DXIL path, and remove the XFAILs for Vulkan.

These are guarded by Int64GroupSharedAtomics, which means they don't run at all on intel or QC. This made it a bit less obvious that they're XPASSing on all Vulkan paths.

A couple of the XFAIL links here were incorrect, and for the ones that were accurate I've migrated the issue to llvm, so it's better to use that URL.
