### PR TITLE
[XFAIL][Clang] Enable FP long vector dot product

### DIFF
--- a/test/Feature/HLSLLib/dot.longvec.fp32.test
+++ b/test/Feature/HLSLLib/dot.longvec.fp32.test
@@ -91,9 +91,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/216094
-# XFAIL: Clang
-
 #  Unimplemented https://github.com/llvm/wg-hlsl/issues/467 
 # XFAIL: Vulkan && DXC
 

--- a/test/Feature/HLSLLib/dot.longvec.fp32.test
+++ b/test/Feature/HLSLLib/dot.longvec.fp32.test
@@ -92,10 +92,10 @@ DescriptorSets:
 #--- end
 
 #  Unimplemented https://github.com/llvm/wg-hlsl/issues/467 
-# XFAIL: Vulkan && DXC
+# XFAIL: Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1481
-# XFAIL:  Metal && (DXC || SM_6_9)
+# XFAIL:  Metal && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T %if Clang %{cs_6_0%} %else %{cs_6_9%} -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
All sub issue for https://github.com/llvm/llvm-project/issues/216094 are now resolved and this test is now passing

resolve https://github.com/llvm/llvm-project/issues/216094