### PR TITLE
Remove XFAILs that were fixed by legalizing byte buffer ptrcasts 

### DIFF
--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit-clobber.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit-clobber.test
@@ -63,8 +63,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/179560
-# XFAIL: Clang && Vulkan
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8172
 # UNSUPPORTED: DXC && Vulkan
 

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit.test
@@ -89,9 +89,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/179560
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int16
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-64bit.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-64bit.test
@@ -89,9 +89,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/179560
-# XFAIL: Clang && Vulkan
-
 # REQUIRES: Int64
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/LocalResources/local_resource_alias_global.test
+++ b/test/Feature/LocalResources/local_resource_alias_global.test
@@ -41,9 +41,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/192523
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/LocalResources/local_resource_loop_array_index.test
+++ b/test/Feature/LocalResources/local_resource_loop_array_index.test
@@ -56,9 +56,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/305
 # UNSUPPORTED: Metal
 
-# Bug: https://github.com/llvm/llvm-project/issues/192523
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/LocalResources/local_resource_read_only.test
+++ b/test/Feature/LocalResources/local_resource_read_only.test
@@ -51,9 +51,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/192523
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/LocalResources/local_resource_struct_method.test
+++ b/test/Feature/LocalResources/local_resource_struct_method.test
@@ -44,9 +44,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/192523
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/LocalResources/local_resource_with_wave_intrinsic.test
+++ b/test/Feature/LocalResources/local_resource_with_wave_intrinsic.test
@@ -47,9 +47,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/192523
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Since llvm/llvm-project#192523 and llvm/llvm-project#179560 are resolved by llvm/llvm-project#212999, remove the XFAILs for the tests that have started passing. Note that there are 5 other tests that are XFAIL'd on these two issues but are now failing for different reasons. I will follow up on those shortly.