### PR TITLE
[SPIRV] Remove stale matrix swizzle XFAILs

### DIFF
--- a/test/Basic/Matrix/matrix_swizzle_one_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_one_based.test
@@ -112,9 +112,6 @@ DescriptorSets:
 ...
 #--- end
 
-# BUG https://github.com/llvm/llvm-project/issues/180258
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_swizzle_zero_based.test
+++ b/test/Basic/Matrix/matrix_swizzle_zero_based.test
@@ -112,9 +112,6 @@ DescriptorSets:
 ...
 #--- end
 
-# BUG https://github.com/llvm/llvm-project/issues/180258
-# XFAIL: Vulkan && Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
llvm/llvm-project#191909 exposed llvm/llvm-project#180258 and caused these tests to fail. That LLVM change was reverted by llvm/llvm-project#218804, and the scheduled Intel Clang Vulkan runs now report both tests as XPASS.
