### PR TITLE
[Clang] Disable test that exposes updatecounter phi selection

### DIFF
--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -51,6 +51,9 @@ DescriptorSets:
 # Bug https://github.com/llvm/offload-test-suite/issues/337
 # XFAIL: AMD
 
+# Bug https://github.com/llvm/llvm-project/issues/222400
+# XFAIL: Clang
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o | FileCheck %s


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/222400