### PR TITLE
[ci_results] Use the README for the workflow list

### DIFF
--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -225,7 +225,7 @@ def get_readme_workflows():
     workflows = []
     # Look for [![Name](https://.../badge.svg)](https://.../workflow.yaml)
     workflow_re = re.compile(
-        r'\[!\[.*?\].*?\]\(https://.*?/actions/workflows/(.*?.yaml)\)'
+        r"\[!\[.*?\].*?\]\(https://.*?/actions/workflows/(.*?.yaml)\)"
     )
     try:
         with open("README.md") as fd:
@@ -238,7 +238,7 @@ def get_readme_workflows():
         )
     if not workflows:
         raise CIResultsError(
-            f"Failed to find workflows in README.md - regex changed?"
+            f"No workflows matched in README.md - Has the format changed?"
         )
     return workflows
 

--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -152,22 +152,10 @@ def analyze_current_status(workflows, regressions_only=False):
     omitted.
     """
     if not workflows:
-        for path in pathlib.Path(".github/workflows").glob("*.yaml"):
-            if any(
-                (
-                    path.name.startswith("build-"),
-                    path.name.startswith("frequent-build-"),
-                    path.name.startswith("pr-"),
-                    path.name.startswith("test-"),
-                    path.name.startswith("validate-"),
-                )
-            ):
-                continue
-            workflows.append(path.name)
-        workflows.sort(key=workflow_status_key)
+        workflows = get_readme_workflows('README.md')
     if not workflows:
         raise CIResultsError(
-            f"No workflows found in .github/workflows/. "
+            f"Could not find workflows in README.md - "
             f"Please run from the top level directory of the repository."
         )
 
@@ -238,51 +226,16 @@ def get_project_for_workflow(workflow):
     raise CIResultsError(f"Workflow {workflow} is neither clang nor dxc")
 
 
-def workflow_status_key(workflow):
-    parts = workflow[: -len(".yaml")].split("-")
-    if not parts:
-        return None
-
-    parts.reverse()
-
-    host = parts.pop()
-    if host == "macos":
-        target = "metal"
-    else:
-        target = parts.pop()
-    compiler = parts.pop()
-    driver = parts.pop()
-
-    # We label warp warp-d3d12 and the variant warp-preview-d3d12.
-    if driver == "warp" and parts[-1] == "d3d12":
-        parts.pop()
-
-    variant = True if parts else False
-
-    # Match the order that we print the results in the offload test suite
-    # README for easier correlation. Unfortunately I don't see an obvious way
-    # to automate this.
-    tier_list = [
-        ("d3d12", "intel"),
-        ("d3d12", "nvidia"),
-        ("warp", "amd"),
-        ("warp", "qc"),
-        ("vk", "intel"),
-        ("mtl", "metal"),
-        ("d3d12", "amd"),
-        ("d3d12", "qc"),
-        ("vk", "amd"),
-        ("vk", "nvidia"),
-        ("vk", "qc"),
-    ]
-    try:
-        tier = tier_list.index((driver, target))
-    except ValueError:
-        tier = len(tier_list)
-
-    compiler_key = 0 if compiler == "dxc" else 1
-
-    return (variant, tier, driver, target, host, compiler_key)
+def get_readme_workflows(readme_filename):
+    workflows = []
+    # Look for [![Name](https://.../badge.svg)](https://.../workflow.yaml)
+    workflow_re = re.compile(
+        r'\[!\[.*?\].*?\]\(https://.*?/actions/workflows/(.*?.yaml)\)'
+    )
+    with open(readme_filename) as fd:
+        for workflow in workflow_re.finditer(fd.read()):
+            workflows.append(workflow.group(1))
+    return workflows
 
 
 def find_failure_range(

--- a/utils/ci_results.py
+++ b/utils/ci_results.py
@@ -152,12 +152,7 @@ def analyze_current_status(workflows, regressions_only=False):
     omitted.
     """
     if not workflows:
-        workflows = get_readme_workflows('README.md')
-    if not workflows:
-        raise CIResultsError(
-            f"Could not find workflows in README.md - "
-            f"Please run from the top level directory of the repository."
-        )
+        workflows = get_readme_workflows()
 
     printer = ResultPrinter()
 
@@ -226,15 +221,25 @@ def get_project_for_workflow(workflow):
     raise CIResultsError(f"Workflow {workflow} is neither clang nor dxc")
 
 
-def get_readme_workflows(readme_filename):
+def get_readme_workflows():
     workflows = []
     # Look for [![Name](https://.../badge.svg)](https://.../workflow.yaml)
     workflow_re = re.compile(
         r'\[!\[.*?\].*?\]\(https://.*?/actions/workflows/(.*?.yaml)\)'
     )
-    with open(readme_filename) as fd:
-        for workflow in workflow_re.finditer(fd.read()):
-            workflows.append(workflow.group(1))
+    try:
+        with open("README.md") as fd:
+            for workflow in workflow_re.finditer(fd.read()):
+                workflows.append(workflow.group(1))
+    except FileNotFoundError:
+        raise CIResultsError(
+            f"Could not find README.md - "
+            f"Please run from the top level directory of the repository."
+        )
+    if not workflows:
+        raise CIResultsError(
+            f"Failed to find workflows in README.md - regex changed?"
+        )
     return workflows
 
 


### PR DESCRIPTION
Instead of all of the complicated filtering and sorting logic we have here that breaks every time a new type of workflow file is added, just grep the README.

I didn't do this originally because it seemed fragile, but it's a lot simpler and less error prone than what we were doing instead.