### PR TITLE
XFAIL countbit.16 on AppleM2

### DIFF
--- a/test/Feature/HLSLLib/countbits.16.test
+++ b/test/Feature/HLSLLib/countbits.16.test
@@ -118,6 +118,9 @@ DescriptorSets:
 
 # REQUIRES: Int16
 
+# Bug: https://github.com/llvm/offload-test-suite/issues/1507
+# XFAIL: Metal && AppleM2
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -enable-16bit-types -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
This is failing in LLVM pre-checkin. Filed llvm/offload-test-suite#1507 to track.