### PR TITLE
Drop metal xfail for interlocked add

### DIFF
--- a/test/Feature/HLSLLib/InterlockedAdd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.resources.32.test
@@ -266,9 +266,6 @@ DescriptorSets:
 # Unimplemented texture atomics: https://github.com/llvm/llvm-project/issues/186154
 # XFAIL: Clang && (DirectX || Metal)
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1435
 # XFAIL: Clang && Vulkan
 


### PR DESCRIPTION
This PR removes an XFAIL for metal on interlockedadd that was observed to pass here:
https://github.com/llvm/offload-test-suite/actions/runs/32896019929/job/97958787176?pr=1477#step:15:889
