### PR TITLE
Add Barrier() tests

### DIFF
--- a/test/Feature/HLSLLib/Barrier-AllMemorySync.test
+++ b/test/Feature/HLSLLib/Barrier-AllMemorySync.test
@@ -1,0 +1,77 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 255)
+    Data[0] = 1u;
+
+  Barrier(ALL_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+
+  if (GTID.x == 0)
+    Out[0] = Data[0];
+
+  Barrier(ALL_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+
+  for (uint I = 0; I < 256; ++I) {
+    if (GTID.x == I)
+      Data[0] = Data[0] + 1u;
+
+    Barrier(ALL_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+  }
+
+  if (GTID.x == 128)
+    Out[1] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 257 ]
+Results:
+  - Result: BarrierAllMemorySync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-CombinedMemorySync.test
+++ b/test/Feature/HLSLLib/Barrier-CombinedMemorySync.test
@@ -1,0 +1,90 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> DeviceData : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+groupshared uint GroupData;
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 255) {
+    DeviceData[0] = 1u;
+    GroupData = 1u;
+  }
+
+  Barrier(UAV_MEMORY | GROUP_SHARED_MEMORY,
+          DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+
+  if (GTID.x == 0) {
+    Out[0] = DeviceData[0];
+    Out[1] = GroupData;
+  }
+
+  Barrier(UAV_MEMORY | GROUP_SHARED_MEMORY,
+          DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+
+  for (uint I = 0; I < 256; ++I) {
+    if (GTID.x == I) {
+      DeviceData[0] = DeviceData[0] + 1u;
+      GroupData = GroupData + 1u;
+    }
+
+    Barrier(UAV_MEMORY | GROUP_SHARED_MEMORY,
+            DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+  }
+
+  if (GTID.x == 128) {
+    Out[2] = DeviceData[0];
+    Out[3] = GroupData;
+  }
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: DeviceData
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 16
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 1, 257, 257 ]
+Results:
+  - Result: BarrierCombinedMemorySync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: DeviceData
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-ExecutionOnly.test
+++ b/test/Feature/HLSLLib/Barrier-ExecutionOnly.test
@@ -1,0 +1,53 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Out : register(u0);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  Barrier(0, GROUP_SYNC);
+
+  if (GTID.x == 0)
+    Out[0] = 1u;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: BarrierExecutionOnly
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# FIXME(DXC-SPIRV-BARRIER): Replace with the DXC issue URL.
+# DXC SPIR-V validation failure: https://godbolt.org/z/qKn9rKcnY
+# XFAIL: DXC && Vulkan
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-GroupSharedGroupSync.test
+++ b/test/Feature/HLSLLib/Barrier-GroupSharedGroupSync.test
@@ -1,0 +1,67 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Out : register(u0);
+
+groupshared uint Data;
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 255)
+    Data = 1u;
+
+  Barrier(GROUP_SHARED_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+
+  if (GTID.x == 0)
+    Out[0] = Data;
+
+  Barrier(GROUP_SHARED_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+
+  for (uint I = 0; I < 256; ++I) {
+    if (GTID.x == I)
+      Data = Data + 1u;
+
+    Barrier(GROUP_SHARED_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+  }
+
+  if (GTID.x == 128)
+    Out[1] = Data;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 257 ]
+Results:
+  - Result: BarrierGroupSharedGroupSync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-GroupSharedNoScope.test
+++ b/test/Feature/HLSLLib/Barrier-GroupSharedNoScope.test
@@ -1,0 +1,56 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Out : register(u0);
+
+groupshared uint Data;
+
+// This is a compile-and-run smoke test. Full memory-order validation is out
+// of scope because this barrier does not synchronize threads.
+[numthreads(1, 1, 1)]
+void main() {
+  Data = 1u;
+  Barrier(GROUP_SHARED_MEMORY, 0);
+  Out[0] = Data;
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: BarrierGroupSharedNoScope
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+...
+#--- end
+
+# FIXME(DXC-SPIRV-BARRIER): Replace with the DXC issue URL.
+# DXC SPIR-V validation failure: https://godbolt.org/z/6zxnbPzsr
+# XFAIL: DXC && Vulkan
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-NonSyncMemory.test
+++ b/test/Feature/HLSLLib/Barrier-NonSyncMemory.test
@@ -1,0 +1,67 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+// These are compile-and-run smoke tests. Full memory-order validation is out
+// of scope because these barriers do not synchronize threads.
+[numthreads(1, 1, 1)]
+void main() {
+  Data[0] = 1u;
+  Barrier(UAV_MEMORY, GROUP_SCOPE);
+  Out[0] = Data[0];
+
+  Data[0] = 2u;
+  Barrier(UAV_MEMORY, DEVICE_SCOPE);
+  Out[1] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 2 ]
+Results:
+  - Result: BarrierNonSyncMemory
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-ResourceDeviceSync.test
+++ b/test/Feature/HLSLLib/Barrier-ResourceDeviceSync.test
@@ -1,0 +1,79 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 255)
+    Data[0] = 1u;
+
+  // One group cannot distinguish device scope from group scope, but the
+  // ordered writers make the synchronization behavior observable.
+  Barrier(Data, DEVICE_SCOPE | GROUP_SYNC);
+
+  if (GTID.x == 0)
+    Out[0] = Data[0];
+
+  Barrier(Data, DEVICE_SCOPE | GROUP_SYNC);
+
+  for (uint I = 0; I < 256; ++I) {
+    if (GTID.x == I)
+      Data[0] = Data[0] + 1u;
+
+    Barrier(Data, DEVICE_SCOPE | GROUP_SYNC);
+  }
+
+  if (GTID.x == 128)
+    Out[1] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 257 ]
+Results:
+  - Result: BarrierResourceDeviceSync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-ResourceNoScope.test
+++ b/test/Feature/HLSLLib/Barrier-ResourceNoScope.test
@@ -1,0 +1,66 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+// This is a compile-and-run smoke test. Full memory-order validation is out
+// of scope because this barrier does not synchronize threads.
+[numthreads(1, 1, 1)]
+void main() {
+  Data[0] = 1u;
+  Barrier(Data, 0);
+  Out[0] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: BarrierResourceNoScope
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# FIXME(DXC-SPIRV-BARRIER): Replace with the DXC issue URL.
+# DXC SPIR-V validation failure: https://godbolt.org/z/MPbG3s45G
+# XFAIL: DXC && Vulkan
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-ResourceNonSync.test
+++ b/test/Feature/HLSLLib/Barrier-ResourceNonSync.test
@@ -1,0 +1,63 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+// This is a compile-and-run smoke test. Full memory-order validation is out
+// of scope because this barrier does not synchronize threads.
+[numthreads(1, 1, 1)]
+void main() {
+  Data[0] = 1u;
+  Barrier(Data, DEVICE_SCOPE);
+  Out[0] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: BarrierResourceNonSync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-UAVDeviceSync.test
+++ b/test/Feature/HLSLLib/Barrier-UAVDeviceSync.test
@@ -1,0 +1,79 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 255)
+    Data[0] = 1u;
+
+  // One group cannot distinguish device scope from group scope, but the
+  // ordered writers make the synchronization behavior observable.
+  Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+
+  if (GTID.x == 0)
+    Out[0] = Data[0];
+
+  Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+
+  for (uint I = 0; I < 256; ++I) {
+    if (GTID.x == I)
+      Data[0] = Data[0] + 1u;
+
+    Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+  }
+
+  if (GTID.x == 128)
+    Out[1] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 257 ]
+Results:
+  - Result: BarrierUAVDeviceSync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier-UAVNoScope.test
+++ b/test/Feature/HLSLLib/Barrier-UAVNoScope.test
@@ -1,0 +1,66 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+// This is a compile-and-run smoke test. Full memory-order validation is out
+// of scope because this barrier does not synchronize threads.
+[numthreads(1, 1, 1)]
+void main() {
+  Data[0] = 1u;
+  Barrier(UAV_MEMORY, 0);
+  Out[0] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 4
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1 ]
+Results:
+  - Result: BarrierUAVNoScope
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# FIXME(DXC-SPIRV-BARRIER): Replace with the DXC issue URL.
+# DXC SPIR-V validation failure: https://godbolt.org/z/sacKh4c35
+# XFAIL: DXC && Vulkan
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/Barrier.test
+++ b/test/Feature/HLSLLib/Barrier.test
@@ -1,0 +1,77 @@
+#--- source.hlsl
+
+RWStructuredBuffer<uint> Data : register(u0);
+RWStructuredBuffer<uint> Out : register(u1);
+
+[numthreads(256, 1, 1)]
+void main(uint3 GTID : SV_GroupThreadID) {
+  if (GTID.x == 255)
+    Data[0] = 1u;
+
+  Barrier(UAV_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+
+  if (GTID.x == 0)
+    Out[0] = Data[0];
+
+  Barrier(UAV_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+
+  for (uint I = 0; I < 256; ++I) {
+    if (GTID.x == I)
+      Data[0] = Data[0] + 1u;
+
+    Barrier(UAV_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+  }
+
+  if (GTID.x == 128)
+    Out[1] = Data[0];
+}
+
+//--- pipeline.yaml
+---
+Shaders:
+  - Stage: Compute
+    Entry: main
+Buffers:
+  - Name: Data
+    Format: UInt32
+    Stride: 4
+    Data: [ 0 ]
+  - Name: Out
+    Format: UInt32
+    Stride: 4
+    FillSize: 8
+  - Name: ExpectedOut
+    Format: UInt32
+    Stride: 4
+    Data: [ 1, 257 ]
+Results:
+  - Result: BarrierUAVGroupSync
+    Rule: BufferExact
+    Actual: Out
+    Expected: ExpectedOut
+DescriptorSets:
+  - Resources:
+    - Name: Data
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 0
+        Space: 0
+      VulkanBinding:
+        Binding: 0
+    - Name: Out
+      Kind: RWStructuredBuffer
+      DirectXBinding:
+        Register: 1
+        Space: 0
+      VulkanBinding:
+        Binding: 1
+...
+#--- end
+
+# Clang does not implement Barrier: https://github.com/llvm/llvm-project/issues/99234
+# XFAIL: Clang
+# REQUIRES: SM_6_8
+
+# RUN: split-file %s %t
+# RUN: %dxc_target -T cs_6_8 -Fo %t.o %t/source.hlsl
+# RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
Adds a representative selection of tests for the `Barrier()` memory-type overload.

Assisted-by: Copilot