### PR TITLE
[XFAIL][Clang] Enable spv-use-legacy-buffer-matrix-order tests

### DIFF
--- a/test/Feature/ByteAddressBuffer/LegacyBufferMatrixOrderLoad.test
+++ b/test/Feature/ByteAddressBuffer/LegacyBufferMatrixOrderLoad.test
@@ -56,7 +56,6 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: Vulkan
-# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fspv-use-legacy-buffer-matrix-order -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ByteAddressBuffer/LegacyBufferMatrixOrderStore.test
+++ b/test/Feature/ByteAddressBuffer/LegacyBufferMatrixOrderStore.test
@@ -39,7 +39,6 @@ DescriptorSets:
 #--- end
 
 # REQUIRES: Vulkan
-# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -fspv-use-legacy-buffer-matrix-order -T cs_6_5 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
Now that https://github.com/llvm/llvm-project/pull/214575 merged we need to enable these tests.

Context:
https://github.com/llvm/llvm-project/issues/136941