### PR TITLE
[Vulkan][DirectX] Refactor texture handling in anticipation of other texture types

### DIFF
--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -26,11 +26,11 @@ enum class ResourceKind {
   AccelerationStructure,
 };
 
-enum class TextureShape {
-  Texture1D,
-  Texture2D,
-  Texture3D,
-  TextureCube,
+enum class ResourceDimension {
+  Dim1D,
+  Dim2D,
+  Dim3D,
+  Cube,
 };
 
 enum ShaderContainerType {

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -26,6 +26,13 @@ enum class ResourceKind {
   AccelerationStructure,
 };
 
+enum class TextureDimension {
+  One,
+  Two,
+  Three,
+  Cube,
+};
+
 enum ShaderContainerType {
   DXIL,
   SPIRV,

--- a/include/API/Enums.h
+++ b/include/API/Enums.h
@@ -26,11 +26,11 @@ enum class ResourceKind {
   AccelerationStructure,
 };
 
-enum class TextureDimension {
-  One,
-  Two,
-  Three,
-  Cube,
+enum class TextureShape {
+  Texture1D,
+  Texture2D,
+  Texture3D,
+  TextureCube,
 };
 
 enum ShaderContainerType {

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -13,6 +13,7 @@
 #define OFFLOADTEST_API_TEXTURE_H
 
 #include "API/API.h"
+#include "API/Enums.h"
 #include "API/Resources.h"
 
 #include "llvm/ADT/BitmaskEnum.h"
@@ -21,6 +22,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Error.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -73,9 +75,20 @@ struct TextureCreateDesc {
   MemoryBacking Backing = MemoryBacking::Automatic;
   TextureUsage Usage = {};
   Format Fmt = Format::RGBA32Float;
+  TextureDimension Dim = TextureDimension::Two;
   uint32_t Width = 1;
   uint32_t Height = 1;
   uint32_t MipLevels = 1;
+
+  // The total number of subresources: one per mip level today.
+  uint32_t getSubresourceCount() const { return MipLevels; }
+
+  uint32_t getMipWidth(uint32_t Mip) const {
+    return std::max(1u, Width >> Mip);
+  }
+  uint32_t getMipHeight(uint32_t Mip) const {
+    return std::max(1u, Height >> Mip);
+  }
   // Clear value for render target or depth/stencil textures.
   // How and when this is applied depends on the backend:
   // - DX uses it as an optimized clear hint at resource creation time
@@ -89,6 +102,11 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
         std::errc::invalid_argument,
         "Format '%s' is not compatible with texture creation.",
         getFormatName(Desc.Fmt).data());
+
+  // Only 2D textures are implemented for now.
+  if (Desc.Dim != TextureDimension::Two)
+    return llvm::createStringError(std::errc::not_supported,
+                                   "Only 2D textures are supported.");
 
   const bool IsDepth = isDepthFormat(Desc.Fmt);
   const bool IsRT = (Desc.Usage & TextureUsage::RenderTarget) != 0;
@@ -159,7 +177,26 @@ struct SubresourceFootprint {
 struct TextureUploadLayout {
   llvm::SmallVector<SubresourceFootprint> Subresources; // One entry per mip.
   uint64_t TotalSizeInBytes = 0;
+
+  // The size of the tightly-packed host-side representation of this texture:
+  // every subresource's rows back to back with no row or subresource padding.
+  uint64_t getPackedSizeInBytes() const {
+    uint64_t Size = 0;
+    for (const SubresourceFootprint &Sub : Subresources)
+      Size += uint64_t(Sub.RowSizeInBytes) * Sub.NumRows;
+    return Size;
+  }
 };
+
+// Copy a texture's contents between a tightly-packed host buffer and a
+// (possibly row/subresource padded) GPU-visible mapping described by `Layout`.
+// These are the single place that knows how to bridge the two layouts, so
+// backends with alignment requirements (e.g. D3D12's 256-byte
+// D3D12_TEXTURE_DATA_PITCH_ALIGNMENT) work for arbitrary widths.
+void copyPackedToTextureLayout(void *Dst, const void *PackedSrc,
+                               const TextureUploadLayout &Layout);
+void copyTextureLayoutToPacked(void *PackedDst, const void *Src,
+                               const TextureUploadLayout &Layout);
 
 // Compute a tightly-packed upload layout (no row or subresource padding) for
 // the given texture description. Suitable for backends whose buffer-to-texture

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -190,9 +190,9 @@ struct TextureUploadLayout {
 
 // Copy a texture's contents between a tightly-packed host buffer and a
 // (possibly row/subresource padded) GPU-visible mapping described by `Layout`.
-// These are the single place that knows how to bridge the two layouts, so
-// backends with alignment requirements (e.g. D3D12's 256-byte
-// D3D12_TEXTURE_DATA_PITCH_ALIGNMENT) work for arbitrary widths.
+// These methods know how to bridge the two layouts, so backends with alignment
+// requirements (e.g. D3D12's 256-byte D3D12_TEXTURE_DATA_PITCH_ALIGNMENT) work
+// for arbitrary widths.
 void copyPackedToTextureLayout(void *Dst, const void *PackedSrc,
                                const TextureUploadLayout &Layout);
 void copyTextureLayoutToPacked(void *PackedDst, const void *Src,

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -69,14 +69,14 @@ struct ClearDepthStencil {
 using ClearValue = std::variant<ClearColor, ClearDepthStencil>;
 
 // TODO: Currently only 2D textures are supported. When expanding to 1D, 3D,
-// cube, or array textures, add validation between usage and TextureShape
+// cube, or array textures, add validation between usage and ResourceDimension
 // (e.g. 3D textures cannot be used as DepthStencil).
 struct TextureCreateDesc {
   MemoryLocation Location = MemoryLocation::GpuOnly;
   MemoryBacking Backing = MemoryBacking::Automatic;
   TextureUsage Usage = {};
   Format Fmt = Format::RGBA32Float;
-  TextureShape Shape = TextureShape::Texture2D;
+  ResourceDimension Dim = ResourceDimension::Dim2D;
   uint32_t Width = 1;
   uint32_t Height = 1;
   uint32_t MipLevels = 1;
@@ -107,7 +107,7 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
         getFormatName(Desc.Fmt).data());
 
   // Only 2D textures are implemented for now.
-  if (Desc.Shape != TextureShape::Texture2D)
+  if (Desc.Dim != ResourceDimension::Dim2D)
     return llvm::createStringError(std::errc::not_supported,
                                    "Only 2D textures are supported.");
 

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -23,6 +23,7 @@
 #include "llvm/Support/Error.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -68,14 +69,14 @@ struct ClearDepthStencil {
 using ClearValue = std::variant<ClearColor, ClearDepthStencil>;
 
 // TODO: Currently only 2D textures are supported. When expanding to 1D, 3D,
-// cube, or array textures, add a TextureType enum and validation between usage
-// and type (e.g. 3D textures cannot be used as DepthStencil).
+// cube, or array textures, add validation between usage and TextureShape
+// (e.g. 3D textures cannot be used as DepthStencil).
 struct TextureCreateDesc {
   MemoryLocation Location = MemoryLocation::GpuOnly;
   MemoryBacking Backing = MemoryBacking::Automatic;
   TextureUsage Usage = {};
   Format Fmt = Format::RGBA32Float;
-  TextureDimension Dim = TextureDimension::Two;
+  TextureShape Shape = TextureShape::Texture2D;
   uint32_t Width = 1;
   uint32_t Height = 1;
   uint32_t MipLevels = 1;
@@ -84,9 +85,11 @@ struct TextureCreateDesc {
   uint32_t getSubresourceCount() const { return MipLevels; }
 
   uint32_t getMipWidth(uint32_t Mip) const {
+    assert(Mip < MipLevels && "Mip level index out of bounds.");
     return std::max(1u, Width >> Mip);
   }
   uint32_t getMipHeight(uint32_t Mip) const {
+    assert(Mip < MipLevels && "Mip level index out of bounds.");
     return std::max(1u, Height >> Mip);
   }
   // Clear value for render target or depth/stencil textures.
@@ -104,7 +107,7 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
         getFormatName(Desc.Fmt).data());
 
   // Only 2D textures are implemented for now.
-  if (Desc.Dim != TextureDimension::Two)
+  if (Desc.Shape != TextureShape::Texture2D)
     return llvm::createStringError(std::errc::not_supported,
                                    "Only 2D textures are supported.");
 

--- a/include/API/Texture.h
+++ b/include/API/Texture.h
@@ -111,6 +111,29 @@ inline llvm::Error validateTextureCreateDesc(const TextureCreateDesc &Desc) {
     return llvm::createStringError(std::errc::not_supported,
                                    "Only 2D textures are supported.");
 
+  if (Desc.Width == 0 || Desc.Height == 0)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "Texture dimensions must be non-zero, got %ux%u.", Desc.Width,
+        Desc.Height);
+
+  if (Desc.MipLevels == 0)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "Texture must have at least one mip level.");
+
+  // A full mip chain halves the largest extent until it reaches 1x1, so the
+  // texture supports floor(log2(max(Width, Height))) + 1 levels.
+  // TODO: Account for Depth when 3D textures are supported.
+  uint32_t MaxMipLevels = 0;
+  for (uint32_t Extent = std::max(Desc.Width, Desc.Height); Extent != 0;
+       Extent >>= 1)
+    ++MaxMipLevels;
+  if (Desc.MipLevels > MaxMipLevels)
+    return llvm::createStringError(
+        std::errc::invalid_argument,
+        "Texture dimensions %ux%u support at most %u mip levels, got %u.",
+        Desc.Width, Desc.Height, MaxMipLevels, Desc.MipLevels);
+
   const bool IsDepth = isDepthFormat(Desc.Fmt);
   const bool IsRT = (Desc.Usage & TextureUsage::RenderTarget) != 0;
   const bool IsDS = (Desc.Usage & TextureUsage::DepthStencil) != 0;

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -104,25 +104,25 @@ static uint32_t getAlignedTexturePitch(uint32_t Width, uint32_t ElementSize) {
   return llvm::alignTo(Width * ElementSize, D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 }
 
-static D3D12_RESOURCE_DIMENSION getDXResourceDimension(TextureShape Shape) {
-  switch (Shape) {
-  case TextureShape::Texture1D:
+static D3D12_RESOURCE_DIMENSION getDXResourceDimension(ResourceDimension Dim) {
+  switch (Dim) {
+  case ResourceDimension::Dim1D:
     return D3D12_RESOURCE_DIMENSION_TEXTURE1D;
-  case TextureShape::Texture2D:
-  case TextureShape::TextureCube:
+  case ResourceDimension::Dim2D:
+  case ResourceDimension::Cube:
     // A cube map is a 2D resource with six slices per cube.
     return D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-  case TextureShape::Texture3D:
+  case ResourceDimension::Dim3D:
     return D3D12_RESOURCE_DIMENSION_TEXTURE3D;
   }
-  llvm_unreachable("All texture shapes handled");
+  llvm_unreachable("All texture dimensions handled");
 }
 
 // Only the fields GetCopyableFootprints consults are needed here; layout,
 // flags, and clear value do not affect the copyable footprint.
 static D3D12_RESOURCE_DESC getDXResourceDesc(const TextureCreateDesc &Desc) {
   D3D12_RESOURCE_DESC TexDesc = {};
-  TexDesc.Dimension = getDXResourceDimension(Desc.Shape);
+  TexDesc.Dimension = getDXResourceDimension(Desc.Dim);
   TexDesc.Width = Desc.Width;
   TexDesc.Height = Desc.Height;
   TexDesc.DepthOrArraySize = 1;
@@ -133,27 +133,27 @@ static D3D12_RESOURCE_DESC getDXResourceDesc(const TextureCreateDesc &Desc) {
 }
 
 static D3D12_SRV_DIMENSION getDXSRVDimension(const TextureCreateDesc &Desc) {
-  switch (Desc.Shape) {
-  case TextureShape::Texture2D:
+  switch (Desc.Dim) {
+  case ResourceDimension::Dim2D:
     return D3D12_SRV_DIMENSION_TEXTURE2D;
-  case TextureShape::Texture1D:
-  case TextureShape::Texture3D:
-  case TextureShape::TextureCube:
-    llvm_unreachable("Texture shape has no SRV mapping yet");
+  case ResourceDimension::Dim1D:
+  case ResourceDimension::Dim3D:
+  case ResourceDimension::Cube:
+    llvm_unreachable("Texture dimension has no SRV mapping yet");
   }
-  llvm_unreachable("All texture shapes handled");
+  llvm_unreachable("All texture dimensions handled");
 }
 
 static D3D12_UAV_DIMENSION getDXUAVDimension(const TextureCreateDesc &Desc) {
-  switch (Desc.Shape) {
-  case TextureShape::Texture2D:
+  switch (Desc.Dim) {
+  case ResourceDimension::Dim2D:
     return D3D12_UAV_DIMENSION_TEXTURE2D;
-  case TextureShape::Texture1D:
-  case TextureShape::Texture3D:
-  case TextureShape::TextureCube:
-    llvm_unreachable("Texture shape has no UAV mapping yet");
+  case ResourceDimension::Dim1D:
+  case ResourceDimension::Dim3D:
+  case ResourceDimension::Cube:
+    llvm_unreachable("Texture dimension has no UAV mapping yet");
   }
-  llvm_unreachable("All texture shapes handled");
+  llvm_unreachable("All texture dimensions handled");
 }
 
 static D3D12_PRIMITIVE_TOPOLOGY_TYPE

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -104,6 +104,58 @@ static uint32_t getAlignedTexturePitch(uint32_t Width, uint32_t ElementSize) {
   return llvm::alignTo(Width * ElementSize, D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 }
 
+static D3D12_RESOURCE_DIMENSION getDXResourceDimension(TextureDimension Dim) {
+  switch (Dim) {
+  case TextureDimension::One:
+    return D3D12_RESOURCE_DIMENSION_TEXTURE1D;
+  case TextureDimension::Two:
+  case TextureDimension::Cube:
+    // A cube map is a 2D resource with six slices per cube.
+    return D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+  case TextureDimension::Three:
+    return D3D12_RESOURCE_DIMENSION_TEXTURE3D;
+  }
+  llvm_unreachable("All texture dimensions handled");
+}
+
+// Only the fields GetCopyableFootprints consults are needed here; layout,
+// flags, and clear value do not affect the copyable footprint.
+static D3D12_RESOURCE_DESC getDXResourceDesc(const TextureCreateDesc &Desc) {
+  D3D12_RESOURCE_DESC TexDesc = {};
+  TexDesc.Dimension = getDXResourceDimension(Desc.Dim);
+  TexDesc.Width = Desc.Width;
+  TexDesc.Height = Desc.Height;
+  TexDesc.DepthOrArraySize = 1;
+  TexDesc.MipLevels = static_cast<UINT16>(Desc.MipLevels);
+  TexDesc.Format = getDXGIFormat(Desc.Fmt);
+  TexDesc.SampleDesc.Count = 1;
+  return TexDesc;
+}
+
+static D3D12_SRV_DIMENSION getDXSRVDimension(const TextureCreateDesc &Desc) {
+  switch (Desc.Dim) {
+  case TextureDimension::Two:
+    return D3D12_SRV_DIMENSION_TEXTURE2D;
+  case TextureDimension::One:
+  case TextureDimension::Three:
+  case TextureDimension::Cube:
+    llvm_unreachable("Texture dimension has no SRV mapping yet");
+  }
+  llvm_unreachable("All texture dimensions handled");
+}
+
+static D3D12_UAV_DIMENSION getDXUAVDimension(const TextureCreateDesc &Desc) {
+  switch (Desc.Dim) {
+  case TextureDimension::Two:
+    return D3D12_UAV_DIMENSION_TEXTURE2D;
+  case TextureDimension::One:
+  case TextureDimension::Three:
+  case TextureDimension::Cube:
+    llvm_unreachable("Texture dimension has no UAV mapping yet");
+  }
+  llvm_unreachable("All texture dimensions handled");
+}
+
 static D3D12_PRIMITIVE_TOPOLOGY_TYPE
 getDXPrimitiveTopologyType(PrimitiveTopology Topology) {
   switch (Topology) {
@@ -890,7 +942,7 @@ public:
     CB.flushBarrier();
 
     const D3D12_RESOURCE_DESC TexDesc = DXDst.Resource->GetDesc();
-    const uint32_t NumSubresources = TexDesc.MipLevels;
+    const uint32_t NumSubresources = DXDst.Desc.getSubresourceCount();
     llvm::SmallVector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> Layouts(
         NumSubresources);
     ComPtr<ID3D12DeviceX> Device;
@@ -964,15 +1016,23 @@ public:
 
     CB.flushBarrier();
 
-    const uint32_t ElementSize = getFormatSizeInBytes(DXSrc.Desc.Fmt);
-    const D3D12_PLACED_SUBRESOURCE_FOOTPRINT Footprint{
-        0,
-        CD3DX12_SUBRESOURCE_FOOTPRINT(
-            getDXGIFormat(DXSrc.Desc.Fmt), DXSrc.Desc.Width, DXSrc.Desc.Height,
-            1, getAlignedTexturePitch(DXSrc.Desc.Width, ElementSize))};
-    const CD3DX12_TEXTURE_COPY_LOCATION DstLoc(DXDst.Buffer.Get(), Footprint);
-    const CD3DX12_TEXTURE_COPY_LOCATION SrcLoc(DXSrc.Resource.Get(), 0);
-    CB.CmdList->CopyTextureRegion(&DstLoc, 0, 0, 0, &SrcLoc, nullptr);
+    // Read back every subresource into the destination buffer using the same
+    // footprints the upload path uses, so the readback is laid out exactly
+    // like getTextureUploadLayout() describes.
+    const D3D12_RESOURCE_DESC TexDesc = DXSrc.Resource->GetDesc();
+    const uint32_t NumSubresources = DXSrc.Desc.getSubresourceCount();
+    llvm::SmallVector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> Layouts(
+        NumSubresources);
+    ComPtr<ID3D12DeviceX> Device;
+    DXSrc.Resource->GetDevice(IID_PPV_ARGS(&Device));
+    Device->GetCopyableFootprints(&TexDesc, 0, NumSubresources, 0,
+                                  Layouts.data(), nullptr, nullptr, nullptr);
+    for (uint32_t Sub = 0; Sub < NumSubresources; ++Sub) {
+      const CD3DX12_TEXTURE_COPY_LOCATION DstLoc(DXDst.Buffer.Get(),
+                                                 Layouts[Sub]);
+      const CD3DX12_TEXTURE_COPY_LOCATION SrcLoc(DXSrc.Resource.Get(), Sub);
+      CB.CmdList->CopyTextureRegion(&DstLoc, 0, 0, 0, &SrcLoc, nullptr);
+    }
 
     if (DXSrc.PreferredState != D3D12_RESOURCE_STATE_COPY_SOURCE)
       CB.addResourceTransition(DXSrc.Resource.Get(),
@@ -2036,14 +2096,7 @@ public:
     const D3D12_HEAP_PROPERTIES HeapProps =
         CD3DX12_HEAP_PROPERTIES(getDXHeapType(Desc.Location));
 
-    D3D12_RESOURCE_DESC TexDesc = {};
-    TexDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-    TexDesc.Width = Desc.Width;
-    TexDesc.Height = Desc.Height;
-    TexDesc.DepthOrArraySize = 1;
-    TexDesc.MipLevels = static_cast<UINT16>(Desc.MipLevels);
-    TexDesc.Format = getDXGIFormat(Desc.Fmt);
-    TexDesc.SampleDesc.Count = 1;
+    D3D12_RESOURCE_DESC TexDesc = getDXResourceDesc(Desc);
     if (Desc.Location == MemoryLocation::GpuOnly) {
       if (Desc.Backing == MemoryBacking::Sparse)
         TexDesc.Layout = D3D12_TEXTURE_LAYOUT_64KB_UNDEFINED_SWIZZLE;
@@ -2105,8 +2158,7 @@ public:
       SRVHandle = *SRVHandleOrErr;
 
       D3D12_SHADER_RESOURCE_VIEW_DESC SRVDesc = {};
-      SRVDesc.ViewDimension =
-          D3D12_SRV_DIMENSION_TEXTURE2D; // assume this is correct for now.
+      SRVDesc.ViewDimension = getDXSRVDimension(Desc);
       SRVDesc.Shader4ComponentMapping =
           D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
       SRVDesc.Format = getDXGIFormatSRV(Desc.Fmt);
@@ -2127,9 +2179,15 @@ public:
       UAVHandle = *UAVHandleOrErr;
 
       D3D12_UNORDERED_ACCESS_VIEW_DESC UAVDesc = {};
-      UAVDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2D;
-      UAVDesc.Texture2D.MipSlice = 0;
-      UAVDesc.Texture2D.PlaneSlice = 0;
+      UAVDesc.ViewDimension = getDXUAVDimension(Desc);
+      switch (UAVDesc.ViewDimension) {
+      case D3D12_UAV_DIMENSION_TEXTURE2D:
+        UAVDesc.Texture2D.MipSlice = 0;
+        UAVDesc.Texture2D.PlaneSlice = 0;
+        break;
+      default:
+        llvm_unreachable("Unhandled texture UAV dimension");
+      }
 
       Device->CreateUnorderedAccessView(TextureObject.Get(), nullptr, &UAVDesc,
                                         UAVHandle);
@@ -2203,18 +2261,8 @@ public:
 
   TextureUploadLayout
   getTextureUploadLayout(const TextureCreateDesc &Desc) const override {
-    // Only the fields GetCopyableFootprints consults are needed here; layout,
-    // flags, and clear value do not affect the copyable footprint.
-    D3D12_RESOURCE_DESC TexDesc = {};
-    TexDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-    TexDesc.Width = Desc.Width;
-    TexDesc.Height = Desc.Height;
-    TexDesc.DepthOrArraySize = 1;
-    TexDesc.MipLevels = static_cast<UINT16>(Desc.MipLevels);
-    TexDesc.Format = getDXGIFormat(Desc.Fmt);
-    TexDesc.SampleDesc.Count = 1;
-
-    const uint32_t NumSubresources = Desc.MipLevels;
+    const D3D12_RESOURCE_DESC TexDesc = getDXResourceDesc(Desc);
+    const uint32_t NumSubresources = Desc.getSubresourceCount();
     llvm::SmallVector<D3D12_PLACED_SUBRESOURCE_FOOTPRINT> Footprints(
         NumSubresources);
     llvm::SmallVector<UINT> NumRows(NumSubresources);

--- a/lib/API/DX/Device.cpp
+++ b/lib/API/DX/Device.cpp
@@ -104,25 +104,25 @@ static uint32_t getAlignedTexturePitch(uint32_t Width, uint32_t ElementSize) {
   return llvm::alignTo(Width * ElementSize, D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
 }
 
-static D3D12_RESOURCE_DIMENSION getDXResourceDimension(TextureDimension Dim) {
-  switch (Dim) {
-  case TextureDimension::One:
+static D3D12_RESOURCE_DIMENSION getDXResourceDimension(TextureShape Shape) {
+  switch (Shape) {
+  case TextureShape::Texture1D:
     return D3D12_RESOURCE_DIMENSION_TEXTURE1D;
-  case TextureDimension::Two:
-  case TextureDimension::Cube:
+  case TextureShape::Texture2D:
+  case TextureShape::TextureCube:
     // A cube map is a 2D resource with six slices per cube.
     return D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-  case TextureDimension::Three:
+  case TextureShape::Texture3D:
     return D3D12_RESOURCE_DIMENSION_TEXTURE3D;
   }
-  llvm_unreachable("All texture dimensions handled");
+  llvm_unreachable("All texture shapes handled");
 }
 
 // Only the fields GetCopyableFootprints consults are needed here; layout,
 // flags, and clear value do not affect the copyable footprint.
 static D3D12_RESOURCE_DESC getDXResourceDesc(const TextureCreateDesc &Desc) {
   D3D12_RESOURCE_DESC TexDesc = {};
-  TexDesc.Dimension = getDXResourceDimension(Desc.Dim);
+  TexDesc.Dimension = getDXResourceDimension(Desc.Shape);
   TexDesc.Width = Desc.Width;
   TexDesc.Height = Desc.Height;
   TexDesc.DepthOrArraySize = 1;
@@ -133,27 +133,27 @@ static D3D12_RESOURCE_DESC getDXResourceDesc(const TextureCreateDesc &Desc) {
 }
 
 static D3D12_SRV_DIMENSION getDXSRVDimension(const TextureCreateDesc &Desc) {
-  switch (Desc.Dim) {
-  case TextureDimension::Two:
+  switch (Desc.Shape) {
+  case TextureShape::Texture2D:
     return D3D12_SRV_DIMENSION_TEXTURE2D;
-  case TextureDimension::One:
-  case TextureDimension::Three:
-  case TextureDimension::Cube:
-    llvm_unreachable("Texture dimension has no SRV mapping yet");
+  case TextureShape::Texture1D:
+  case TextureShape::Texture3D:
+  case TextureShape::TextureCube:
+    llvm_unreachable("Texture shape has no SRV mapping yet");
   }
-  llvm_unreachable("All texture dimensions handled");
+  llvm_unreachable("All texture shapes handled");
 }
 
 static D3D12_UAV_DIMENSION getDXUAVDimension(const TextureCreateDesc &Desc) {
-  switch (Desc.Dim) {
-  case TextureDimension::Two:
+  switch (Desc.Shape) {
+  case TextureShape::Texture2D:
     return D3D12_UAV_DIMENSION_TEXTURE2D;
-  case TextureDimension::One:
-  case TextureDimension::Three:
-  case TextureDimension::Cube:
-    llvm_unreachable("Texture dimension has no UAV mapping yet");
+  case TextureShape::Texture1D:
+  case TextureShape::Texture3D:
+  case TextureShape::TextureCube:
+    llvm_unreachable("Texture shape has no UAV mapping yet");
   }
-  llvm_unreachable("All texture dimensions handled");
+  llvm_unreachable("All texture shapes handled");
 }
 
 static D3D12_PRIMITIVE_TOPOLOGY_TYPE

--- a/lib/API/Device.cpp
+++ b/lib/API/Device.cpp
@@ -596,10 +596,7 @@ offloadtest::createTextureWithData(
   // The source data is tightly packed across mips, so its required size is the
   // sum of each subresource's tight row size times its row count, independent
   // of any backend row/offset padding in the upload buffer.
-  uint64_t PackedSizeInBytes = 0;
-  for (const SubresourceFootprint &Sub : Layout.Subresources)
-    PackedSizeInBytes += uint64_t(Sub.RowSizeInBytes) * Sub.NumRows;
-  if (SizeInBytes < PackedSizeInBytes)
+  if (SizeInBytes < Layout.getPackedSizeInBytes())
     return llvm::createStringError(
         "Data upload is not enough for texture size.");
 
@@ -614,17 +611,8 @@ offloadtest::createTextureWithData(
   auto MappedPtrOrErr = (*OutUploadBuffer)->map();
   if (!MappedPtrOrErr)
     return MappedPtrOrErr.takeError();
-  auto *const DstBase = static_cast<uint8_t *>(*MappedPtrOrErr);
-  const auto *SrcPtr = static_cast<const uint8_t *>(Data);
 
-  for (const SubresourceFootprint &Sub : Layout.Subresources) {
-    uint8_t *DstPtr = DstBase + Sub.Offset;
-    for (uint32_t Row = 0; Row < Sub.NumRows; ++Row) {
-      memcpy(DstPtr, SrcPtr, Sub.RowSizeInBytes);
-      DstPtr += Sub.RowPitchInBytes;
-      SrcPtr += Sub.RowSizeInBytes;
-    }
-  }
+  copyPackedToTextureLayout(*MappedPtrOrErr, Data, Layout);
   (*OutUploadBuffer)->unmap();
 
   if (auto Err = Encoder->copyBufferToTexture(**OutUploadBuffer, *Texture))

--- a/lib/API/Texture.cpp
+++ b/lib/API/Texture.cpp
@@ -8,10 +8,9 @@
 // Useful for calculating the size for an upload or readback buffer.
 size_t
 offloadtest::Texture::calculateLinearSizeInBytes(const Device &Dev) const {
-  const auto &Desc = getDesc();
-  const uint32_t Stride = Dev.getTextureUploadRowStrideInBytes(Desc);
-  return (Desc.Height - 1) * Stride +
-         Desc.Width * getFormatSizeInBytes(Desc.Fmt);
+  // The backend's own layout already accounts for every (mip, slice)
+  // subresource as well as any row and subresource alignment it requires.
+  return Dev.getTextureUploadLayout(getDesc()).TotalSizeInBytes;
 }
 
 offloadtest::TextureUploadLayout

--- a/lib/API/Texture.cpp
+++ b/lib/API/Texture.cpp
@@ -1,7 +1,8 @@
 #include "API/Texture.h"
 #include "API/Device.h"
 
-#include <algorithm>
+#include <cassert>
+#include <cstring>
 
 // Calculate the size in bytes of the texture data given a linear layout
 // Useful for calculating the size for an upload or readback buffer.
@@ -17,19 +18,51 @@ offloadtest::TextureUploadLayout
 offloadtest::computeTightTextureUploadLayout(const TextureCreateDesc &Desc) {
   const uint32_t ElementSize = getFormatSizeInBytes(Desc.Fmt);
   TextureUploadLayout Layout;
-  Layout.Subresources.reserve(Desc.MipLevels);
+  Layout.Subresources.reserve(Desc.getSubresourceCount());
   uint64_t Offset = 0;
-  for (uint32_t I = 0; I < Desc.MipLevels; ++I) {
-    const uint32_t MipWidth = std::max(1u, Desc.Width >> I);
-    const uint32_t MipHeight = std::max(1u, Desc.Height >> I);
+  for (uint32_t Mip = 0; Mip < Desc.MipLevels; ++Mip) {
     SubresourceFootprint Sub;
     Sub.Offset = Offset;
-    Sub.RowSizeInBytes = MipWidth * ElementSize;
+    Sub.RowSizeInBytes = Desc.getMipWidth(Mip) * ElementSize;
     Sub.RowPitchInBytes = Sub.RowSizeInBytes;
-    Sub.NumRows = MipHeight;
+    Sub.NumRows = Desc.getMipHeight(Mip);
     Layout.Subresources.push_back(Sub);
     Offset += uint64_t(Sub.RowSizeInBytes) * Sub.NumRows;
   }
   Layout.TotalSizeInBytes = Offset;
   return Layout;
+}
+
+void offloadtest::copyPackedToTextureLayout(void *Dst, const void *PackedSrc,
+                                            const TextureUploadLayout &Layout) {
+  auto *const DstBase = static_cast<uint8_t *>(Dst);
+  const auto *SrcPtr = static_cast<const uint8_t *>(PackedSrc);
+  for (const SubresourceFootprint &Sub : Layout.Subresources) {
+    assert(Sub.RowSizeInBytes <= Sub.RowPitchInBytes &&
+           "The packed side has no padding, so a row can never be larger "
+           "than the padded side's row pitch.");
+    uint8_t *DstPtr = DstBase + Sub.Offset;
+    for (uint32_t Row = 0; Row < Sub.NumRows; ++Row) {
+      memcpy(DstPtr, SrcPtr, Sub.RowSizeInBytes);
+      DstPtr += Sub.RowPitchInBytes;
+      SrcPtr += Sub.RowSizeInBytes;
+    }
+  }
+}
+
+void offloadtest::copyTextureLayoutToPacked(void *PackedDst, const void *Src,
+                                            const TextureUploadLayout &Layout) {
+  auto *DstPtr = static_cast<uint8_t *>(PackedDst);
+  const auto *const SrcBase = static_cast<const uint8_t *>(Src);
+  for (const SubresourceFootprint &Sub : Layout.Subresources) {
+    assert(Sub.RowSizeInBytes <= Sub.RowPitchInBytes &&
+           "The packed side has no padding, so a row can never be larger "
+           "than the padded side's row pitch.");
+    const uint8_t *SrcPtr = SrcBase + Sub.Offset;
+    for (uint32_t Row = 0; Row < Sub.NumRows; ++Row) {
+      memcpy(DstPtr, SrcPtr, Sub.RowSizeInBytes);
+      DstPtr += Sub.RowSizeInBytes;
+      SrcPtr += Sub.RowPitchInBytes;
+    }
+  }
 }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -198,16 +198,101 @@ static VkImageViewType getImageViewType(const ResourceKind RK) {
   llvm_unreachable("All cases handled");
 }
 
+static VkImageType getVKImageType(TextureDimension Dim) {
+  switch (Dim) {
+  case TextureDimension::One:
+    return VK_IMAGE_TYPE_1D;
+  case TextureDimension::Two:
+  case TextureDimension::Cube:
+    // A cube map is a 2D image with six layers per cube.
+    return VK_IMAGE_TYPE_2D;
+  case TextureDimension::Three:
+    return VK_IMAGE_TYPE_3D;
+  }
+  llvm_unreachable("All texture dimensions handled");
+}
+
 static VkImageType getVKImageType(const ResourceKind RK) {
   switch (RK) {
   case ResourceKind::Texture2D:
   case ResourceKind::RWTexture2D:
   case ResourceKind::SampledTexture2D:
-    return VK_IMAGE_TYPE_2D;
+    return getVKImageType(TextureDimension::Two);
   default:
     llvm_unreachable("Unsupported image kind");
   }
   llvm_unreachable("All cases handled");
+}
+
+// Build the buffer <-> image copy regions covering every subresource of a
+// texture. Vulkan staging buffers are tightly packed, matching
+// `computeTightTextureUploadLayout`.
+static llvm::SmallVector<VkBufferImageCopy>
+getTextureCopyRegions(const TextureCreateDesc &Desc) {
+  const VkImageAspectFlags AspectMask = isDepthFormat(Desc.Fmt)
+                                            ? VK_IMAGE_ASPECT_DEPTH_BIT
+                                            : VK_IMAGE_ASPECT_COLOR_BIT;
+  const uint32_t ElementSize = getFormatSizeInBytes(Desc.Fmt);
+  llvm::SmallVector<VkBufferImageCopy> Regions;
+  Regions.reserve(Desc.getSubresourceCount());
+  uint64_t CurrentOffset = 0;
+  for (uint32_t Mip = 0; Mip < Desc.MipLevels; ++Mip) {
+    const uint32_t MipWidth = Desc.getMipWidth(Mip);
+    const uint32_t MipHeight = Desc.getMipHeight(Mip);
+    VkBufferImageCopy Region = {};
+    Region.bufferOffset = CurrentOffset;
+    Region.imageSubresource.aspectMask = AspectMask;
+    Region.imageSubresource.mipLevel = Mip;
+    Region.imageSubresource.baseArrayLayer = 0;
+    Region.imageSubresource.layerCount = 1;
+    Region.imageExtent = {MipWidth, MipHeight, 1};
+    Regions.push_back(Region);
+    CurrentOffset += uint64_t(MipWidth) * MipHeight * ElementSize;
+  }
+  return Regions;
+}
+
+static VkImageAspectFlags getVKAspectMask(const CPUBuffer &B) {
+  return B.Format == DataFormat::Depth32 ? VK_IMAGE_ASPECT_DEPTH_BIT
+                                         : VK_IMAGE_ASPECT_COLOR_BIT;
+}
+
+// As above, for a legacy pipeline texture resource.
+static llvm::SmallVector<VkBufferImageCopy>
+getTextureCopyRegions(const CPUBuffer &B) {
+  const VkImageAspectFlags AspectMask = getVKAspectMask(B);
+  llvm::SmallVector<VkBufferImageCopy> Regions;
+  uint64_t CurrentOffset = 0;
+  for (int Mip = 0; Mip < B.OutputProps.MipLevels; ++Mip) {
+    VkBufferImageCopy Region = {};
+    Region.bufferOffset = CurrentOffset;
+    Region.imageSubresource.aspectMask = AspectMask;
+    Region.imageSubresource.mipLevel = Mip;
+    Region.imageSubresource.baseArrayLayer = 0;
+    Region.imageSubresource.layerCount = 1;
+    Region.imageExtent.width =
+        std::max(1u, static_cast<uint32_t>(B.OutputProps.Width) >> Mip);
+    Region.imageExtent.height =
+        std::max(1u, static_cast<uint32_t>(B.OutputProps.Height) >> Mip);
+    Region.imageExtent.depth =
+        std::max(1u, static_cast<uint32_t>(B.OutputProps.Depth) >> Mip);
+    Regions.push_back(Region);
+    CurrentOffset += static_cast<uint64_t>(Region.imageExtent.width) *
+                     Region.imageExtent.height * Region.imageExtent.depth *
+                     B.getElementSize();
+  }
+  return Regions;
+}
+
+// The full subresource range of a pipeline texture resource.
+static VkImageSubresourceRange getVKFullSubresourceRange(const CPUBuffer &B) {
+  VkImageSubresourceRange SubRange = {};
+  SubRange.aspectMask = getVKAspectMask(B);
+  SubRange.baseMipLevel = 0;
+  SubRange.levelCount = B.OutputProps.MipLevels;
+  SubRange.baseArrayLayer = 0;
+  SubRange.layerCount = 1;
+  return SubRange;
 }
 
 static VkShaderStageFlagBits getShaderStageFlag(Stages Stage) {
@@ -1097,25 +1182,8 @@ public:
                              VK_ACCESS_TRANSFER_WRITE_BIT);
     CB.flushBarrier();
 
-    const VkImageAspectFlags AspectMask = isDepthFormat(VKDst.Desc.Fmt)
-                                              ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                              : VK_IMAGE_ASPECT_COLOR_BIT;
-    const uint32_t ElementSize = getFormatSizeInBytes(VKDst.Desc.Fmt);
-    llvm::SmallVector<VkBufferImageCopy> Regions;
-    uint64_t CurrentOffset = 0;
-    for (uint32_t I = 0; I < VKDst.Desc.MipLevels; ++I) {
-      const uint32_t MipWidth = std::max(1u, VKDst.Desc.Width >> I);
-      const uint32_t MipHeight = std::max(1u, VKDst.Desc.Height >> I);
-      VkBufferImageCopy Region = {};
-      Region.bufferOffset = CurrentOffset;
-      Region.imageSubresource.aspectMask = AspectMask;
-      Region.imageSubresource.mipLevel = I;
-      Region.imageSubresource.baseArrayLayer = 0;
-      Region.imageSubresource.layerCount = 1;
-      Region.imageExtent = {MipWidth, MipHeight, 1};
-      Regions.push_back(Region);
-      CurrentOffset += uint64_t(MipWidth) * MipHeight * ElementSize;
-    }
+    const llvm::SmallVector<VkBufferImageCopy> Regions =
+        getTextureCopyRegions(VKDst.Desc);
 
     insertDebugSignpost(
         llvm::formatv("copyBufferToTexture {0} -> {1}", VKSrc.Name, VKDst.Name)
@@ -1174,9 +1242,11 @@ public:
     insertDebugSignpost(
         llvm::formatv("copyTextureToBuffer {0} -> {1}", VKSrc.Name, VKDst.Name)
             .str());
+    const llvm::SmallVector<VkBufferImageCopy> Regions =
+        getTextureCopyRegions(VKSrc.Desc);
     vkCmdCopyImageToBuffer(CB.CmdBuffer, VKSrc.Image,
                            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VKDst.Buffer,
-                           0, nullptr);
+                           Regions.size(), Regions.data());
 
     CB.addImageTransition(VK_ACCESS_TRANSFER_READ_BIT, /*SrcAccessMask*/
                           VK_ACCESS_NONE,              /*DstAccessMask*/
@@ -3980,36 +4050,9 @@ public:
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
-      llvm::SmallVector<VkBufferImageCopy> Regions;
-      uint64_t CurrentOffset = 0;
-      for (int I = 0; I < B.OutputProps.MipLevels; ++I) {
-        VkBufferImageCopy Region = {};
-        Region.imageSubresource.aspectMask = B.Format == DataFormat::Depth32
-                                                 ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                                 : VK_IMAGE_ASPECT_COLOR_BIT;
-        Region.imageSubresource.mipLevel = I;
-        Region.imageSubresource.baseArrayLayer = 0;
-        Region.imageSubresource.layerCount = 1;
-        Region.imageExtent.width =
-            std::max(1u, static_cast<uint32_t>(B.OutputProps.Width) >> I);
-        Region.imageExtent.height =
-            std::max(1u, static_cast<uint32_t>(B.OutputProps.Height) >> I);
-        Region.imageExtent.depth =
-            std::max(1u, static_cast<uint32_t>(B.OutputProps.Depth) >> I);
-        Region.bufferOffset = CurrentOffset;
-        Regions.push_back(Region);
-        CurrentOffset += static_cast<uint64_t>(Region.imageExtent.width) *
-                         Region.imageExtent.height * Region.imageExtent.depth *
-                         B.getElementSize();
-      }
-
-      VkImageSubresourceRange SubRange = {};
-      SubRange.aspectMask = B.Format == DataFormat::Depth32
-                                ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                : VK_IMAGE_ASPECT_COLOR_BIT;
-      SubRange.baseMipLevel = 0;
-      SubRange.levelCount = B.OutputProps.MipLevels;
-      SubRange.layerCount = 1;
+      const llvm::SmallVector<VkBufferImageCopy> Regions =
+          getTextureCopyRegions(B);
+      const VkImageSubresourceRange SubRange = getVKFullSubresourceRange(B);
 
       VkImageMemoryBarrier ImageBarrier = {};
       ImageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -4126,13 +4169,7 @@ public:
       return;
     if (R.isImage()) {
       const offloadtest::CPUBuffer &B = *R.BufferPtr;
-      VkImageSubresourceRange SubRange = {};
-      SubRange.aspectMask = B.Format == DataFormat::Depth32
-                                ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                : VK_IMAGE_ASPECT_COLOR_BIT;
-      SubRange.baseMipLevel = 0;
-      SubRange.levelCount = B.OutputProps.MipLevels;
-      SubRange.layerCount = 1;
+      const VkImageSubresourceRange SubRange = getVKFullSubresourceRange(B);
 
       VkImageMemoryBarrier ImageBarrier = {};
       ImageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -4152,28 +4189,8 @@ public:
                              nullptr, 1, &ImageBarrier);
       }
 
-      llvm::SmallVector<VkBufferImageCopy> Regions;
-      uint64_t CurrentOffset = 0;
-      for (int I = 0; I < B.OutputProps.MipLevels; ++I) {
-        VkBufferImageCopy Region = {};
-        Region.imageSubresource.aspectMask = B.Format == DataFormat::Depth32
-                                                 ? VK_IMAGE_ASPECT_DEPTH_BIT
-                                                 : VK_IMAGE_ASPECT_COLOR_BIT;
-        Region.imageSubresource.mipLevel = I;
-        Region.imageSubresource.baseArrayLayer = 0;
-        Region.imageSubresource.layerCount = 1;
-        Region.imageExtent.width =
-            std::max(1u, static_cast<uint32_t>(B.OutputProps.Width) >> I);
-        Region.imageExtent.height =
-            std::max(1u, static_cast<uint32_t>(B.OutputProps.Height) >> I);
-        Region.imageExtent.depth =
-            std::max(1u, static_cast<uint32_t>(B.OutputProps.Depth) >> I);
-        Region.bufferOffset = CurrentOffset;
-        Regions.push_back(Region);
-        CurrentOffset += static_cast<uint64_t>(Region.imageExtent.width) *
-                         Region.imageExtent.height * Region.imageExtent.depth *
-                         B.getElementSize();
-      }
+      const llvm::SmallVector<VkBufferImageCopy> Regions =
+          getTextureCopyRegions(B);
 
       for (auto &ResRef : R.ResourceRefs)
         vkCmdCopyImageToBuffer(IS.CB->CmdBuffer, ResRef.Image.Image,

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -198,18 +198,18 @@ static VkImageViewType getImageViewType(const ResourceKind RK) {
   llvm_unreachable("All cases handled");
 }
 
-static VkImageType getVKImageType(TextureDimension Dim) {
-  switch (Dim) {
-  case TextureDimension::One:
+static VkImageType getVKImageType(TextureShape Shape) {
+  switch (Shape) {
+  case TextureShape::Texture1D:
     return VK_IMAGE_TYPE_1D;
-  case TextureDimension::Two:
-  case TextureDimension::Cube:
+  case TextureShape::Texture2D:
+  case TextureShape::TextureCube:
     // A cube map is a 2D image with six layers per cube.
     return VK_IMAGE_TYPE_2D;
-  case TextureDimension::Three:
+  case TextureShape::Texture3D:
     return VK_IMAGE_TYPE_3D;
   }
-  llvm_unreachable("All texture dimensions handled");
+  llvm_unreachable("All texture shapes handled");
 }
 
 static VkImageType getVKImageType(const ResourceKind RK) {
@@ -217,7 +217,7 @@ static VkImageType getVKImageType(const ResourceKind RK) {
   case ResourceKind::Texture2D:
   case ResourceKind::RWTexture2D:
   case ResourceKind::SampledTexture2D:
-    return getVKImageType(TextureDimension::Two);
+    return getVKImageType(TextureShape::Texture2D);
   default:
     llvm_unreachable("Unsupported image kind");
   }

--- a/lib/API/VK/Device.cpp
+++ b/lib/API/VK/Device.cpp
@@ -198,18 +198,18 @@ static VkImageViewType getImageViewType(const ResourceKind RK) {
   llvm_unreachable("All cases handled");
 }
 
-static VkImageType getVKImageType(TextureShape Shape) {
-  switch (Shape) {
-  case TextureShape::Texture1D:
+static VkImageType getVKImageType(ResourceDimension Dim) {
+  switch (Dim) {
+  case ResourceDimension::Dim1D:
     return VK_IMAGE_TYPE_1D;
-  case TextureShape::Texture2D:
-  case TextureShape::TextureCube:
+  case ResourceDimension::Dim2D:
+  case ResourceDimension::Cube:
     // A cube map is a 2D image with six layers per cube.
     return VK_IMAGE_TYPE_2D;
-  case TextureShape::Texture3D:
+  case ResourceDimension::Dim3D:
     return VK_IMAGE_TYPE_3D;
   }
-  llvm_unreachable("All texture shapes handled");
+  llvm_unreachable("All texture dimensions handled");
 }
 
 static VkImageType getVKImageType(const ResourceKind RK) {
@@ -217,7 +217,7 @@ static VkImageType getVKImageType(const ResourceKind RK) {
   case ResourceKind::Texture2D:
   case ResourceKind::RWTexture2D:
   case ResourceKind::SampledTexture2D:
-    return getVKImageType(TextureShape::Texture2D);
+    return getVKImageType(ResourceDimension::Dim2D);
   default:
     llvm_unreachable("Unsupported image kind");
   }

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -120,22 +120,13 @@ llvm::Error readBack(Device &Dev, Pipeline &P, SharedInvocationState &IS) {
       const void *DataPtr = *DataPtrOrErr;
 
       if (R.first->isTexture()) {
-        const TextureCreateDesc &Desc = RSIt->Tex->getDesc();
-        const uint32_t SrcStrideInBytes =
-            Dev.getTextureUploadRowStrideInBytes(Desc);
-        const uint32_t DstStrideInBytes =
-            Desc.Width * getFormatSizeInBytes(Desc.Fmt);
-        assert(DstStrideInBytes <= SrcStrideInBytes &&
-               "Destination should not have padding and thus should be <= "
-               "than SrcStride where we do expect potential padding.");
-        uint8_t *Dst = (uint8_t *)DataIt->get();
-        const uint8_t *Src = (const uint8_t *)DataPtr;
-
-        for (uint32_t Y = 0; Y < Desc.Height; ++Y) {
-          memcpy(Dst, Src, DstStrideInBytes);
-          Dst += DstStrideInBytes;
-          Src += SrcStrideInBytes;
-        }
+        // The GPU-visible copy may carry row and subresource padding (e.g.
+        // D3D12's 256-byte aligned rows), while the CPU buffer is tightly
+        // packed across every subresource. Let the backend's layout drive the
+        // un-padding so arbitrary widths work.
+        const TextureUploadLayout Layout =
+            Dev.getTextureUploadLayout(RSIt->Tex->getDesc());
+        copyTextureLayoutToPacked(DataIt->get(), DataPtr, Layout);
       } else {
         memcpy(DataIt->get(), DataPtr, R.first->size());
       }

--- a/lib/Support/OffloadMigration.cpp
+++ b/lib/Support/OffloadMigration.cpp
@@ -120,10 +120,6 @@ llvm::Error readBack(Device &Dev, Pipeline &P, SharedInvocationState &IS) {
       const void *DataPtr = *DataPtrOrErr;
 
       if (R.first->isTexture()) {
-        // The GPU-visible copy may carry row and subresource padding (e.g.
-        // D3D12's 256-byte aligned rows), while the CPU buffer is tightly
-        // packed across every subresource. Let the backend's layout drive the
-        // un-padding so arbitrary widths work.
         const TextureUploadLayout Layout =
             Dev.getTextureUploadLayout(RSIt->Tex->getDesc());
         copyTextureLayoutToPacked(DataIt->get(), DataPtr, Layout);

--- a/test/Feature/Textures/SRVToUAV.test
+++ b/test/Feature/Textures/SRVToUAV.test
@@ -29,22 +29,30 @@ Buffers:
   - Name: Out
     Format: Float32
     Channels: 4
-    FillSize: 64
+    # A UAV only ever addresses mip 0, so mip 1 must come back exactly as it was.
+    Data: [0.25, 0.25, 0.25, 1.0,
+           0.25, 0.25, 0.25, 1.0,
+           0.25, 0.25, 0.25, 1.0,
+           0.25, 0.25, 0.25, 1.0,
+           1.0, 0.0, 1.0, 1.0]
     OutputProps:
       Height: 2
       Width: 2
       Depth: 1
+      MipLevels: 2
   - Name: ExpectedOut
     Format: Float32
     Channels: 4
     Data: [0.0, 0.0, 1.0, 1.0,
            0.0, 1.0, 0.0, 1.0,
            1.0, 0.0, 0.0, 1.0,
-           0.0, 1.0, 1.0, 1.0]
+           0.0, 1.0, 1.0, 1.0,
+           1.0, 0.0, 1.0, 1.0]
     OutputProps:
       Height: 2
       Width: 2
       Depth: 1
+      MipLevels: 2
 Results:
   - Result: Test1
     Rule: BufferExact

--- a/test/Tools/Offloader/TextureExtentValidation.test
+++ b/test/Tools/Offloader/TextureExtentValidation.test
@@ -1,122 +1,94 @@
-#--- vertex.hlsl
-struct PSInput
-{
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
-};
+#--- source.hlsl
 
-PSInput main(float4 position : POSITION, float4 color : COLOR)
-{
-    PSInput result;
+// This test verifies that a texture with a zero extent is rejected with a
+// clear error rather than being handed to the driver.
 
-    result.position = position;
-    result.color = color;
+Texture2D<float4> Tex : register(t0);
+RWBuffer<float4> Out : register(u0);
 
-    return result;
+[numthreads(1, 1, 1)]
+void main() {
+  Out[0] = Tex.Load(int3(0, 0, 0));
 }
 
-#--- pixel.hlsl
-struct PSInput
-{
-    float4 position : SV_POSITION;
-    float4 color : COLOR;
-};
-
-float4 main(PSInput input) : SV_TARGET
-{
-    return input.color;
-}
-
-#--- zero-width.yaml
+//--- zero-width.yaml
 ---
 Shaders:
-  - Stage: Vertex
+  - Stage: Compute
     Entry: main
-  - Stage: Pixel
-    Entry: main
+
 Buffers:
-  - Name: VertexData
-    Format: Float32
-    Stride: 28
-    Data: [ 0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 1.0,
-            0.25, -0.25, 0.0, 0.0, 1.0, 0.0, 1.0,
-           -0.25, -0.25, 0.0, 0.0, 0.0, 1.0, 1.0 ]
-  - Name: Output
+  # Pipeline.cpp only size-checks OutputProps when Width > 0, so a zero width
+  # reaches the texture validation with the data below left as-is.
+  - Name: Tex
     Format: Float32
     Channels: 4
-    # The render target extent is taken from OutputProps. An empty buffer is
-    # required so that the CPUBuffer size still matches width * height *
-    # element size (0), otherwise that earlier check reports first and this
-    # test would no longer exercise the extent validation.
-    Data: []
-    OutputProps:
-      Height: 256
-      Width: 0
-      Depth: 1
-Bindings:
-  VertexBuffer: VertexData
-  VertexAttributes:
-    - Format: Float32
-      Channels: 3
-      Offset: 0
-      Name: POSITION
-    - Format: Float32
-      Channels: 4
-      Offset: 12
-      Name: COLOR
-  RenderTarget: Output
-DescriptorSets: []
+    OutputProps: { Width: 0, Height: 2, Depth: 1 }
+    Data: [ 1.0, 0.0, 0.0, 1.0 ]
+
+  - Name: Out
+    Format: Float32
+    Channels: 4
+    FillSize: 16
+
+DescriptorSets:
+  - Resources:
+    - Name: Tex
+      Kind: Texture2D
+      DirectXBinding: { Register: 0, Space: 0 }
+    - Name: Out
+      Kind: RWBuffer
+      DirectXBinding: { Register: 0, Space: 0 }
+
+Results: []
 ...
 
-#--- zero-height.yaml
+//--- zero-height.yaml
 ---
 Shaders:
-  - Stage: Vertex
+  - Stage: Compute
     Entry: main
-  - Stage: Pixel
-    Entry: main
+
 Buffers:
-  - Name: VertexData
-    Format: Float32
-    Stride: 28
-    Data: [ 0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 1.0,
-            0.25, -0.25, 0.0, 0.0, 1.0, 0.0, 1.0,
-           -0.25, -0.25, 0.0, 0.0, 0.0, 1.0, 1.0 ]
-  - Name: Output
+  # Width is non-zero here, so the expected size is 2 * 0 * 16 = 0 and the
+  # buffer must be empty to get past that check.
+  - Name: Tex
     Format: Float32
     Channels: 4
+    OutputProps: { Width: 2, Height: 0, Depth: 1 }
     Data: []
-    OutputProps:
-      Height: 0
-      Width: 256
-      Depth: 1
-Bindings:
-  VertexBuffer: VertexData
-  VertexAttributes:
-    - Format: Float32
-      Channels: 3
-      Offset: 0
-      Name: POSITION
-    - Format: Float32
-      Channels: 4
-      Offset: 12
-      Name: COLOR
-  RenderTarget: Output
-DescriptorSets: []
+
+  - Name: Out
+    Format: Float32
+    Channels: 4
+    FillSize: 16
+
+DescriptorSets:
+  - Resources:
+    - Name: Tex
+      Kind: Texture2D
+      DirectXBinding: { Register: 0, Space: 0 }
+    - Name: Out
+      Kind: RWBuffer
+      DirectXBinding: { Register: 0, Space: 0 }
+
+Results: []
 ...
 #--- end
 
-# Verifies that a render target with a zero extent is rejected with a clear
-# error instead of being handed to the driver.
+# Only DirectX routes texture resources through TextureCreateDesc today; the
+# Vulkan and Metal backends still create images directly from the pipeline
+# description, so they never reach this validation.
+# UNSUPPORTED: Vulkan
+# UNSUPPORTED: Metal
 
 # RUN: split-file %s %t
-# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
-# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 
-# RUN: not %offloader %t/zero-width.yaml %t-vertex.o %t-pixel.o -r Output 2>&1 \
+# RUN: not %offloader %t/zero-width.yaml %t.o 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=ZERO-WIDTH
-# ZERO-WIDTH: error: Texture dimensions must be non-zero, got 0x256.
+# ZERO-WIDTH: error: Texture dimensions must be non-zero, got 0x2.
 
-# RUN: not %offloader %t/zero-height.yaml %t-vertex.o %t-pixel.o -r Output 2>&1 \
+# RUN: not %offloader %t/zero-height.yaml %t.o 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=ZERO-HEIGHT
-# ZERO-HEIGHT: error: Texture dimensions must be non-zero, got 256x0.
+# ZERO-HEIGHT: error: Texture dimensions must be non-zero, got 2x0.

--- a/test/Tools/Offloader/TextureExtentValidation.test
+++ b/test/Tools/Offloader/TextureExtentValidation.test
@@ -1,0 +1,122 @@
+#--- vertex.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+PSInput main(float4 position : POSITION, float4 color : COLOR)
+{
+    PSInput result;
+
+    result.position = position;
+    result.color = color;
+
+    return result;
+}
+
+#--- pixel.hlsl
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color;
+}
+
+#--- zero-width.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: VertexData
+    Format: Float32
+    Stride: 28
+    Data: [ 0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 1.0,
+            0.25, -0.25, 0.0, 0.0, 1.0, 0.0, 1.0,
+           -0.25, -0.25, 0.0, 0.0, 0.0, 1.0, 1.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    # The render target extent is taken from OutputProps. An empty buffer is
+    # required so that the CPUBuffer size still matches width * height *
+    # element size (0), otherwise that earlier check reports first and this
+    # test would no longer exercise the extent validation.
+    Data: []
+    OutputProps:
+      Height: 256
+      Width: 0
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 3
+      Offset: 0
+      Name: POSITION
+    - Format: Float32
+      Channels: 4
+      Offset: 12
+      Name: COLOR
+  RenderTarget: Output
+DescriptorSets: []
+...
+
+#--- zero-height.yaml
+---
+Shaders:
+  - Stage: Vertex
+    Entry: main
+  - Stage: Pixel
+    Entry: main
+Buffers:
+  - Name: VertexData
+    Format: Float32
+    Stride: 28
+    Data: [ 0.0, 0.25, 0.0, 1.0, 0.0, 0.0, 1.0,
+            0.25, -0.25, 0.0, 0.0, 1.0, 0.0, 1.0,
+           -0.25, -0.25, 0.0, 0.0, 0.0, 1.0, 1.0 ]
+  - Name: Output
+    Format: Float32
+    Channels: 4
+    Data: []
+    OutputProps:
+      Height: 0
+      Width: 256
+      Depth: 1
+Bindings:
+  VertexBuffer: VertexData
+  VertexAttributes:
+    - Format: Float32
+      Channels: 3
+      Offset: 0
+      Name: POSITION
+    - Format: Float32
+      Channels: 4
+      Offset: 12
+      Name: COLOR
+  RenderTarget: Output
+DescriptorSets: []
+...
+#--- end
+
+# Verifies that a render target with a zero extent is rejected with a clear
+# error instead of being handed to the driver.
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T vs_6_0 -Fo %t-vertex.o %t/vertex.hlsl
+# RUN: %dxc_target -T ps_6_0 -Fo %t-pixel.o %t/pixel.hlsl
+
+# RUN: not %offloader %t/zero-width.yaml %t-vertex.o %t-pixel.o -r Output 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=ZERO-WIDTH
+# ZERO-WIDTH: error: Texture dimensions must be non-zero, got 0x256.
+
+# RUN: not %offloader %t/zero-height.yaml %t-vertex.o %t-pixel.o -r Output 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=ZERO-HEIGHT
+# ZERO-HEIGHT: error: Texture dimensions must be non-zero, got 256x0.

--- a/test/Tools/Offloader/TextureMipLevelValidation.test
+++ b/test/Tools/Offloader/TextureMipLevelValidation.test
@@ -1,0 +1,103 @@
+#--- source.hlsl
+
+// This test verifies that a texture declaring more mip levels than its
+// dimensions can support, or no mip levels at all, is rejected with a clear
+// error rather than being handed to the driver.
+
+Texture2D<float4> Tex : register(t0);
+RWBuffer<float4> Out : register(u0);
+
+[numthreads(1, 1, 1)]
+void main() {
+  Out[0] = Tex.mips[0][int2(0, 0)];
+}
+
+//--- too-many-mips.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+
+Buffers:
+  # A 2x2 texture supports floor(log2(2)) + 1 = 2 mip levels, but declares 3.
+  # The data is sized to the declared 3-level chain (2x2 + 1x1 + 1x1 texels)
+  # so that the buffer-size check in Pipeline.cpp passes and this test still
+  # reaches the texture validation.
+  - Name: Tex
+    Format: Float32
+    Channels: 4
+    OutputProps: { Width: 2, Height: 2, Depth: 1, MipLevels: 3 }
+    Data: [ 1.0, 0.0, 0.0, 1.0,
+            0.0, 1.0, 0.0, 1.0,
+            0.0, 0.0, 1.0, 1.0,
+            1.0, 1.0, 1.0, 1.0,
+            1.0, 1.0, 0.0, 1.0,
+            0.0, 1.0, 1.0, 1.0 ]
+
+  - Name: Out
+    Format: Float32
+    Channels: 4
+    FillSize: 16
+
+DescriptorSets:
+  - Resources:
+    - Name: Tex
+      Kind: Texture2D
+      DirectXBinding: { Register: 0, Space: 0 }
+    - Name: Out
+      Kind: RWBuffer
+      DirectXBinding: { Register: 0, Space: 0 }
+
+Results: []
+...
+
+//--- zero-mips.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+
+Buffers:
+  # MipLevels: 0 makes the expected data size zero, so the buffer must be
+  # empty for the buffer-size check to pass and hand off to the texture
+  # validation.
+  - Name: Tex
+    Format: Float32
+    Channels: 4
+    OutputProps: { Width: 2, Height: 2, Depth: 1, MipLevels: 0 }
+    Data: []
+
+  - Name: Out
+    Format: Float32
+    Channels: 4
+    FillSize: 16
+
+DescriptorSets:
+  - Resources:
+    - Name: Tex
+      Kind: Texture2D
+      DirectXBinding: { Register: 0, Space: 0 }
+    - Name: Out
+      Kind: RWBuffer
+      DirectXBinding: { Register: 0, Space: 0 }
+
+Results: []
+...
+#--- end
+
+# Only DirectX routes texture resources through TextureCreateDesc today; the
+# Vulkan and Metal backends still create images directly from the pipeline
+# description, so they never reach this validation.
+# UNSUPPORTED: Vulkan
+# UNSUPPORTED: Metal
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
+
+# RUN: not %offloader %t/too-many-mips.yaml %t.o 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=TOO-MANY
+# TOO-MANY: error: Texture dimensions 2x2 support at most 2 mip levels, got 3.
+
+# RUN: not %offloader %t/zero-mips.yaml %t.o 2>&1 \
+# RUN:   | FileCheck %s --check-prefix=ZERO-MIPS
+# ZERO-MIPS: error: Texture must have at least one mip level.


### PR DESCRIPTION
A new TextureDimension enum has been added. Places where a 2D texture-related were expected are now replaced with a helper function and switch over the enum to return the appropriate value.

Places that assumed the number of texture subresources was the number of mip levels are now replaced with a call to a helper to obtain the correct subresource count. The number of subresources is equal to the number of mip levels right now, but that will change with array textures which will add array slices.

Added backend-agnostic helper functions for texture subresource layout arithmetic, and symmetric functions for copying texture contents between tightly-packed host buffers and GPU-mapped memory regions.

Also fixes two latent bugs:
DX copyTextureToBuffer only copied subresource 0, never reading back mip beyond the most detailed one (mip 0).
VK copyTextureToBuffer passed regionCount = 0, making the copy a no-op.

Assisted by: Claude Opus 5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>