### PR TITLE
[CI] Fix lavapipe SKU selection for the test-lavapipe label

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -107,7 +107,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-amd, windows-sw-rasterizer-x86_64, windows-qc]
+        # Lavapipe is only installed on the AMD (x64) and QC (arm64) boxes.
+        # See docs/CI.md.
+        SKU: [windows-amd, windows-qc]
         TestTarget: [check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
 
     uses: ./.github/workflows/build-and-test-callable.yaml

--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Lavapipe is only installed on the AMD (x64) and QC (arm64) boxes.
+        # Lavapipe is only installed on the AMD (x64) and QC (arm64) workers.
         # See docs/CI.md.
         SKU: [windows-amd, windows-qc]
         TestTarget: [check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]


### PR DESCRIPTION
The test-lavapipe matrix listed windows-sw-rasterizer-x86_64 alongside windows-amd and windows-qc, which spun up 6 jobs and duplicated x64 coverage on a SKU that has no lavapipe ICD installed.

Lavapipe is only provisioned on the AMD box (x64) and the QC box (arm64), per docs/CI.md and the post-merge windows-{amd,qc}-{dxc,clang}-lavapipe workflows. Restrict the matrix to those two SKUs so the label produces 4 jobs: 2 x64 and 2 arm64. This also matches the lavapipe SKU sets already used by Exec-Tests-Extra and Exec-Tests-Extra-VK-All.