### PR TITLE
Remove Clang XFAILs from `max` and `min` matrix tests

### DIFF
--- a/test/Feature/HLSLLib/max_mat.fp.test
+++ b/test/Feature/HLSLLib/max_mat.fp.test
@@ -107,9 +107,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184511
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/max_mat.int.test
+++ b/test/Feature/HLSLLib/max_mat.int.test
@@ -106,9 +106,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184511
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/max_mat.uint.test
+++ b/test/Feature/HLSLLib/max_mat.uint.test
@@ -106,9 +106,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184511
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/min_mat.fp.test
+++ b/test/Feature/HLSLLib/min_mat.fp.test
@@ -107,9 +107,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184512
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/min_mat.int.test
+++ b/test/Feature/HLSLLib/min_mat.int.test
@@ -106,9 +106,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184512
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/min_mat.uint.test
+++ b/test/Feature/HLSLLib/min_mat.uint.test
@@ -106,9 +106,6 @@ DescriptorSets:
         Binding: 2
 #--- end
 
-# Unimplemented https://github.com/llvm/llvm-project/issues/184512
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The `max` and `min` matrix implementations have been merged, so these now pass.