### PR TITLE
Add HLSL memory barrier smoke tests

### DIFF
--- a/test/Feature/HLSLLib/AllMemoryBarrier.test
+++ b/test/Feature/HLSLLib/AllMemoryBarrier.test
@@ -1,0 +1,68 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+groupshared uint GroupPayload;
+
+// This is a compile-and-run smoke test. Full validation of memory-ordering
+// behavior is out of scope because this barrier does not synchronize threads.
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0) {
+    GroupPayload = 0x12345678u;
+    Data[0] = 0x87654321u;
+  }
+
+  AllMemoryBarrier();
+
+  if (GTID.x == 0)
+    Out[0] = GroupPayload == 0x12345678u && Data[0] == 0x87654321u ? 1u
+                                                                   : 0u;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: AllMemoryBarrier
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/DeviceMemoryBarrier.test
+++ b/test/Feature/HLSLLib/DeviceMemoryBarrier.test
@@ -1,0 +1,63 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+// This is a compile-and-run smoke test. Full validation of memory-ordering
+// behavior is out of scope because this barrier does not synchronize threads.
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0)
+    Data[0] = 0x12345678u;
+
+  DeviceMemoryBarrier();
+
+  if (GTID.x == 0)
+    Out[0] = Data[0] == 0x12345678u ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: DeviceMemoryBarrier
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/GroupMemoryBarrier.test
+++ b/test/Feature/HLSLLib/GroupMemoryBarrier.test
@@ -1,0 +1,53 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Out : register(u0);
+
+groupshared uint Payload;
+
+// This is a compile-and-run smoke test. Full validation of memory-ordering
+// behavior is out of scope because this barrier does not synchronize threads.
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 0)
+    Payload = 0x12345678u;
+
+  GroupMemoryBarrier();
+
+  if (GTID.x == 0)
+    Out[0] = Payload == 0x12345678u ? 1u : 0u;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: GroupMemoryBarrier
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Add compile-and-run tests for GroupMemoryBarrier, DeviceMemoryBarrier, and AllMemoryBarrier. These barriers order memory but do not synchronize threads, so the tests verify that shaders containing each intrinsic compile and execute.

Fixes #829 
Fixes #833 
Fixes #844 
