### PR TITLE
Use values with smaller error for tan.16

### DIFF
--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -42,7 +42,7 @@ Buffers:
             0x0000, 0xBEEC, 0x3EEC, 0xc05f ]
     # -sqrt(3), -1, -1/sqrt(3), sqrt(3)-2
     # 2-sqrt(3), 1/sqrt(3), 1, sqrt(3)
-    # 0, tan(pi) == 0, tan(355.0) == 0, tan(2.0) ~= -2.185
+    # 0, tan(pi) == 0, tan(355.0) ~= 0.000, tan(2.0) ~= -2.185
     # 0, -sqrt(3), sqrt(3), tan(2.0) ~= -2.185
 Results:
   - Result: Test1

--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -41,8 +41,8 @@ Buffers:
             0x0000, 0xBEEC, 0x3EEC, 0xc05f ]
     # -sqrt(3), -1, -1/sqrt(3), sqrt(3)-2
     # 2-sqrt(3), 1/sqrt(3), 1, sqrt(3)
-    # 0, tan(-100pi), tan(100), tan(100pi)
-    # 0, -sqrt(3), sqrt(3), tan(2.0)
+    # 0, tan(pi) == 0, tan(355.0) == 0, tan(2.0) == 0
+    # 0, -sqrt(3), sqrt(3), tan(2.0) == 0
 Results:
   - Result: Test1
     Rule: BufferFloatEpsilon

--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -9,7 +9,7 @@ void main() {
   Out[0] = tan(In[0]);
   Out[1] = half4(tan(In[1].xyz), tan(In[1].w));
   Out[2] = half4(tan(In[2].xy), tan(In[2].zw));
-  Out[3] = tan(half4(0, -1.04719755, 1.04719755, 100)); // 0, -pi/3, pi/3, 100
+  Out[3] = tan(half4(0., -1.04719755, 1.04719755, 2.)); // 0, -pi/3, pi/3, 2.0
 }
 
 //--- pipeline.yaml
@@ -24,10 +24,10 @@ Buffers:
     Stride: 8
     Data: [ 0xBC30, 0xBA48, 0xB830, 0xB430,
             0x3430, 0x3830, 0x3A48, 0x3C30,
-            0x0000, 0xDCE9, 0x5640, 0x5CE9 ]
+            0x0000, 0x4248, 0x5D8C, 0x4000 ]
     # -pi/3, -pi/4, -pi/6, -pi/12
     # pi/12, pi/6, pi/4, pi/3
-    # 0, -100pi, 100, 100pi
+    # 0, pi (rounded 3.140625), 113pi (rounded 355.0), 2.0
   - Name: Out
     Format: Float16
     Stride: 8
@@ -37,8 +37,8 @@ Buffers:
     Stride: 8
     Data: [ 0xBEEC, 0xBBFF, 0xB89E, 0xB449,
             0x3449, 0x389E, 0x3BFF, 0x3EEC,
-            0x0000, 0xADD3, 0xB8B3, 0x2DD3,
-            0x0000, 0xBEEC, 0x3EEC, 0xB8B3 ]
+            0x0000, 0x0000, 0x0000, 0xc05f,
+            0x0000, 0xBEEC, 0x3EEC, 0xc05f ]
     # -sqrt(3), -1, -1/sqrt(3), sqrt(3)-2
     # 2-sqrt(3), 1/sqrt(3), 1, sqrt(3)
     # 0, tan(-100pi), tan(100), tan(100pi)

--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -9,7 +9,8 @@ void main() {
   Out[0] = tan(In[0]);
   Out[1] = half4(tan(In[1].xyz), tan(In[1].w));
   Out[2] = half4(tan(In[2].xy), tan(In[2].zw));
-  Out[3] = tan(half4(0., -1.04719755, 1.04719755, 2.)); // 0, -pi/3, pi/3, 2.0
+  // 0.0, -pi/3, pi/3, 2.0
+  Out[3] = tan(half4(0.0h, -1.04719755h, 1.04719755h, 2.0h));
 }
 
 //--- pipeline.yaml

--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -46,8 +46,9 @@ Buffers:
     # 0, -sqrt(3), sqrt(3), tan(2.0) ~= -2.185
 Results:
   - Result: Test1
-    Rule: BufferFloatEpsilon
-    Epsilon: 0.003
+    Rule: BufferFloatULP
+    ULPT: 2
+    ZeroTolerance: 0.001
     Actual: Out
     Expected: ExpectedOut
 DescriptorSets:

--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -42,8 +42,8 @@ Buffers:
             0x0000, 0xBEEC, 0x3EEC, 0xc05f ]
     # -sqrt(3), -1, -1/sqrt(3), sqrt(3)-2
     # 2-sqrt(3), 1/sqrt(3), 1, sqrt(3)
-    # 0, tan(pi) == 0, tan(355.0) == 0, tan(2.0) == 0
-    # 0, -sqrt(3), sqrt(3), tan(2.0) == 0
+    # 0, tan(pi) == 0, tan(355.0) == 0, tan(2.0) ~= -2.185
+    # 0, -sqrt(3), sqrt(3), tan(2.0) ~= -2.185
 Results:
   - Result: Test1
     Rule: BufferFloatEpsilon

--- a/test/Feature/HLSLLib/tan.16.test
+++ b/test/Feature/HLSLLib/tan.16.test
@@ -42,7 +42,7 @@ Buffers:
     # -sqrt(3), -1, -1/sqrt(3), sqrt(3)-2
     # 2-sqrt(3), 1/sqrt(3), 1, sqrt(3)
     # 0, tan(-100pi), tan(100), tan(100pi)
-    # 0, -sqrt(3), sqrt(3), tan(100)
+    # 0, -sqrt(3), sqrt(3), tan(2.0)
 Results:
   - Result: Test1
     Rule: BufferFloatEpsilon


### PR DESCRIPTION
A few of the values here were a bit too likely to differ across APIs and hardware.

- In practice I would expect most uses of tan (especially in half precision) to be on inputs between -2pi and 2pi, and values like 100.0h that are 10pi or more could easily hit a lot of intermediate rounding.
- The 100pi input here is pretty far off from being representable in half (0x5ce9 is 314.25), so we're just testing another arbitrary value here that is also susceptible to rounding errors. Using the well-known 355/113 approximation of pi we can test something that's more likely to be consistent.
- We didn't have a test for pi itself, which seems pretty useful.
- An arbitrary number in the likely range is also a good idea, so I added cases for 2.0h.