### PR TITLE
Add `InterlockedCompareStoreFloatBitwise` tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareExchangeFloatBitwise.32.test
@@ -23,8 +23,8 @@ RWStructuredBuffer<float> NanIn : register(u3);
 groupshared float SlotsMinusTwoPointFive[256]; // per-thread slots, each -2.5
 groupshared float MatchMinusFive;              // contended, compare matches
 groupshared float NoMatchSeventySeven;         // contended, never matches
-groupshared float ZeroPositive;                // +0.0, compared against -0.0
-groupshared float NanQuiet;                    // NaN, compared against NaN
+groupshared float PositiveZero;                // +0.0, compared against -0.0
+groupshared float QuietNaN;                    // NaN, compared against NaN
 groupshared float ClaimZero;                   // 0.0, claimed by the winner
 
 [numthreads(256, 1, 1)]
@@ -33,8 +33,8 @@ void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     MatchMinusFive = -5.0f;
     NoMatchSeventySeven = 77.0f;
-    ZeroPositive = 0.0f;
-    NanQuiet = NanIn[0];
+    PositiveZero = 0.0f;
+    QuietNaN = NanIn[0];
     ClaimZero = 0.0f;
   }
   GroupMemoryBarrierWithGroupSync();
@@ -69,8 +69,8 @@ void main(uint3 GTID : SV_GroupThreadID) {
   // Check 3. The final value shows whether each compare matched. A compare
   // of NaN against NaN gives false, thus the reported value cannot show it.
   float OrigZero, OrigNan;
-  InterlockedCompareExchangeFloatBitwise(ZeroPositive, -0.0f, 99.0f, OrigZero);
-  InterlockedCompareExchangeFloatBitwise(NanQuiet, NanIn[0], 7.0f, OrigNan);
+  InterlockedCompareExchangeFloatBitwise(PositiveZero, -0.0f, 99.0f, OrigZero);
+  InterlockedCompareExchangeFloatBitwise(QuietNaN, NanIn[0], 7.0f, OrigNan);
 
   OutOrig[GTID.x] = ((OrigMatch == -5.0f || OrigMatch == 42.0f) &&
                      OrigNoMatch == 77.0f && OrigZero == 0.0f &&
@@ -81,8 +81,8 @@ void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     OutFinal[0] = MatchMinusFive;      // 42.0
     OutFinal[1] = NoMatchSeventySeven; // 77.0
-    OutFinal[2] = ZeroPositive;        // +0.0, -0.0 must not have matched
-    OutFinal[3] = NanQuiet;            // 7.0, the NaN must have matched
+    OutFinal[2] = PositiveZero;        // +0.0, -0.0 must not have matched
+    OutFinal[3] = QuietNaN;            // 7.0, the NaN must have matched
     OutFinal[4] = ClaimZero;           // 1.0, exactly one thread claimed
   }
 }

--- a/test/Feature/HLSLLib/InterlockedCompareStoreFloatBitwise.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStoreFloatBitwise.32.test
@@ -1,10 +1,10 @@
 #--- source.hlsl
 
 // Tests InterlockedCompareStoreFloatBitwise on groupshared destinations.
-// 256 threads run at the same time. Each test value is exact in float, thus
-// the shader compares floats directly. The intrinsic does not report the
-// original value, thus each check reads the destination. There are three
-// checks:
+// 256 threads run at the same time. Each test value is exactly representable
+// as a 32-bit float, thus the shader compares floats directly. The intrinsic
+// does not report the original value, thus each check reads the destination.
+// There are three checks:
 //
 //   1. Private slots. A compare that does not match must not store. A later
 //      compare that matches must store.
@@ -22,8 +22,8 @@ RWStructuredBuffer<float> NanIn : register(u2);
 groupshared float SlotsMinusTwoPointFive[256]; // per-thread slots, each -2.5
 groupshared float MatchMinusFive;              // contended, compare matches
 groupshared float NoMatchSeventySeven;         // contended, never matches
