### PR TITLE
Fix golden image filename case

### DIFF
--- a/test/Graphics/MeshShaders/SimpleLines.test
+++ b/test/Graphics/MeshShaders/SimpleLines.test
@@ -84,4 +84,4 @@ REQUIRES: MeshShader
 # RUN: %dxc_target -T ms_6_5 -Fo %t-mesh.o %t/mesh.hlsl
 # RUN: %dxc_target -T ps_6_5 -Fo %t-pixel.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-mesh.o %t-pixel.o -r Output -o %t/Output.png
-# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/MeshShaders/SimpleLines.png -rules %t/rules.yaml
+# RUN: imgdiff %t/Output.png %goldenimage_dir/hlsl/Graphics/meshshaders/simplelines.png -rules %t/rules.yaml


### PR DESCRIPTION
The SimpleLines.test failed on Ubuntu due to the filename of the golden image having a case mismatch with the actual filename, leading to the golden image not being found.
This change trivially corrects the filename case.

Fixes #1457