### PR TITLE
Update stale XFAIL tracker links

### DIFF
--- a/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.int64.test
@@ -167,7 +167,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1407
+# Bug: https://github.com/llvm/llvm-project/issues/217831
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164

--- a/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.typed.int64.test
@@ -125,7 +125,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1438
+# Bug: https://github.com/llvm/llvm-project/issues/217823
 # XFAIL: Clang && Vulkan
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6

--- a/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.int64.test
@@ -192,7 +192,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1407
+# Bug: https://github.com/llvm/llvm-project/issues/217831
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164

--- a/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.resources.typed.int64.test
@@ -140,7 +140,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1438
+# Bug: https://github.com/llvm/llvm-project/issues/217823
 # XFAIL: Clang && Vulkan
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6

--- a/test/WaveOps/WavePrefixProduct.32.test
+++ b/test/WaveOps/WavePrefixProduct.32.test
@@ -470,7 +470,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1083
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084

--- a/test/WaveOps/WavePrefixProduct.fp16.test
+++ b/test/WaveOps/WavePrefixProduct.fp16.test
@@ -172,7 +172,7 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1083
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084

--- a/test/WaveOps/WavePrefixProduct.fp64.test
+++ b/test/WaveOps/WavePrefixProduct.fp64.test
@@ -171,7 +171,7 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1083
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1084

--- a/test/WaveOps/WavePrefixProduct.int16.test
+++ b/test/WaveOps/WavePrefixProduct.int16.test
@@ -317,7 +317,7 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug: # Bug: https://github.com/llvm/offload-test-suite/issues/1083
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/961

--- a/test/WaveOps/WavePrefixProduct.int64.test
+++ b/test/WaveOps/WavePrefixProduct.int64.test
@@ -317,7 +317,7 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1083
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/959

--- a/test/WaveOps/WavePrefixSum.32.test
+++ b/test/WaveOps/WavePrefixSum.32.test
@@ -465,7 +465,7 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/186151
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/960

--- a/test/WaveOps/WavePrefixSum.fp16.test
+++ b/test/WaveOps/WavePrefixSum.fp16.test
@@ -166,7 +166,7 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# Bug: https://github.com/llvm/llvm-project/issues/186151
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/960

--- a/test/WaveOps/WavePrefixSum.fp64.test
+++ b/test/WaveOps/WavePrefixSum.fp64.test
@@ -166,7 +166,7 @@ DescriptorSets:
 
 # REQUIRES: Double
 
-# Bug: https://github.com/llvm/llvm-project/issues/186151
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/961

--- a/test/WaveOps/WavePrefixSum.int16.test
+++ b/test/WaveOps/WavePrefixSum.int16.test
@@ -317,7 +317,7 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug: https://github.com/llvm/llvm-project/issues/186151
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/961

--- a/test/WaveOps/WavePrefixSum.int64.test
+++ b/test/WaveOps/WavePrefixSum.int64.test
@@ -317,7 +317,7 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# Bug: https://github.com/llvm/llvm-project/issues/186151
+# Bug: https://github.com/llvm/llvm-project/issues/217826
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/959


### PR DESCRIPTION
Point all WavePrefixSum and WavePrefixProduct datatype XFAILs at llvm/llvm-project#217826.

Update XFAIL links for issues that were moved to the llvm-project repo - llvm/llvm-project#217831 and llvm/llvm-project#217823

Remove the duplicated `# Bug:` label in the int16 WavePrefixProduct test.
