### PR TITLE
Enable TextureCube and RWTexture.Load() tests for Clang

### DIFF
--- a/test/Feature/Textures/Array.Load.test
+++ b/test/Feature/Textures/Array.Load.test
@@ -3,12 +3,6 @@
 [[vk::binding(1, 0)]] RWBuffer<float4> Out : register(u0);
 [[vk::binding(2, 0)]] RWTexture2DArray<float4> RWTex : register(u1);
 
-#ifndef NO_RWTEXTURE_LOAD
-#define RW_LOAD_OR(Call, Expect) (Call)
-#else
-#define RW_LOAD_OR(Call, Expect) (Expect)
-#endif
-
 [numthreads(1, 1, 1)]
 void main() {
   // Texture2DArray::Load takes int4(x, y, arraySlice, mip).
@@ -23,9 +17,9 @@ void main() {
 
   // RWTexture2DArray::Load takes int3(x, y, arraySlice), not the int4 the SRV
   // form takes: a UAV has a single mip, so the slice occupies the last component.
-  Out[5] = RW_LOAD_OR(RWTex.Load(int3(0, 0, 0)), float4(1, 0, 0, 1));     // Red
-  Out[6] = RW_LOAD_OR(RWTex.Load(int3(0, 0, 1)), float4(0, 1, 1, 1));     // Cyan
-  Out[7] = RW_LOAD_OR(RWTex.Load(int3(1, 0, 2)), float4(0.5, 0.5, 0, 1)); // Olive
+  Out[5] = RWTex.Load(int3(0, 0, 0)); // Red
+  Out[6] = RWTex.Load(int3(0, 0, 1)); // Cyan
+  Out[7] = RWTex.Load(int3(1, 0, 2)); // Olive
 }
 
 //--- pipeline.yaml
@@ -115,7 +109,5 @@ Results:
 # XFAIL: Metal
 
 # RUN: split-file %s %t
-# Clang does not implement Load() on RW texture types yet, so those checks
-# compile out there: https://github.com/llvm/llvm-project/issues/218535
-# RUN: %dxc_target -T cs_6_0 %if Clang %{ -DNO_RWTEXTURE_LOAD %} -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/CalculateLevelOfDetail.test
+++ b/test/Feature/Textures/CalculateLevelOfDetail.test
@@ -17,12 +17,7 @@ VSOutput mainVS(VSInput input) {
 [[vk::binding(0, 0)]] Texture2D<float4> Tex : register(t0);
 [[vk::binding(1, 0)]] SamplerState Samp : register(s0);
 [[vk::binding(2, 0)]] RWBuffer<float> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(3, 0)]] TextureCube<float4> TexCube : register(t1); // 4x4 faces, 3 mips
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // Use SV_Position (pixel coordinates) to simulate the grid logic.
@@ -64,10 +59,8 @@ float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   float3 CubeFlat = float3(1, 0, 0) + float3(float2(GTid.xy) * 0.00001, 0);
   float3 CubeSteep = float3(1, 0, 0.5 - float(GTid.x));
 
