### PR TITLE
Fix clang-tidy for generated sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ if (OFFLOADTEST_USE_CLANG_TIDY)
   endif()
   # Only lint headers that live inside this project's source tree.
   set(CLANG_TIDY_ARGS ${CLANG_TIDY_ARGS}
+    --config-file=${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy
     --header-filter=^${CMAKE_CURRENT_SOURCE_DIR}/.*)
   if (OFFLOADTEST_CLANG_TIDY_APPLY_FIX)
     set(CLANG_TIDY_ARGS ${CLANG_TIDY_ARGS} --fix)


### PR DESCRIPTION
Pass the repository's `.clang-tidy` configuration explicitly when clang-tidy is enabled.

The Agility SDK integration generates `AgilitySDK.cpp` in the build directory. Because clang-tidy discovers configuration relative to each translation unit, it cannot find the source-tree `.clang-tidy` file for this generated source and exits with `Error: no checks enabled.`

_Assisted by GitHub Copilot._