### PR TITLE
Update passing InterlockedXYZ tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedAdd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.32.test
@@ -188,9 +188,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1435
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/HLSLLib/InterlockedAdd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.int64.test
@@ -197,14 +197,8 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
-
-# Bug: https://github.com/llvm/offload-test-suite/issues/1402
-# XFAIL: Clang && DirectX
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1435
 # XFAIL: Clang && Vulkan

--- a/test/Feature/HLSLLib/InterlockedAdd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.resources.32.test
@@ -266,7 +266,7 @@ DescriptorSets:
 # Unimplemented texture atomics: https://github.com/llvm/llvm-project/issues/186154
 # XFAIL: Clang && (DirectX || Metal)
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1435
+# Bug: https://github.com/llvm/llvm-project/issues/221370
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedAdd.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.resources.int64.test
@@ -222,7 +222,7 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
 # UNSUPPORTED: WARP && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1435
+# TODO: Bug: Unsupported ptrcast user. Please fix.
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedAdd.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.resources.int64.test
@@ -222,7 +222,7 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
 # UNSUPPORTED: WARP && DXC
 
-# TODO: Bug: Unsupported ptrcast user. Please fix.
+# Bug: https://github.com/llvm/llvm-project/issues/221370
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedAdd.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.resources.typed.int64.test
@@ -165,7 +165,7 @@ DescriptorSets:
 # Bug: https://github.com/llvm/offload-test-suite/issues/1418
 # UNSUPPORTED: WARP && DXC
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1435
+# Bug: https://github.com/llvm/llvm-project/issues/221366
 # XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedAnd.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.32.test
@@ -123,9 +123,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedAnd.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.int64.test
@@ -128,9 +128,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
-# XFAIL: Clang
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
@@ -220,8 +220,11 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
-# XFAIL: Clang
+# Unimplemented texture atomics: https://github.com/llvm/llvm-project/issues/186154
+# XFAIL: Clang && (DirectX || Metal)
+
+# Bug: https://github.com/llvm/llvm-project/issues/221370
+# XFAIL: Clang && Vulkan
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
@@ -173,7 +173,7 @@ DescriptorSets:
 # XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
+# XFAIL: Metal
 
 # Unimplemented: https://github.com/microsoft/DirectXShaderCompiler/issues/8451
 # XFAIL: Vulkan && DXC

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.int64.test
@@ -169,8 +169,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
-# XFAIL: Clang
+# Bug: https://github.com/llvm/llvm-project/issues/221370
+# XFAIL: Clang && Vulkan
 
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.typed.int64.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.typed.int64.test
@@ -129,8 +129,8 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/99125
-# XFAIL: Clang
+# Bug: https://github.com/llvm/llvm-project/issues/221366
+# XFAIL: Clang && Vulkan
 
 # REQUIRES: Int64TypedResourceAtomics && SM_6_6
 # RUN: split-file %s %t

--- a/test/Feature/HLSLLib/InterlockedExchange.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedExchange.resources.32.test
@@ -307,9 +307,6 @@ DescriptorSets:
 # Unimplemented: https://github.com/llvm/llvm-project/issues/99129
 # XFAIL: Clang
 
-# Bug: https://github.com/llvm/offload-test-suite/issues/1164
-# XFAIL: Metal && DXC
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_6 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.32.test
@@ -181,9 +181,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedMin.int64.test
+++ b/test/Feature/HLSLLib/InterlockedMin.int64.test
@@ -168,9 +168,6 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal
 

--- a/test/Feature/HLSLLib/InterlockedOr.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.32.test
@@ -122,9 +122,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedOr.int64.test
+++ b/test/Feature/HLSLLib/InterlockedOr.int64.test
@@ -127,9 +127,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: Metal && DXC
 

--- a/test/Feature/HLSLLib/InterlockedXor.32.test
+++ b/test/Feature/HLSLLib/InterlockedXor.32.test
@@ -194,9 +194,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedXor.int64.test
+++ b/test/Feature/HLSLLib/InterlockedXor.int64.test
@@ -171,9 +171,6 @@ DescriptorSets:
 
 # REQUIRES: Int64 && Int64GroupSharedAtomics && SM_6_6
 
-# Bug: https://github.com/llvm/llvm-project/issues/217196
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/offload-test-suite/issues/1164
 # XFAIL: DXC && Metal
 


### PR DESCRIPTION
These are generally passing given the following changes:
- PR llvm/llvm-project#219277, fixing llvm/llvm-project#217196
- PR llvm/llvm-project#219317, fixing llvm/llvm-project#99125

There are two new issues that are still causing some of these to fail:
- llvm/llvm-project#221366 - an issue with TypedBuffer
- llvm/llvm-project#221370 - an issue with ByteAddressBuffer

Finally, the `InterlockedExchange.resources.32` test looks like it was erroneously marked XFAIL on Metal - it has never failed.