### PR TITLE
[ci_results] Use strptime instead of fromisoformat

### DIFF
--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -419,7 +419,8 @@ def get_last_run(workflow, status="completed"):
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
         # Work around it by trying again a few times if the results seem stale.
-        ran_at = dt.datetime.fromisoformat(last_run["createdAt"])
+        ran_at = dt.datetime.strptime(last_run["createdAt"],
+                                      "%Y-%m-%dT%H:%M:%S%z")
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
         last_run = get_last_run_internal(workflow, status)
@@ -460,7 +461,8 @@ def get_recent_runs(workflow, *, run_limit):
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
         # Work around it by trying again a few times if the results seem stale.
-        ran_at = dt.datetime.fromisoformat(recent_runs[0]["createdAt"])
+        ran_at = dt.datetime.strptime(recent_runs[0]["createdAt"],
+                                      "%Y-%m-%dT%H:%M:%S%z")
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
         recent_runs = get_recent_runs_internal(workflow, run_limit=run_limit)

--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -419,8 +419,7 @@ def get_last_run(workflow, status="completed"):
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
         # Work around it by trying again a few times if the results seem stale.
-        ran_at = dt.datetime.strptime(last_run["createdAt"],
-                                      "%Y-%m-%dT%H:%M:%S%z")
+        ran_at = parse_github_timestamp(last_run["createdAt"])
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
         last_run = get_last_run_internal(workflow, status)
@@ -461,8 +460,7 @@ def get_recent_runs(workflow, *, run_limit):
     for _ in range(5):
         # The gh cli seems to sometimes just return results from a month ago.
         # Work around it by trying again a few times if the results seem stale.
-        ran_at = dt.datetime.strptime(recent_runs[0]["createdAt"],
-                                      "%Y-%m-%dT%H:%M:%S%z")
+        ran_at = parse_github_timestamp(recent_runs[0]["createdAt"])
         if dt.datetime.now(ran_at.tzinfo) - ran_at < dt.timedelta(days=1):
             break
         recent_runs = get_recent_runs_internal(workflow, run_limit=run_limit)
@@ -493,6 +491,10 @@ def get_recent_runs_internal(workflow, *, run_limit):
     if not output:
         return None
     return json.loads(output)
+
+
+def parse_github_timestamp(timestamp):
+    return dt.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S%z")
 
 
 def get_log_proc(databaseId):


### PR DESCRIPTION
Apparently [fromisoformat] got smarter in python 3.11. Use strptime for compatibility with older python, since we know the exact format of github's dates anyway.

[fromisoformat]:
  https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat