### PR TITLE
[VK] Enable trig tests

### DIFF
--- a/test/Feature/HLSLLib/cos.nan-inf-denorm.32.test
+++ b/test/Feature/HLSLLib/cos.nan-inf-denorm.32.test
@@ -58,8 +58,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && MoltenVK
+# Bug https://github.com/llvm/llvm-project/issues/156069
+# XFAIL: MoltenVK && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/701
 # XFAIL: Metal && !AppleM1 && !AppleM2 && Clang

--- a/test/Feature/HLSLLib/sin.nan-inf-denorm.32.test
+++ b/test/Feature/HLSLLib/sin.nan-inf-denorm.32.test
@@ -58,8 +58,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug https://github.com/KhronosGroup/SPIRV-Cross/issues/2525
-# XFAIL: Vulkan && MoltenVK
+# Bug https://github.com/llvm/llvm-project/issues/156069
+# XFAIL: MoltenVK && Clang
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/701
 # XFAIL: Metal && !AppleM1 && !AppleM2 && Clang


### PR DESCRIPTION
This SPIRV-CROSS issue is now resolved. If you ugrade to the latest Vulkan SDK these two tests now pass on MoltenVK.

https://github.com/KhronosGroup/SPIRV-Cross/issues/2525