-groupshared float ZeroPositive;                // +0.0, compared against -0.0
-groupshared float NanQuiet;                    // NaN, compared against NaN
+groupshared float PositiveZero;                // +0.0, compared against -0.0
+groupshared float QuietNaN;                    // NaN, compared against NaN
 
 [numthreads(256, 1, 1)]
 void main(uint3 GTID : SV_GroupThreadID) {
@@ -31,13 +31,15 @@ void main(uint3 GTID : SV_GroupThreadID) {
   if (GTID.x == 0) {
     MatchMinusFive = -5.0f;
     NoMatchSeventySeven = 77.0f;
-    ZeroPositive = 0.0f;
-    NanQuiet = NanIn[0];
+    PositiveZero = 0.0f;
+    QuietNaN = NanIn[0];
   }
   GroupMemoryBarrierWithGroupSync();
 
-  // Check 1. Only the second call stores. If the first call stored, the
-  // second compare cannot match and the slot keeps the wrong value.
+  // Check 1. The compare against 1.0f must not store, leaving the slot at
+  // -2.5f. The following compare against -2.5f must store the per-thread
+  // value. If the first call stored, the second compare cannot match and the
+  // slot keeps the wrong value.
   InterlockedCompareStoreFloatBitwise(SlotsMinusTwoPointFive[GTID.x], 1.0f,
                                       99.0f);
   InterlockedCompareStoreFloatBitwise(SlotsMinusTwoPointFive[GTID.x], -2.5f,
@@ -51,16 +53,16 @@ void main(uint3 GTID : SV_GroupThreadID) {
   InterlockedCompareStoreFloatBitwise(NoMatchSeventySeven, 78.0f, -1.0f);
 
   // Check 3.
-  InterlockedCompareStoreFloatBitwise(ZeroPositive, -0.0f, 99.0f);
-  InterlockedCompareStoreFloatBitwise(NanQuiet, NanIn[0], 7.0f);
+  InterlockedCompareStoreFloatBitwise(PositiveZero, -0.0f, 99.0f);
+  InterlockedCompareStoreFloatBitwise(QuietNaN, NanIn[0], 7.0f);
 
   GroupMemoryBarrierWithGroupSync();
 
   if (GTID.x == 0) {
     OutFinal[0] = MatchMinusFive;      // 42.0
     OutFinal[1] = NoMatchSeventySeven; // 77.0
-    OutFinal[2] = ZeroPositive;        // +0.0, -0.0 must not have matched
-    OutFinal[3] = NanQuiet;            // 7.0, the NaN must have matched
+    OutFinal[2] = PositiveZero;        // +0.0, -0.0 must not have matched
+    OutFinal[3] = QuietNaN;            // 7.0, the NaN must have matched
   }
 }
 

--- a/test/Feature/HLSLLib/InterlockedCompareStoreFloatBitwise.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStoreFloatBitwise.32.test
@@ -1,0 +1,152 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareStoreFloatBitwise on groupshared destinations.
+// 256 threads run at the same time. Each test value is exact in float, thus
+// the shader compares floats directly. The intrinsic does not report the
+// original value, thus each check reads the destination. There are three
+// checks:
+//
+//   1. Private slots. A compare that does not match must not store. A later
+//      compare that matches must store.
+//   2. Contended locations. All threads propose the same value, thus the
+//      final value is the same whichever thread stores it. A compare that
+//      never matches must not change the destination.
+//   3. Bit patterns. +0.0 against -0.0 must not store. A NaN against the
+//      same NaN bits must store. A buffer supplies the NaN, because HLSL
+//      has no NaN literal.
+
+RWStructuredBuffer<uint> OutSlots : register(u0);
+RWStructuredBuffer<float> OutFinal : register(u1);
+RWStructuredBuffer<float> NanIn : register(u2);
+
+groupshared float SlotsMinusTwoPointFive[256]; // per-thread slots, each -2.5
+groupshared float MatchMinusFive;              // contended, compare matches
+groupshared float NoMatchSeventySeven;         // contended, never matches
+groupshared float ZeroPositive;                // +0.0, compared against -0.0
+groupshared float NanQuiet;                    // NaN, compared against NaN
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  SlotsMinusTwoPointFive[GTID.x] = -2.5f;
+  if (GTID.x == 0) {
+    MatchMinusFive = -5.0f;
+    NoMatchSeventySeven = 77.0f;
+    ZeroPositive = 0.0f;
+    NanQuiet = NanIn[0];
+  }
+  GroupMemoryBarrierWithGroupSync();
+
+  // Check 1. Only the second call stores. If the first call stored, the
+  // second compare cannot match and the slot keeps the wrong value.
+  InterlockedCompareStoreFloatBitwise(SlotsMinusTwoPointFive[GTID.x], 1.0f,
+                                      99.0f);
+  InterlockedCompareStoreFloatBitwise(SlotsMinusTwoPointFive[GTID.x], -2.5f,
+                                      (float)GTID.x + 1000.0f);
+
+  OutSlots[GTID.x] = (SlotsMinusTwoPointFive[GTID.x] ==
+                      (float)GTID.x + 1000.0f) ? 1u : 0u;
+
+  // Check 2.
+  InterlockedCompareStoreFloatBitwise(MatchMinusFive, -5.0f, 42.0f);
+  InterlockedCompareStoreFloatBitwise(NoMatchSeventySeven, 78.0f, -1.0f);
+
+  // Check 3.
+  InterlockedCompareStoreFloatBitwise(ZeroPositive, -0.0f, 99.0f);
+  InterlockedCompareStoreFloatBitwise(NanQuiet, NanIn[0], 7.0f);
+
+  GroupMemoryBarrierWithGroupSync();
+
+  if (GTID.x == 0) {
+    OutFinal[0] = MatchMinusFive;      // 42.0
+    OutFinal[1] = NoMatchSeventySeven; // 77.0
+    OutFinal[2] = ZeroPositive;        // +0.0, -0.0 must not have matched
+    OutFinal[3] = NanQuiet;            // 7.0, the NaN must have matched
+  }
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: ExpectedOnes
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+  - Name: OutSlots
+    Format: UInt32
+    Stride: 4
+    FillSize: 1024
+  - Name: OutFinal
+    Format: Float32
+    Stride: 4
+    FillSize: 16
+  - Name: ExpectedFinal
+    Format: Float32
+    Stride: 4
+    Data: [ 42.0, 77.0, 0.0, 7.0 ]
+  - Name: NanIn
+    Format: Float32
+    Stride: 4
+    Data: [ nan ]
+Results:
+  - Result: TestSlots
+    Rule: BufferExact
+    Actual: OutSlots
+    Expected: ExpectedOnes
+  - Result: TestFinal
+    Rule: BufferExact
+    Actual: OutFinal
+    Expected: ExpectedFinal
+DescriptorSets:
+  - Resources:
+    - Name: OutSlots
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: OutFinal
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: NanIn
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99202
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8864
+# XFAIL: Vulkan && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedCompareStoreFloatBitwise.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedCompareStoreFloatBitwise.resources.32.test
@@ -1,0 +1,163 @@
+#--- source.hlsl
+
+// Tests InterlockedCompareStoreFloatBitwise on the resource destination
+// types that HLSL permits:
+//
+//   * RWStructuredBuffer<float>[i]                       (free function)
+//   * RWBuffer<float>[i]                                 (typed buffer UAV)
+//   * RWTexture2D<float>[coord]                          (typed texture UAV)
+//   * RWByteAddressBuffer::InterlockedCompareStoreFloatBitwise  (method)
+//
+// For each type, the shader makes one compare that matches and one compare
+// that never matches. The intrinsic does not report the original value,
+// thus the test reads the destinations back. All 256 threads make the same
+// calls, thus the compare that matches is contended and all threads propose
+// the same value. The file InterlockedCompareStoreFloatBitwise.32.test
+// covers the bit patterns (-0.0 against +0.0, and NaN).
+
+RWStructuredBuffer<float> SBufF : register(u0);
+RWBuffer<float>           TBufF : register(u1);
+RWTexture2D<float>        Tex2D : register(u2);
+RWByteAddressBuffer       BABuf : register(u3);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    SBufF[0] = -5.0f;                 // compare matches
+    SBufF[1] = 9.0f;                  // compare never matches
+    TBufF[0] = -5.0f;                 // compare matches
+    TBufF[1] = 9.0f;                  // compare never matches
+    Tex2D[uint2(0, 0)] = -5.0f;       // compare matches
+    Tex2D[uint2(1, 0)] = 9.0f;        // compare never matches
+    BABuf.Store<float>(0, -5.0f);     // compare matches
+    BABuf.Store<float>(4, 44.0f);     // compare never matches
+  }
+  DeviceMemoryBarrierWithGroupSync();
+
+  // RWStructuredBuffer<float> (free function).
+  InterlockedCompareStoreFloatBitwise(SBufF[0], -5.0f, 66.0f);
+  InterlockedCompareStoreFloatBitwise(SBufF[1], 10.0f, 0.0f);
+
+  // RWBuffer<float> (typed buffer UAV).
+  InterlockedCompareStoreFloatBitwise(TBufF[0], -5.0f, 77.0f);
+  InterlockedCompareStoreFloatBitwise(TBufF[1], 10.0f, 0.0f);
+
+  // RWTexture2D<float> (typed texture UAV).
+  InterlockedCompareStoreFloatBitwise(Tex2D[uint2(0, 0)], -5.0f, 88.0f);
+  InterlockedCompareStoreFloatBitwise(Tex2D[uint2(1, 0)], 10.0f, 0.0f);
+
+  // RWByteAddressBuffer method form.
+  BABuf.InterlockedCompareStoreFloatBitwise(0, -5.0f, 123.0f);
+  BABuf.InterlockedCompareStoreFloatBitwise(4, 45.0f, -1.0f);
+}
+
+//--- pipeline.yaml
+
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: SBufF
+    Format: Float32
+    Stride: 4
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedSBufF
+    Format: Float32
+    Stride: 4
+    Data: [ 66.0, 9.0 ]
+  - Name: TBufF
+    Format: Float32
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedTBufF
+    Format: Float32
+    Channels: 1
+    Data: [ 77.0, 9.0 ]
+  - Name: Tex2D
+    Format: Float32
+    Channels: 1
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+    OutputProps:
+      Height: 1
+      Width: 2
+      Depth: 1
+  - Name: ExpectedTex2D
+    Format: Float32
+    Channels: 1
+    Data: [ 88.0, 9.0 ]
+    OutputProps:
+      Height: 1
+      Width: 2
+      Depth: 1
+  - Name: BABuf
+    Format: Float32
+    Stride: 4
+    FillSize: 8
+    FillValue: 137  # trash non-zero initialization data
+  - Name: ExpectedBABuf
+    Format: Float32
+    Stride: 4
+    Data: [ 123.0, 44.0 ]
+Results:
+  - Result: TestSBufF
+    Rule: BufferExact
+    Actual: SBufF
+    Expected: ExpectedSBufF
+  - Result: TestTBufF
+    Rule: BufferExact
+    Actual: TBufF
+    Expected: ExpectedTBufF
+  - Result: TestTex2D
+    Rule: BufferExact
+    Actual: Tex2D
+    Expected: ExpectedTex2D
+  - Result: TestBABuf
+    Rule: BufferExact
+    Actual: BABuf
+    Expected: ExpectedBABuf
+DescriptorSets:
+  - Resources:
+    - Name: SBufF
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: TBufF
+      Kind: RWBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+    - Name: Tex2D
+      Kind: RWTexture2D
+      DirectXBinding:
+        Register: 2
+        Space: 0
+      VulkanBinding:
+        Binding: 2
+    - Name: BABuf
+      Kind: RWByteAddressBuffer
+      DirectXBinding:
+        Register: 3
+        Space: 0
+      VulkanBinding:
+        Binding: 3
+...
+#--- end
+
+# Unimplemented: https://github.com/llvm/llvm-project/issues/99202
+# XFAIL: Clang
+
+# Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8864
+# XFAIL: Vulkan && DXC
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This PR adds tests for `InterlockedCompareStoreFloatBitwise`.
It mirrors the tests added for the exchange variant here: https://github.com/llvm/offload-test-suite/pull/1450

Fixes https://github.com/llvm/offload-test-suite/issues/853
Assisted by: Github Copilot