### PR TITLE
Remove `UNSUPPORTED` labels from tests that are supported

### DIFF
--- a/test/Basic/DescriptorSets.test
+++ b/test/Basic/DescriptorSets.test
@@ -54,9 +54,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Clang doesn't support the `vk::binding` attribute.
-# UNSUPPORTED: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/DescriptorSets.hlsl
 # RUN: %offloader %t/DescriptorSets.yaml %t.o | FileCheck %s

--- a/test/Basic/Matrix/matrix_bool_and_operator.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator.test
@@ -127,9 +127,8 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Note: Metal does not support boolean matrix types. For
-# Vulkan KosmicKrisp and MoltenVK the output is always False.
-# UNSUPPORTED: Metal || KosmicKrisp || MoltenVK
+# Note: For Vulkan KosmicKrisp and MoltenVK the output is always False.
+# UNSUPPORTED: KosmicKrisp || MoltenVK
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_bool_and_operator.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator.test
@@ -127,9 +127,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Note: For Vulkan KosmicKrisp and MoltenVK the output is always False.
-# UNSUPPORTED: KosmicKrisp || MoltenVK
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
@@ -129,9 +129,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
 # XFAIL: Clang && Intel-Gen-Current && DirectX
 
-# Note: For Vulkan KosmicKrisp and MoltenVK the output is always False.
-# UNSUPPORTED: KosmicKrisp || MoltenVK
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
+++ b/test/Basic/Matrix/matrix_bool_and_operator_thread_group.test
@@ -129,9 +129,8 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/696
 # XFAIL: Clang && Intel-Gen-Current && DirectX
 
-# Note: Metal does not support boolean matrix types. For
-# Vulkan KosmicKrisp and MoltenVK the output is always False.
-# UNSUPPORTED: Metal || KosmicKrisp || MoltenVK
+# Note: For Vulkan KosmicKrisp and MoltenVK the output is always False.
+# UNSUPPORTED: KosmicKrisp || MoltenVK
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/Matrix/matrix_bool_or_operator.test
+++ b/test/Basic/Matrix/matrix_bool_or_operator.test
@@ -147,9 +147,6 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Note: For Vulkan KosmicKrisp and MoltenVK the output is always False.
-# UNSUPPORTED: KosmicKrisp || MoltenVK
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Basic/Matrix/matrix_bool_or_operator.test
+++ b/test/Basic/Matrix/matrix_bool_or_operator.test
@@ -147,9 +147,8 @@ DescriptorSets:
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8129
 # XFAIL: DXC && Vulkan
 
-# Note: Metal does not support boolean matrix types. For
-# Vulkan KosmicKrisp and MoltenVK the output is always False.
-# UNSUPPORTED: Metal || KosmicKrisp || MoltenVK
+# Note: For Vulkan KosmicKrisp and MoltenVK the output is always False.
+# UNSUPPORTED: KosmicKrisp || MoltenVK
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Basic/TestFloat32Pipeline.test
+++ b/test/Basic/TestFloat32Pipeline.test
@@ -38,9 +38,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140739
-# UNSUPPORTED: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/cbuffer.test
+++ b/test/Basic/cbuffer.test
@@ -54,7 +54,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Basic/simple.test
+++ b/test/Basic/simple.test
@@ -40,9 +40,6 @@ DescriptorSets:
 ...
 #--- end
 
-# https://github.com/llvm/llvm-project/issues/140739
-# UNSUPPORTED: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/simple.hlsl
 # RUN: %offloader %t/simple.yaml %t.o | FileCheck %s

--- a/test/Bugs/Adjacent-Partial-Writes.yaml
+++ b/test/Bugs/Adjacent-Partial-Writes.yaml
@@ -64,10 +64,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/226
 # XFAIL: Intel-Memory-Coherence-Issue-226 && !Clang
 
