### PR TITLE
[Clang][VK] Enable abs long vectors

### DIFF
--- a/test/Feature/HLSLLib/abs.long-vector.32.test
+++ b/test/Feature/HLSLLib/abs.long-vector.32.test
@@ -75,7 +75,7 @@ DescriptorSets:
 #--- end
 
 # Unimplemented https://github.com/llvm/wg-hlsl/issues/467
-# XFAIL: Vulkan
+# XFAIL: Vulkan && DXC
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T %if Clang %{cs_6_0%} %else %{cs_6_9%} -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
The SPIR-V backend recently turned on SPV_EXT_long_vector. So it seems like some, but not all HLSL intrinsics are just working for spir-v with no required changes by us.