### PR TITLE
Remove XFAIL for passing WaveActiveCountBits on QC/Vulkan

### DIFF
--- a/test/Feature/WaveOps/WaveActiveCountBits.test
+++ b/test/Feature/WaveOps/WaveActiveCountBits.test
@@ -63,9 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/llvm/offload-test-suite/issues/549
-# XFAIL: QC && Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This test is passing, and was referencing the wrong bug. The actual bug was https://github.com/llvm/llvm-project/issues/182145, which is fixed.