### PR TITLE
[VK] Enable tan matrix for clang

### DIFF
--- a/test/Feature/HLSLLib/tan_mat.test
+++ b/test/Feature/HLSLLib/tan_mat.test
@@ -92,9 +92,6 @@ DescriptorSets:
         Binding: 1
 #--- end
 
-# Bug https://github.com/llvm/llvm-project/issues/220723
-# XFAIL: Clang && Vulkan
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -HV 202x -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
The fix for https://github.com/llvm/llvm-project/issues/220723 merged in https://github.com/llvm/llvm-project/pull/220782 so remove the xfail and enable the test.