-# https://github.com/microsoft/DirectXShaderCompiler/issues/7494
-# https://github.com/llvm/llvm-project/issues/142677
-# UNSUPPORTED: Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Attributes/SwitchBranchAttr.test
+++ b/test/Feature/Attributes/SwitchBranchAttr.test
@@ -4,8 +4,8 @@ RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
 void main(uint3 TID : SV_GroupThreadID) {
+    int X = In[TID.x];
     [branch]
-      int X = In[TID.x];
     switch (TID.x % 3) {
       case 0:
         Out[TID.x] = -X;
@@ -51,7 +51,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/Attributes/SwitchFlattenAttr.test
+++ b/test/Feature/Attributes/SwitchFlattenAttr.test
@@ -4,8 +4,8 @@ RWBuffer<int> Out : register(u1);
 
 [numthreads(8,1,1)]
 void main(uint3 TID : SV_GroupThreadID) {
+    int X = In[TID.x];
     [flatten]
-      int X = In[TID.x];
     switch (TID.x % 3) {
       case 0:
         Out[TID.x] = -X;
@@ -51,7 +51,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit-clobber.test
+++ b/test/Feature/ByteAddressBuffer/ByteAddressBuffers-16bit-clobber.test
@@ -64,7 +64,7 @@ DescriptorSets:
 #--- end
 
 # Bug https://github.com/microsoft/DirectXShaderCompiler/issues/8172
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # REQUIRES: Int16
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -119,7 +119,7 @@ DescriptorSets:
 # REQUIRES: Int16
 
 # Bug https://github.com/llvm/llvm-project/issues/219327
-# XFAIL: Clang && DirectX
+# XFAIL: Clang && (DirectX || Metal)
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -59,7 +59,7 @@ Buffers:
   - Name: ExpectedOut # The result we expect
     Format: UInt32
     Stride: 16
-    Data: [3, 0, 8, 16, 3, 0, 8, 16, 3, 0, 0, 0]
+    Data: [3, 0, 8, 16, 0, 8, 16, 16, 3, 0, 0, 0]
 Results:
   - Result: Test1
     Rule: BufferExact
@@ -118,16 +118,8 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug in DXC-Vulkan
-# https://github.com/microsoft/DirectXShaderCompiler/issues/7494
-# Bug in Clang-Vulkan
-# https://github.com/llvm/llvm-project/issues/142677
-# However, the behaviour is also inconsistent across GPUs when using directx
-# and requires an HLK test so we will mark everything as UNSUPPORTED.
-# For more context see here:
-# https://github.com/microsoft/DirectXShaderCompiler/issues/7499
-# UNSUPPORTED: DXC
-# UNSUPPORTED: Clang
+# Bug https://github.com/llvm/llvm-project/issues/219327
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/countbits.64.test
+++ b/test/Feature/HLSLLib/countbits.64.test
@@ -92,10 +92,6 @@ DescriptorSets:
 
 # REQUIRES: Int64
 
-# https://github.com/microsoft/DirectXShaderCompiler/issues/7494
-# https://github.com/llvm/llvm-project/issues/142677
-# UNSUPPORTED: Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/distance.16.test
+++ b/test/Feature/HLSLLib/distance.16.test
@@ -117,9 +117,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang && Vulkan
-# Clang-Vulkan is unsupported because of two validation errors
-# This issue tracks its resolution: https://github.com/llvm/offload-test-suite/issues/285
 # REQUIRES: Half
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/distance.32.test
+++ b/test/Feature/HLSLLib/distance.32.test
@@ -114,9 +114,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang && Vulkan
-# Clang-Vulkan is unsupported because of two validation errors
-# This issue tracks its resolution: https://github.com/llvm/offload-test-suite/issues/285
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/dot4add.test
+++ b/test/Feature/HLSLLib/dot4add.test
@@ -73,9 +73,6 @@ DescriptorSets:
 ...
 #--- end
 
-# We don't yet support PackedVectorFormat4x8Bit
-# UNSUPPORTED: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/firstbithigh.16.test
+++ b/test/Feature/HLSLLib/firstbithigh.16.test
@@ -86,7 +86,7 @@ DescriptorSets:
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
 # Unsupported https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -enable-16bit-types -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/firstbithigh.16.test
+++ b/test/Feature/HLSLLib/firstbithigh.16.test
@@ -85,7 +85,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
-# Unsupported https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl
+# Unsupported https://github.com/microsoft/DirectXShaderCompiler/issues/8536
 # XFAIL: DXC && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -85,7 +85,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
-# https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
+# Unsupported https://github.com/microsoft/DirectXShaderCompiler/issues/8536
 # XFAIL: DXC && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/567

--- a/test/Feature/HLSLLib/firstbithigh.64.test
+++ b/test/Feature/HLSLLib/firstbithigh.64.test
@@ -86,7 +86,7 @@ DescriptorSets:
 
 # 16/64 bit firstbithigh doesn't have a DXC-Vulkan lowering
 # https://github.com/microsoft/DirectXShaderCompiler/blob/main/tools/clang/test/CodeGenSPIRV/intrinsics.firstbithigh.64bit.hlsl
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/567
 # XFAIL: QC && DirectX

--- a/test/Feature/HLSLLib/firstbitlow.16.test
+++ b/test/Feature/HLSLLib/firstbitlow.16.test
@@ -79,7 +79,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering
-# https://github.com/microsoft/DirectXShaderCompiler/blob/48d6e3c635f0ab3ae79580c37003e6faeca6c671/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl#L5
+# Unsupported https://github.com/microsoft/DirectXShaderCompiler/issues/8536
 # XFAIL: DXC && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/firstbitlow.16.test
+++ b/test/Feature/HLSLLib/firstbitlow.16.test
@@ -80,7 +80,7 @@ DescriptorSets:
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering
 # https://github.com/microsoft/DirectXShaderCompiler/blob/48d6e3c635f0ab3ae79580c37003e6faeca6c671/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl#L5
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -enable-16bit-types -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -80,7 +80,7 @@ DescriptorSets:
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering
 # https://github.com/microsoft/DirectXShaderCompiler/blob/48d6e3c635f0ab3ae79580c37003e6faeca6c671/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl#L5
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1024
 # XFAIL: QC && Vulkan && Clang

--- a/test/Feature/HLSLLib/firstbitlow.64.test
+++ b/test/Feature/HLSLLib/firstbitlow.64.test
@@ -79,7 +79,7 @@ DescriptorSets:
 # XFAIL: Metal
 
 # 16/64 bit firstbitlow doesn't have a DXC-Vulkan lowering
-# https://github.com/microsoft/DirectXShaderCompiler/blob/48d6e3c635f0ab3ae79580c37003e6faeca6c671/tools/clang/test/CodeGenSPIRV/intrinsics.firstbitlow.64bit.hlsl#L5
+# Unsupported https://github.com/microsoft/DirectXShaderCompiler/issues/8536
 # XFAIL: DXC && Vulkan
 
 # Bug https://github.com/llvm/offload-test-suite/issues/1024

--- a/test/Feature/HLSLLib/ldexp.16.test
+++ b/test/Feature/HLSLLib/ldexp.16.test
@@ -72,7 +72,6 @@ DescriptorSets:
 
 # REQUIRES: Half
 
-# UNSUPPORTED: Clang && Vulkan
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/ldexp.32.test
+++ b/test/Feature/HLSLLib/ldexp.32.test
@@ -70,7 +70,6 @@ DescriptorSets:
 ...
 #--- end
 
-# UNSUPPORTED: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/reflect.32.test
+++ b/test/Feature/HLSLLib/reflect.32.test
@@ -179,7 +179,6 @@ DescriptorSets:
         Binding: 8      
 ...
 #--- end
-# UNSUPPORTED: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/LocalResources/local_resource_array_dynamic_index.test
+++ b/test/Feature/LocalResources/local_resource_array_dynamic_index.test
@@ -56,9 +56,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/305
-# UNSUPPORTED: Metal
-
 # Bug: https://github.com/llvm/llvm-project/issues/192523
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/LocalResources/local_resource_loop_array_index.test
+++ b/test/Feature/LocalResources/local_resource_loop_array_index.test
@@ -53,9 +53,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/305
-# UNSUPPORTED: Metal
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -66,7 +66,7 @@ DescriptorSets:
 #--- end
 
 # DXC + Vulkan does not support multi-dimensional resource arrays
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164908
 # XFAIL: Clang && Vulkan

--- a/test/Feature/ResourceArrays/multi-dim-array-subset.test
+++ b/test/Feature/ResourceArrays/multi-dim-array-subset.test
@@ -66,7 +66,7 @@ DescriptorSets:
 #--- end
 
 # DXC + Vulkan does not support multi-dimensional resource arrays
-# XFAIL: DXC && Vulkan
+# UNSUPPORTED: DXC && Vulkan
 
 # Unimplemented https://github.com/llvm/llvm-project/issues/164908
 # XFAIL: Clang && Vulkan

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -121,7 +121,7 @@ DescriptorSets:
 # XFAIL: Clang && Vulkan
 
 # DXC + Vulkan does not support global structures containing buffers.
-# UNSUPPORTED: DXC && Vulkan
+# XFAIL: DXC && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/Feature/ResourcesInStructs/res-in-struct-mix.test
+++ b/test/Feature/ResourcesInStructs/res-in-struct-mix.test
@@ -121,7 +121,7 @@ DescriptorSets:
 # XFAIL: Clang && Vulkan
 
 # DXC + Vulkan does not support global structures containing buffers.
-# XFAIL: DXC && Vulkan
+# UNSUPPORTED: DXC && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/GSFlag.test
+++ b/test/WaveOps/GSFlag.test
@@ -42,7 +42,6 @@ DescriptorSets:
 ...
 
 #--- end
-# UNSUPPORTED: Clang
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s

--- a/test/WaveOps/WaveActiveBitAnd.convergence.test
+++ b/test/WaveOps/WaveActiveBitAnd.convergence.test
@@ -164,9 +164,6 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/977
 # XFAIL: Vulkan && Clang
 
-# Not implemented: https://github.com/llvm/llvm-project/issues/99166
-# UNSUPPORTED: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveActiveBitAnd.int64.test
+++ b/test/WaveOps/WaveActiveBitAnd.int64.test
@@ -172,7 +172,7 @@ DescriptorSets:
 
 # 64 bit wave ops are not supported on metal.
 # https://github.com/llvm/offload-test-suite/issues/355
-# UNSUPPORTED: Metal
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveBitOr.int64.test
+++ b/test/WaveOps/WaveActiveBitOr.int64.test
@@ -175,7 +175,7 @@ DescriptorSets:
 
 # 64 bit wave ops are not supported on metal.
 # https://github.com/llvm/offload-test-suite/issues/355
-# UNSUPPORTED: Metal
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveActiveBitXor.int64.test
+++ b/test/WaveOps/WaveActiveBitXor.int64.test
@@ -195,7 +195,7 @@ DescriptorSets:
 
 # 64 bit wave ops are not supported on metal.
 # https://github.com/llvm/offload-test-suite/issues/355
-# UNSUPPORTED: Metal
+# XFAIL: Metal
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -fvk-use-dx-layout -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneAt.Int.64.test
+++ b/test/WaveOps/WaveReadLaneAt.Int.64.test
@@ -99,7 +99,7 @@ DescriptorSets:
 #--- end
 
 # Tracked by https://github.com/llvm/offload-test-suite/issues/355
-# UNSUPPORTED: Metal
+# XFAIL: Metal
 
 # Bug Tracked by https://github.com/llvm/offload-test-suite/issues/672
 # XFAIL: Vulkan && MoltenVK

--- a/test/WaveOps/WaveReadLaneAt.mtx.test
+++ b/test/WaveOps/WaveReadLaneAt.mtx.test
@@ -58,8 +58,6 @@ DescriptorSets:
         Binding: 1
 ...
 #--- end
-# UNSUPPORTED: Clang
-# Test is unsupported in clang because matrix support isn't ready yet
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/WaveOps/WaveReadLaneAt.mtx.test
+++ b/test/WaveOps/WaveReadLaneAt.mtx.test
@@ -59,6 +59,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug https://github.com/llvm/offload-test-suite/issues/1293
+# XFAIL: Intel-Gen-Current && Clang && DirectX
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/WaveOps/WaveReadLaneFirst.fp64.test
+++ b/test/WaveOps/WaveReadLaneFirst.fp64.test
@@ -310,9 +310,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal
 
-# Bug https://github.com/llvm/offload-test-suite/issues/433
-# UNSUPPORTED: WARP
-
 REQUIRES: Double
 
 # RUN: split-file %s %t

--- a/test/WaveOps/WaveReadLaneFirst.int64.test
+++ b/test/WaveOps/WaveReadLaneFirst.int64.test
@@ -311,9 +311,6 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/393
 # XFAIL: Metal || (Vulkan && MoltenVK)
 
-# Bug https://github.com/llvm/offload-test-suite/issues/433
-# UNSUPPORTED: WARP
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o 


### PR DESCRIPTION
These all should be XFAILs, but they were marked as unsupported. Many of these pass now, so in those cases I've just removed them.

There are two more interesting cases:
- `countbits.16` had a mistake in the test and is failing for clang. I filed llvm/llvm-project#219327 to track the clang failure.
- `SwitchBranchAttr` and `SwitchFlattenAttr` had the attribute in the wrong place and weren't actually testing what they said they were.