### PR TITLE
[DX] Enable countbits16 for clang

### DIFF
--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -118,9 +118,6 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
-# Bug https://github.com/llvm/llvm-project/issues/219327
-# XFAIL: Clang && (DirectX || Metal)
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The fix for https://github.com/llvm/llvm-project/issues/219327 merged in https://github.com/llvm/llvm-project/pull/221033

This change just removes the xfail