-  float lod4 = CUBE_OR(TexCube.CalculateLevelOfDetail(Samp, CubeFlat),
-                        0.0);
-  float lod5 = CUBE_OR(TexCube.CalculateLevelOfDetail(Samp, CubeSteep),
-                        1.0);
+  float lod4 = TexCube.CalculateLevelOfDetail(Samp, CubeFlat);
+  float lod5 = TexCube.CalculateLevelOfDetail(Samp, CubeSteep);
 
   if (all(GTid.xy == 0)) {
     Out[0] = lod0;
@@ -182,6 +175,5 @@ Results:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_6 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T ps_6_6 -E mainPS %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t-ps.o %t/pixel.hlsl
+# RUN: %dxc_target -T ps_6_6 -E mainPS -Fo %t-ps.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-vs.o %t-ps.o

--- a/test/Feature/Textures/Gather.test
+++ b/test/Feature/Textures/Gather.test
@@ -3,12 +3,7 @@
 [[vk::binding(1, 0)]] SamplerState Samp : register(s0);
 [[vk::binding(3, 0)]] SamplerState SampRepeat : register(s1);
 [[vk::binding(2, 0)]] RWBuffer<float4> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(4, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 [numthreads(1, 1, 1)]
 void main() {
@@ -59,21 +54,15 @@ void main() {
 
   // Face +X holds a distinct value in every channel of every texel, so all
   // four single-channel gathers are distinguishable.
-  Out[13] = CUBE_OR(TexCube.Gather(Samp, PosX),      // equivalent to GatherRed
-                    float4(0.375, 0.5, 0.25, 0.125));
-  Out[14] = CUBE_OR(TexCube.GatherRed(Samp, PosX),
-                    float4(0.375, 0.5, 0.25, 0.125));
-  Out[15] = CUBE_OR(TexCube.GatherGreen(Samp, PosX),
-                    float4(0.75, 0.875, 0.625, 0.5));
-  Out[16] = CUBE_OR(TexCube.GatherBlue(Samp, PosX),
-                    float4(0.5, 0.625, 0.375, 0.25));
-  Out[17] = CUBE_OR(TexCube.GatherAlpha(Samp, PosX),
-                    float4(0.125, 0.25, 0.875, 0.75));
+  Out[13] = TexCube.Gather(Samp, PosX); // equivalent to GatherRed
+  Out[14] = TexCube.GatherRed(Samp, PosX);
+  Out[15] = TexCube.GatherGreen(Samp, PosX);
+  Out[16] = TexCube.GatherBlue(Samp, PosX);
+  Out[17] = TexCube.GatherAlpha(Samp, PosX);
 
   // A gather on another face must collect only that face's texels. The faces
   // in between are uniform, so straying over an edge shows as a constant.
-  Out[18] = CUBE_OR(TexCube.GatherRed(Samp, NegZ),
-                    float4(0.625, 0.5, 0.75, 0.875));
+  Out[18] = TexCube.GatherRed(Samp, NegZ);
 }
 
 //--- pipeline.yaml
@@ -196,6 +185,5 @@ Results:
 # XFAIL: Metal
 
 # RUN: split-file %s %t
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T cs_6_0 %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/GatherCmp.test
+++ b/test/Feature/Textures/GatherCmp.test
@@ -4,12 +4,7 @@
 [[vk::binding(3, 0)]] SamplerComparisonState SampGreater : register(s1); // Greater
 [[vk::binding(4, 0)]] SamplerComparisonState SampRepeat : register(s2); // Less, Repeat
 [[vk::binding(2, 0)]] RWBuffer<float4> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(5, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 [numthreads(1, 1, 1)]
 void main() {
@@ -71,19 +66,16 @@ void main() {
   //
   // 8: face +X holds the same values as the 2D texture above, so ref=0.5 with
   // Less gives the same [0, 1, 1, 0].
-  Out[8] = CUBE_OR(TexCube.GatherCmp(Samp, float3(1, 0, 0), 0.5),
-                   float4(0, 1, 1, 0));
+  Out[8] = TexCube.GatherCmp(Samp, float3(1, 0, 0), 0.5);
 
   // 9: the same face with Greater inverts every comparison -> [1, 0, 0, 1].
-  Out[9] = CUBE_OR(TexCube.GatherCmp(SampGreater, float3(1, 0, 0), 0.5),
-                   float4(1, 0, 0, 1));
+  Out[9] = TexCube.GatherCmp(SampGreater, float3(1, 0, 0), 0.5);
 
   // 10: face -Z holds 0.9/0.1 instead, so ref=0.5 with Less gives
   // [ (0,1)=0.9 -> 1, (1,1)=0.1 -> 0, (1,0)=0.1 -> 0, (0,0)=0.9 -> 1 ].
   // The faces in between are a uniform 0.5, so straying over a face edge
   // would not produce this pattern.
-  Out[10] = CUBE_OR(TexCube.GatherCmp(Samp, float3(0, 0, -1), 0.5),
-                    float4(1, 0, 0, 1));
+  Out[10] = TexCube.GatherCmp(Samp, float3(0, 0, -1), 0.5);
 }
 
 //--- pipeline.yaml
@@ -190,6 +182,5 @@ Results:
 # XFAIL: Metal
 
 # RUN: split-file %s %t
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T cs_6_0 %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Load.test
+++ b/test/Feature/Textures/Load.test
@@ -3,12 +3,6 @@
 [[vk::binding(1, 0)]] RWBuffer<float4> Out : register(u0);
 [[vk::binding(2, 0)]] RWTexture2D<float4> RWTex : register(u1);
 
-#ifndef NO_RWTEXTURE_LOAD
-#define RW_LOAD_OR(Call, Expect) (Call)
-#else
-#define RW_LOAD_OR(Call, Expect) (Expect)
-#endif
-
 [numthreads(1, 1, 1)]
 void main() {
   // Explicit Load(int3)
@@ -30,8 +24,8 @@ void main() {
 
   // RWTexture2D::Load takes an int2, not the int3 the SRV form takes: a UAV
   // has a single mip level, so there is no mip component to supply.
-  Out[7] = RW_LOAD_OR(RWTex.Load(int2(0, 0)), float4(0, 1, 1, 1));       // Cyan
-  Out[8] = RW_LOAD_OR(RWTex.Load(int2(1, 1)), float4(0.5, 0.5, 0.5, 1)); // Grey
+  Out[7] = RWTex.Load(int2(0, 0)); // Cyan
+  Out[8] = RWTex.Load(int2(1, 1)); // Grey
 }
 
 //--- pipeline.yaml
@@ -102,7 +96,5 @@ Results:
 
 
 # RUN: split-file %s %t
-# Clang does not implement Load() on RW texture types yet, so those checks
-# compile out there: https://github.com/llvm/llvm-project/issues/218535
-# RUN: %dxc_target -T cs_6_0 %if Clang %{ -DNO_RWTEXTURE_LOAD %} -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Sample.test
+++ b/test/Feature/Textures/Sample.test
@@ -18,12 +18,7 @@ VSOutput mainVS(VSInput input) {
 [[vk::binding(1, 0)]] SamplerState Samp0 : register(s0); // Mag=Nearest, Min=Linear
 [[vk::binding(2, 0)]] SamplerState Samp1 : register(s1); // Mag=Linear, Min=Nearest
 [[vk::binding(3, 0)]] RWBuffer<float4> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(4, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // Base UV at texture center (0.5, 0.5).
@@ -67,18 +62,14 @@ float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // overload for a cube, but the clamp overload does exist.
   float3 CubeMag = float3(1, 0, 0) + float3(offset * 0.0001, 0);
   float3 CubeMin = float3(1, 0, 0) + float3(offset * 2.0, 0);
-  float4 r6 = CUBE_OR(TexCube.Sample(Samp1, CubeMag),
-                       float4(1, 0, 0, 1));
-  float4 r7 = CUBE_OR(TexCube.Sample(Samp1, CubeMin),
-                       float4(1, 1, 0, 1));
+  float4 r6 = TexCube.Sample(Samp1, CubeMag);
+  float4 r7 = TexCube.Sample(Samp1, CubeMin);
 
   float3 CubeMagZ = float3(0, 0, -1) + float3(offset * 0.0001, 0);
-  float4 r8 = CUBE_OR(TexCube.Sample(Samp1, CubeMagZ),
-                       float4(0, 0, 1, 1));
+  float4 r8 = TexCube.Sample(Samp1, CubeMagZ);
 
   // Sample with an LOD clamp; 0.0 leaves it at mip 0.
-  float4 r9 = CUBE_OR(TexCube.Sample(Samp1, CubeMag, 0.0f),
-                       float4(1, 0, 0, 1));
+  float4 r9 = TexCube.Sample(Samp1, CubeMag, 0.0f);
 
   if (all(GTid.xy == 0)) {
     Out[0] = r0;
@@ -239,6 +230,5 @@ Results:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T ps_6_0 -E mainPS %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t-ps.o %t/pixel.hlsl
+# RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-vs.o %t-ps.o

--- a/test/Feature/Textures/SampleBias.test
+++ b/test/Feature/Textures/SampleBias.test
@@ -18,12 +18,7 @@ VSOutput mainVS(VSInput input) {
 [[vk::binding(1, 0)]] SamplerState Samp : register(s0); // Mag=Nearest, Min=Linear
 [[vk::binding(3, 0)]] SamplerState Samp2 : register(s1); // Mag=Linear, Min=Nearest
 [[vk::binding(2, 0)]] RWBuffer<float4> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(4, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // Setup UVs to have a derivative of exactly 0.5.
@@ -61,25 +56,21 @@ float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   float3 CubeDir = float3(1, 0, 0) + float3(float2(GTid.xy) * 0.5, 0);
 
   // Large positive bias drives the LOD to the coarsest mip -> Yellow.
-  float4 r6 = CUBE_OR(TexCube.SampleBias(Samp, CubeDir, 4.0),
-                       float4(1, 1, 0, 1));
+  float4 r6 = TexCube.SampleBias(Samp, CubeDir, 4.0);
 
   // Negative bias keeps it at mip 0 -> Red.
-  float4 r7 = CUBE_OR(TexCube.SampleBias(Samp, CubeDir, -4.0),
-                       float4(1, 0, 0, 1));
+  float4 r7 = TexCube.SampleBias(Samp, CubeDir, -4.0);
 
   // The Clamp argument is a *minimum* LOD, as the 2D case above shows: a
   // negative bias that would select mip 0 is raised back to mip 1 by a clamp
   // of 1.0 -> Yellow. Contrast with r7, which is the same bias unclamped.
-  float4 r8 = CUBE_OR(TexCube.SampleBias(Samp, CubeDir, -4.0, 1.0),
-                       float4(1, 1, 0, 1));
+  float4 r8 = TexCube.SampleBias(Samp, CubeDir, -4.0, 1.0);
 
   // A second face, to show each face has its own mip chain: -Z is Blue at mip
   // 0 and Green at mip 1, so a coarse LOD here must give Green rather than
   // +X's Yellow.
   float3 CubeDirNegZ = float3(float2(GTid.xy) * 0.5, -1);
-  float4 r9 = CUBE_OR(TexCube.SampleBias(Samp, CubeDirNegZ, 4.0),
-                       float4(0, 1, 0, 1));
+  float4 r9 = TexCube.SampleBias(Samp, CubeDirNegZ, 4.0);
 
   if (all(GTid.xy == 0)) {
     Out[0] = r0;
@@ -241,6 +232,5 @@ Results:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T ps_6_0 -E mainPS %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t-ps.o %t/pixel.hlsl
+# RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-vs.o %t-ps.o

--- a/test/Feature/Textures/SampleCmp.test
+++ b/test/Feature/Textures/SampleCmp.test
@@ -18,12 +18,7 @@ VSOutput mainVS(VSInput input) {
 [[vk::binding(1, 0)]] SamplerComparisonState Samp : register(s0); // Less
 [[vk::binding(3, 0)]] SamplerComparisonState SampGreater : register(s1); // Greater
 [[vk::binding(2, 0)]] RWBuffer<float> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(4, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // TODO: Add extra testing when we add multiple mip levels.
@@ -89,18 +84,14 @@ float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // 0.2/0.8 values as the 2D texture above, so Less against 0.5 blends
   // (0+1+0+1)/4 = 0.5 exactly as the 2D case does. Face -Z is a uniform 0.9,
   // where every texel passes -> 1.0, so the face really is being selected.
-  float r13 = CUBE_OR(TexCube.SampleCmp(Samp, float3(1, 0, 0), 0.5),
-                       0.5);
-  float r14 = CUBE_OR(TexCube.SampleCmp(Samp, float3(0, 0, -1), 0.5),
-                       1.0);
+  float r13 = TexCube.SampleCmp(Samp, float3(1, 0, 0), 0.5);
+  float r14 = TexCube.SampleCmp(Samp, float3(0, 0, -1), 0.5);
 
   // Greater against the uniform 0.9 face fails everywhere -> 0.0.
-  float r15 = CUBE_OR(TexCube.SampleCmp(SampGreater, float3(0, 0, -1), 0.5),
-                       0.0);
+  float r15 = TexCube.SampleCmp(SampGreater, float3(0, 0, -1), 0.5);
 
   // SampleCmpLevelZero forces mip 0 rather than deriving an LOD.
-  float r16 = CUBE_OR(TexCube.SampleCmpLevelZero(Samp, float3(1, 0, 0), 0.5),
-                       0.5);
+  float r16 = TexCube.SampleCmpLevelZero(Samp, float3(1, 0, 0), 0.5);
 
   if (all((int2)Pos.xy == 0)) {
     Out[0] = r0;
@@ -251,6 +242,5 @@ Results:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T ps_6_0 -E mainPS %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t-ps.o %t/pixel.hlsl
+# RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-vs.o %t-ps.o

--- a/test/Feature/Textures/SampleGrad.test
+++ b/test/Feature/Textures/SampleGrad.test
@@ -3,12 +3,7 @@
 [[vk::binding(1, 0)]] SamplerState Samp0 : register(s0); // Mag=Nearest, Min=Linear
 [[vk::binding(2, 0)]] SamplerState Samp1 : register(s1); // Mag=Linear, Min=Nearest
 [[vk::binding(3, 0)]] RWBuffer<float4> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(4, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 [numthreads(1, 1, 1)]
 void main() {
@@ -48,15 +43,11 @@ void main() {
 
   // Face +X is Red at mip 0 and Yellow at mip 1; face -Z is Blue then Green.
   // Each face carries its own mip chain, so minification on one face must not
-  // reach into another's.
-  Out[5] = CUBE_OR(TexCube.SampleGrad(Samp0, float3(1, 0, 0), CubeDDXMag, CubeDDYMag),
-                   float4(1, 0, 0, 1)); // mip 0 Red
-  Out[6] = CUBE_OR(TexCube.SampleGrad(Samp0, float3(1, 0, 0), CubeDDXMin, CubeDDYMin),
-                   float4(1, 1, 0, 1)); // mip 1 Yellow
-  Out[7] = CUBE_OR(TexCube.SampleGrad(Samp0, float3(0, 0, -1), CubeDDXMag, CubeDDYMag),
-                   float4(0, 0, 1, 1)); // mip 0 Blue
-  Out[8] = CUBE_OR(TexCube.SampleGrad(Samp0, float3(0, 0, -1), CubeDDXMin, CubeDDYMin),
-                   float4(0, 1, 0, 1)); // mip 1 Green
+  // reach into another's. The Mag gradients select mip 0, the Min ones mip 1.
+  Out[5] = TexCube.SampleGrad(Samp0, float3(1, 0, 0), CubeDDXMag, CubeDDYMag);
+  Out[6] = TexCube.SampleGrad(Samp0, float3(1, 0, 0), CubeDDXMin, CubeDDYMin);
+  Out[7] = TexCube.SampleGrad(Samp0, float3(0, 0, -1), CubeDDXMag, CubeDDYMag);
+  Out[8] = TexCube.SampleGrad(Samp0, float3(0, 0, -1), CubeDDXMin, CubeDDYMin);
 }
 
 //--- pipeline.yaml
@@ -171,6 +162,5 @@ Results:
 # XFAIL: Metal
 
 # RUN: split-file %s %t
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T cs_6_0 %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t.o %t/source.hlsl
+# RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/Textures/Sampler.filter.test
+++ b/test/Feature/Textures/Sampler.filter.test
@@ -18,12 +18,7 @@ VSOutput mainVS(VSInput input) {
 [[vk::binding(1, 0)]] SamplerState LinearSamp : register(s0);
 [[vk::binding(2, 0)]] SamplerState PointSamp : register(s1);
 [[vk::binding(3, 0)]] RWBuffer<float4> Out : register(u0);
-#ifndef NO_TEXTURECUBE
 [[vk::binding(4, 0)]] TextureCube<float4> TexCube : register(t1);
-#define CUBE_OR(Call, Expect) (Call)
-#else
-#define CUBE_OR(Call, Expect) (Expect)
-#endif
 
 float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // 2x2 Texture:
@@ -46,18 +41,12 @@ float4 mainPS(float4 Pos : SV_POSITION) : SV_Target {
   // uniform colour, which isolates the face ordering from any in-face
   // addressing convention -- and means a Linear filter cannot blend a face
   // into a different result.
-  float4 r2 = CUBE_OR(TexCube.SampleLevel(LinearSamp, float3( 1,  0,  0), 0),
-                       float4(1, 0, 0, 1)); // +X Red
-  float4 r3 = CUBE_OR(TexCube.SampleLevel(LinearSamp, float3(-1,  0,  0), 0),
-                       float4(0, 1, 0, 1)); // -X Green
-  float4 r4 = CUBE_OR(TexCube.SampleLevel(LinearSamp, float3( 0,  1,  0), 0),
-                       float4(0, 0, 1, 1)); // +Y Blue
-  float4 r5 = CUBE_OR(TexCube.SampleLevel(LinearSamp, float3( 0, -1,  0), 0),
-                       float4(1, 1, 0, 1)); // -Y Yellow
-  float4 r6 = CUBE_OR(TexCube.SampleLevel(LinearSamp, float3( 0,  0,  1), 0),
-                       float4(1, 0, 1, 1)); // +Z Magenta
-  float4 r7 = CUBE_OR(TexCube.SampleLevel(LinearSamp, float3( 0,  0, -1), 0),
-                       float4(0, 1, 1, 1)); // -Z Cyan
+  float4 r2 = TexCube.SampleLevel(LinearSamp, float3( 1,  0,  0), 0); // +X Red
+  float4 r3 = TexCube.SampleLevel(LinearSamp, float3(-1,  0,  0), 0); // -X Green
+  float4 r4 = TexCube.SampleLevel(LinearSamp, float3( 0,  1,  0), 0); // +Y Blue
+  float4 r5 = TexCube.SampleLevel(LinearSamp, float3( 0, -1,  0), 0); // -Y Yellow
+  float4 r6 = TexCube.SampleLevel(LinearSamp, float3( 0,  0,  1), 0); // +Z Magenta
+  float4 r7 = TexCube.SampleLevel(LinearSamp, float3( 0,  0, -1), 0); // -Z Cyan
 
   if (all((int2)Pos.xy == 0)) {
     Out[0] = r0;
@@ -207,6 +196,5 @@ Results:
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T vs_6_0 -E mainVS -Fo %t-vs.o %t/vertex.hlsl
-# Clang does not implement TextureCube yet: https://github.com/llvm/llvm-project/issues/194740
-# RUN: %dxc_target -T ps_6_0 -E mainPS %if Clang %{ -DNO_TEXTURECUBE %} -Fo %t-ps.o %t/pixel.hlsl
+# RUN: %dxc_target -T ps_6_0 -E mainPS -Fo %t-ps.o %t/pixel.hlsl
 # RUN: %offloader %t/pipeline.yaml %t-vs.o %t-ps.o


### PR DESCRIPTION
The following issues are fixed so their corresponding tests can now be enabled for Clang
- https://github.com/llvm/llvm-project/issues/218535
- https://github.com/llvm/llvm-project/issues/194740