### PR TITLE
Add clang-resource-headers to distribution cmake

### DIFF
--- a/cmake/caches/StandaloneDistribution.cmake
+++ b/cmake/caches/StandaloneDistribution.cmake
@@ -13,6 +13,7 @@ set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
 set(LLVM_INSTALL_TOOLCHAIN_ONLY OFF CACHE BOOL "")
 set(LLVM_DISTRIBUTION_COMPONENTS
     clang
+    clang-resource-headers
     # Ships clang-tidy so a standalone offload-test-suite build can enable
     # OFFLOADTEST_USE_CLANG_TIDY without needing a separate Clang toolchain
     # on the machine doing the standalone build.

--- a/docs/offload-distribution.md
+++ b/docs/offload-distribution.md
@@ -19,8 +19,9 @@ A complete deployment consists of two install prefixes:
    Contains:
    - `bin/` — clang, FileCheck, split-file, not, obj2yaml, api-query,
      offloader, and the other tools created by `add_offloadtest_tool`.
-   - `include/`, `lib/clang/<ver>/include/` — clang resource headers
-     (`hlsl-resource-headers` component).
+   - `include/`, `lib/clang/<ver>/include/` — HLSL resource headers
+     (`hlsl-resource-headers` component): `hlsl.h` and the `hlsl/`
+     subdirectory.
    - `share/hlsl-test-suite/` — test sources, `lit.site.cfg.py.in` template,
      `configure-test-suite.py`, and golden images.
 


### PR DESCRIPTION
This PR adds the clang-resource-headers component to the distribution cmake list.

`StandaloneDistribution.cmake` ships `clang` but not `clang-resource-headers`,
so the distribution has no `lib/clang/<ver>/include`. The `clang` component
installs the driver, but not the builtin headers it needs.

This does not matter today, because `test-callable.yaml` builds the offload
test suite with MSVC. It does matter for #1486, which switches that build to
the distribution's `clang-cl`. Without the headers, Clang falls back to the
MSVC copies of `immintrin.h`, which only declare the SSE2 intrinsics because
MSVC expands them at codegen. Clang emits real calls instead, and libpng's
`filter_sse2_intrinsics.c` then fails to link with 18 undefined `_mm_*`
symbols.

This must land first so a scheduled `frequent-build-llvm` run publishes an
artifact containing the headers before #1486 can go green.

Also corrects a line in `docs/offload-distribution.md` that credited
`lib/clang/<ver>/include/` to `hlsl-resource-headers`. That component installs
only `hlsl.h` and the `hlsl/` subdirectory.

Assisted by: Github Copilot
Addresses: https://github.com/llvm/offload-test-suite/issues/1388