### PR TITLE
Update xfails for `InterlockedMin` tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -181,9 +181,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -181,6 +181,8 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/217196
+# XFAIL: Clang && (DirectX || Metal)
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -183,6 +183,7 @@ DescriptorSets:
 
 # Bug: https://github.com/llvm/llvm-project/issues/217196
 # XFAIL: Clang && (DirectX || Metal)
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -168,9 +168,6 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
 

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -169,7 +169,7 @@ DescriptorSets:
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: DXC && Metal
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -170,6 +170,7 @@ DescriptorSets:
 
 # Bug: https://github.com/llvm/llvm-project/issues/217831
 # XFAIL: Clang && Vulkan
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal
 

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -168,6 +168,8 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
+# Bug: https://github.com/llvm/llvm-project/issues/217831
+# XFAIL: Clang && Vulkan
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal
 

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -168,8 +168,8 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Bug: https://github.com/llvm/llvm-project/issues/217831
-# XFAIL: Clang && Vulkan
+# Bug: https://github.com/llvm/llvm-project/issues/217196
+# XFAIL: Clang && (DirectX || Metal)
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -231,9 +231,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -231,6 +231,12 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/218034
+# XFAIL: Clang && (DirectX || Metal)
+
+# Bug: https://github.com/llvm/llvm-project/issues/217831
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -176,8 +176,11 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/217831
+# XFAIL: Clang && Vulkan
+
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
+# XFAIL: Metal
 
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
 # XFAIL: Vulkan && DXC

--- a/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.int64.test
@@ -176,9 +176,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -132,6 +132,8 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/217823
+# XFAIL: Clang && Vulkan
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -132,9 +132,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99123
-# XFAIL: Clang
-
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.typed.int64.test
@@ -134,6 +134,7 @@ DescriptorSets:
 
 # Bug: https://github.com/llvm/llvm-project/issues/217823
 # XFAIL: Clang && Vulkan
+
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_6 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/216856 just merged, so it is implemented in clang upstream.
So, we should remove the relevant xfails in the offload test suite.