### PR TITLE
Migrate Intel SKU to frequent build method

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -13,28 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # windows-nvidia runs on the frequent builder instead; see
-  # Exec-Tests-Windows-NVIDIA below and docs/frequent-builder.md.
-  Exec-Tests-Windows:
-    permissions:
-      contents: read
-      checks: write
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable-default-tests') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        SKU: [windows-intel]
-        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
-
-    uses: ./.github/workflows/build-and-test-callable.yaml
-    with:
-      OS: windows
-      SKU: ${{ matrix.SKU }}
-      TestTarget: ${{ matrix.TestTarget }}
-      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
-      SplitBuild: true
-      LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
-
   # Resolved once per PR so every frequent-builder cell tests the same
   # toolchain. See docs/frequent-builder.md.
   Resolve-Frequent-Builds:
@@ -46,7 +24,7 @@ jobs:
 
   # Consumes prebuilt LLVM/DXC rather than compiling them per cell, so these
   # cells take no generic build-pool capacity.
-  Exec-Tests-Windows-NVIDIA:
+  Exec-Tests-Windows:
     permissions:
       contents: read
       checks: write
@@ -56,13 +34,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
+        SKU: [windows-intel, windows-nvidia]
+        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk]
+        exclude:
+          - { SKU: windows-nvidia, TestTarget: check-hlsl-vk }
+          - { SKU: windows-nvidia, TestTarget: check-hlsl-clang-vk }
 
     uses: ./.github/workflows/test-callable.yaml
     with:
       OS: windows
       Arch: x64
-      SKU: windows-nvidia
+      SKU: ${{ matrix.SKU }}
       TestTarget: ${{ matrix.TestTarget }}
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       LlvmRunId: ${{ needs.Resolve-Frequent-Builds.outputs.LlvmRunId }}

--- a/.github/workflows/test-callable.yaml
+++ b/.github/workflows/test-callable.yaml
@@ -148,8 +148,6 @@ jobs:
               echo "::error::clang-tidy missing from the downloaded distribution ($clang_tidy). The resolved frequent-build-llvm run predates clang-tidy being added to StandaloneDistribution.cmake; rebuild or resolve a newer run."
               exit 1
             fi
-            # The legacy build used clang-cl for these sources. Use clang-cl
-            # from the distribution to keep the same compiler.
             clang_cl="$GITHUB_WORKSPACE/install/bin/clang-cl"
             if [ -x "${clang_cl}.exe" ]; then clang_cl="${clang_cl}.exe"; fi
             if [ ! -x "$clang_cl" ]; then

--- a/.github/workflows/test-callable.yaml
+++ b/.github/workflows/test-callable.yaml
@@ -148,9 +148,19 @@ jobs:
               echo "::error::clang-tidy missing from the downloaded distribution ($clang_tidy). The resolved frequent-build-llvm run predates clang-tidy being added to StandaloneDistribution.cmake; rebuild or resolve a newer run."
               exit 1
             fi
+            # The legacy build used clang-cl for these sources. Use clang-cl
+            # from the distribution to keep the same compiler.
+            clang_cl="$GITHUB_WORKSPACE/install/bin/clang-cl"
+            if [ -x "${clang_cl}.exe" ]; then clang_cl="${clang_cl}.exe"; fi
+            if [ ! -x "$clang_cl" ]; then
+              echo "::error::clang-cl missing from the downloaded distribution ($clang_cl). It is installed by the 'clang' component in StandaloneDistribution.cmake; rebuild or resolve a newer frequent-build-llvm run."
+              exit 1
+            fi
             cmake -G Ninja -S "$GITHUB_WORKSPACE/OffloadTest" -B "$GITHUB_WORKSPACE/standalone-build" \
               -C "$GITHUB_WORKSPACE/OffloadTest/cmake/caches/sccache.cmake" \
               -DCMAKE_BUILD_TYPE=${{ inputs.BuildType }} \
+              -DCMAKE_C_COMPILER="$clang_cl" \
+              -DCMAKE_CXX_COMPILER="$clang_cl" \
               -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/install/lib/cmake/llvm" \
               -DLLVM_MAIN_SRC_DIR="$GITHUB_WORKSPACE/llvm-project/llvm" \
               -DDXC_DIR="$GITHUB_WORKSPACE/dxc-dist/bin" \

--- a/.github/workflows/test-callable.yaml
+++ b/.github/workflows/test-callable.yaml
@@ -6,8 +6,8 @@ permissions:
 # Runs one lit suite on a GPU runner against distributions built by earlier
 # frequent-build-llvm.yaml and frequent-build-dxc.yaml runs, rebuilding the
 # offload-test-suite tools standalone from the PR head. Called by
-# pr-matrix.yaml for windows-nvidia and by validate-frequent-builder.yaml;
-# see docs/frequent-builder.md.
+# pr-matrix.yaml for its default x64 cells and by
+# validate-frequent-builder.yaml; see docs/frequent-builder.md.
 
 on:
   workflow_call:

--- a/docs/frequent-builder.md
+++ b/docs/frequent-builder.md
@@ -11,9 +11,9 @@ LLVM and DXC are built by two independent schedules:
 
 Test cells consume both through `test-callable.yaml`.
 
-Migration is incremental. Today `pr-matrix.yaml` routes only the
-`windows-nvidia` x64 cells (`check-hlsl-d3d12` and `check-hlsl-clang-d3d12`)
-this way; every other cell still builds its own toolchain via
+Migration is incremental. Today `pr-matrix.yaml` routes its default x64
+cells (`Exec-Tests-Windows`: `windows-intel` and `windows-nvidia`) this way;
+the warp, `test-all` and macOS cells still build their own toolchain via
 `build-and-test-callable.yaml` with `SplitBuild: true`. So "PRs never build
 LLVM or DXC" below describes the end state, not the current one.
 

--- a/docs/frequent-builder.md
+++ b/docs/frequent-builder.md
@@ -9,7 +9,10 @@ LLVM and DXC are built by two independent schedules:
 | `frequent-build-llvm.yaml`| LLVM/Clang | every 2 hours| `build-llvm-callable.yaml` |
 | `frequent-build-dxc.yaml` | DXC        | daily        | `build-dxc-callable.yaml`  |
 
-Test cells consume both through `test-callable.yaml`.
+Test cells consume both through `test-callable.yaml`. A **test cell** is one
+entry in a `pr-matrix.yaml` job matrix, that is one SKU and test-target pair
+such as `(windows-intel, check-hlsl-d3d12)`. Each cell shows as one check on
+the PR.
 
 Migration is incremental. Today `pr-matrix.yaml` routes its default x64
 cells (`Exec-Tests-Windows`: `windows-intel` and `windows-nvidia`) this way;


### PR DESCRIPTION
Like https://github.com/llvm/offload-test-suite/pull/1436, this PR migrates the intel runners to pull from the frequent builder's binaries.
#1436 built the offload test suite with MSVC, because the standalone configure in  test-callable.yaml  set no compiler. This PR makes that build use `clang-cl` from the downloaded distribution, matching the legacy in-tree build. This applies to the intel and the nvidia cells.
The intel and nvidia cells are now one `Exec-Tests-Windows` matrix job, which replaces the separate `Exec-Tests-Windows-NVIDIA` job. This renames the nvidia checks.

Assisted by: Github Copilot
Addresses: https://github.com/llvm/offload-test-suite/issues/1388
