### PR TITLE
[Metal] Add support for uint32 formats

### DIFF
--- a/lib/API/MTL/MTLDevice.cpp
+++ b/lib/API/MTL/MTLDevice.cpp
@@ -114,6 +114,8 @@ static MTL::PixelFormat getMTLFormat(DataFormat Format, int Channels) {
   switch (Format) {
   case DataFormat::Int32:
     MTLFormats(32Sint) break;
+  case DataFormat::UInt32:
+    MTLFormats(32Uint) break;
   case DataFormat::Float32:
     MTLFormats(32Float) break;
   case DataFormat::UInt64:

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
@@ -223,9 +223,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99125
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareExchange.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchange.resources.32.test
@@ -309,9 +309,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99130
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
 # UNSUPPORTED: WARP && DXC
 

--- a/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStore.resources.32.test
@@ -249,9 +249,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99128
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
 # UNSUPPORTED: WARP && DXC
 

--- a/test/Feature/HLSLLib/InterlockedMax.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMax.resources.32.test
@@ -235,9 +235,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99124
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -234,9 +234,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99123
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedOr.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.32.test
@@ -222,9 +222,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/194930
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.32.test
@@ -249,9 +249,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99127
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
All of these interlock failures were just because the offloader did not know how to handle uint32 data formats. A small two line fix was needed.