### PR TITLE
The inc_counter_array XFAIL is DirectX-specific

### DIFF
--- a/test/Feature/StructuredBuffer/inc_counter_array.test
+++ b/test/Feature/StructuredBuffer/inc_counter_array.test
@@ -52,7 +52,7 @@ DescriptorSets:
 # XFAIL: AMD
 
 # Bug https://github.com/llvm/llvm-project/issues/222400
-# XFAIL: Clang
+# XFAIL: Clang && DirectX
 
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_0 -Fo %t.o %t/source.hlsl


### PR DESCRIPTION
The issue in llvm/llvm-project#222400 is DirectX specific, so this XFAIL should be. This should fix the XPASS on the various Vulkan bots.