### PR TITLE
Respect NuGet sources when downloading packages

### DIFF
--- a/cmake/modules/NuGet.cmake
+++ b/cmake/modules/NuGet.cmake
@@ -1,3 +1,11 @@
+option(OFFLOADTEST_USE_NUGET_EXE
+  "Use nuget.exe from PATH to download NuGet packages" ON)
+
+if (OFFLOADTEST_USE_NUGET_EXE)
+  find_program(OFFLOADTEST_NUGET_EXECUTABLE NAMES nuget.exe)
+  mark_as_advanced(OFFLOADTEST_NUGET_EXECUTABLE)
+endif()
+
 function(guess_nuget_arch output_var)
   if (CMAKE_C_COMPILER_ARCHITECTURE_ID)
     set(compiler_arch "${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
@@ -24,14 +32,65 @@ function(guess_nuget_arch output_var)
   endif()
 endfunction()
 
-function(download_nuget_package package version output_var)
-  set(archive "${CMAKE_CURRENT_BINARY_DIR}/${package}.${version}.zip")
+function(download_nuget_package_with_cli package version archive)
+  set(package_dir
+    "${CMAKE_CURRENT_BINARY_DIR}/nuget-downloads/${package}")
+  file(REMOVE_RECURSE "${package_dir}")
+
+  set(nuget_args
+    install "${package}"
+    -OutputDirectory "${package_dir}"
+    -DependencyVersion Ignore
+    -DirectDownload
+    -PackageSaveMode nupkg
+    -NonInteractive
+    -ForceEnglishOutput)
+  if (NOT version STREQUAL "Latest")
+    list(APPEND nuget_args -Version "${version}")
+  endif()
+
+  message(STATUS
+    "Downloading NuGet package ${package} ${version} with "
+    "${OFFLOADTEST_NUGET_EXECUTABLE}")
+  execute_process(
+    COMMAND "${OFFLOADTEST_NUGET_EXECUTABLE}" ${nuget_args}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE nuget_result
+    OUTPUT_VARIABLE nuget_output
+    ERROR_VARIABLE nuget_error
+    ECHO_OUTPUT_VARIABLE
+    ECHO_ERROR_VARIABLE)
+  if (NOT nuget_result EQUAL 0)
+    file(REMOVE_RECURSE "${package_dir}")
+    message(FATAL_ERROR
+      "nuget.exe failed to download package ${package} ${version} "
+      "(exit code ${nuget_result}).\n${nuget_output}${nuget_error}")
+  endif()
+
+  file(GLOB_RECURSE package_archives LIST_DIRECTORIES FALSE
+    "${package_dir}/*.nupkg")
+  list(LENGTH package_archives archive_count)
+  if (NOT archive_count EQUAL 1)
+    file(REMOVE_RECURSE "${package_dir}")
+    message(FATAL_ERROR
+      "Expected nuget.exe to save one package archive for "
+      "${package} ${version}, found ${archive_count}.")
+  endif()
+
+  list(GET package_archives 0 package_archive)
+  file(COPY_FILE "${package_archive}" "${archive}" ONLY_IF_DIFFERENT)
+  file(REMOVE_RECURSE "${package_dir}")
+endfunction()
+
+function(download_nuget_package_direct package version archive)
   if (version STREQUAL "Latest")
     set(url "https://www.nuget.org/api/v2/package/${package}/")
   else()
     set(url "https://www.nuget.org/api/v2/package/${package}/${version}/")
   endif()
 
+  message(STATUS
+    "Downloading NuGet package ${package} ${version} directly from nuget.org")
   file(DOWNLOAD "${url}" "${archive}"
     STATUS download_status
     TLS_VERIFY ON)
@@ -42,6 +101,24 @@ function(download_nuget_package package version output_var)
     message(FATAL_ERROR
       "Failed to download NuGet package ${package} ${version}: "
       "${status_message}")
+  endif()
+endfunction()
+
+function(download_nuget_package package version output_var)
+  set(archive "${CMAKE_CURRENT_BINARY_DIR}/${package}.${version}.zip")
+  file(REMOVE "${archive}")
+
+  if (OFFLOADTEST_USE_NUGET_EXE AND OFFLOADTEST_NUGET_EXECUTABLE)
+    download_nuget_package_with_cli("${package}" "${version}" "${archive}")
+  else()
+    if (OFFLOADTEST_USE_NUGET_EXE)
+      message(STATUS
+        "nuget.exe was not found on PATH; using the direct web downloader")
+    else()
+      message(STATUS
+        "OFFLOADTEST_USE_NUGET_EXE is OFF; using the direct web downloader")
+    endif()
+    download_nuget_package_direct("${package}" "${version}" "${archive}")
   endif()
 
   set(${output_var} "${archive}" PARENT_SCOPE)

--- a/cmake/modules/NuGet.cmake
+++ b/cmake/modules/NuGet.cmake
@@ -35,6 +35,7 @@ endfunction()
 function(download_nuget_package_with_cli package version archive)
   set(package_dir
     "${CMAKE_CURRENT_BINARY_DIR}/nuget-downloads/${package}")
+  # Avoid stale archives when Latest resolves to a different package version.
   file(REMOVE_RECURSE "${package_dir}")
 
   set(nuget_args
@@ -61,6 +62,7 @@ function(download_nuget_package_with_cli package version archive)
     ECHO_OUTPUT_VARIABLE
     ECHO_ERROR_VARIABLE)
   if (NOT nuget_result EQUAL 0)
+    # Remove any partial package left by the failed NuGet invocation.
     file(REMOVE_RECURSE "${package_dir}")
     message(FATAL_ERROR
       "nuget.exe failed to download package ${package} ${version} "
@@ -71,6 +73,7 @@ function(download_nuget_package_with_cli package version archive)
     "${package_dir}/*.nupkg")
   list(LENGTH package_archives archive_count)
   if (NOT archive_count EQUAL 1)
+    # Remove the unexpected package layout before reporting the error.
     file(REMOVE_RECURSE "${package_dir}")
     message(FATAL_ERROR
       "Expected nuget.exe to save one package archive for "
@@ -79,6 +82,7 @@ function(download_nuget_package_with_cli package version archive)
 
   list(GET package_archives 0 package_archive)
   file(COPY_FILE "${package_archive}" "${archive}" ONLY_IF_DIFFERENT)
+  # Callers extract the retained archive, so discard NuGet's staging tree.
   file(REMOVE_RECURSE "${package_dir}")
 endfunction()
 

--- a/docs/Direct3D.md
+++ b/docs/Direct3D.md
@@ -31,6 +31,12 @@ The **AGILITY_SDK_VERSION** CMake option selects the package:
 * `Latest` downloads the latest stable package from NuGet.
 * An explicit NuGet package version may be specified.
 
+When `nuget.exe` is available on `PATH`, CMake uses it to download the package,
+including its configured NuGet sources and authentication. If it is not
+available, CMake downloads the package directly from nuget.org. Set
+**OFFLOADTEST_USE_NUGET_EXE**, which defaults to `ON`, to `OFF` to force the
+direct download.
+
 For example:
 
 ```shell

--- a/docs/WARP.md
+++ b/docs/WARP.md
@@ -22,3 +22,9 @@ WARP:
   explicit WARP version, and the configuration step will pull WARP from NuGet.
   See the [NuGet package listing](https://www.nuget.org/packages/Microsoft.Direct3D.WARP)
   to identify valid versions.
+
+When `nuget.exe` is available on `PATH`, CMake uses it to download WARP,
+including its configured NuGet sources and authentication. If it is not
+available, CMake downloads WARP directly from nuget.org. Set
+**OFFLOADTEST_USE_NUGET_EXE**, which defaults to `ON`, to `OFF` to force the
+direct download.


### PR DESCRIPTION
- Prefer `nuget.exe` when available so configured package sources and authentication are honored.
- Preserve direct nuget.org downloads when `nuget.exe` is unavailable or `OFFLOADTEST_USE_NUGET_EXE=OFF`.

_Assisted by GitHub Copilot._