### PR TITLE
Update xfails for texture-related interlocked tests

### DIFF
--- a/test/Feature/HLSLLib/InterlockedAdd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAdd.resources.32.test
@@ -263,9 +263,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented texture atomics: https://github.com/llvm/llvm-project/issues/186154
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/llvm-project/issues/221370
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedAnd.resources.32.test
@@ -220,9 +220,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented texture atomics: https://github.com/llvm/llvm-project/issues/186154
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/llvm-project/issues/221370
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/HLSLLib/InterlockedMin.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedMin.resources.32.test
@@ -231,9 +231,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Bug: https://github.com/llvm/llvm-project/issues/218034
-# XFAIL: Clang && (DirectX || Metal)
-
 # Bug: https://github.com/llvm/llvm-project/issues/217831
 # XFAIL: Clang && Vulkan
 

--- a/test/Feature/HLSLLib/InterlockedOr.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.32.test
@@ -219,9 +219,6 @@ DescriptorSets:
 ...
 #--- end
 
-# Unimplemented: https://github.com/llvm/llvm-project/issues/194930
-# XFAIL: Clang
-
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o

--- a/test/Feature/HLSLLib/InterlockedOr.resources.32.test
+++ b/test/Feature/HLSLLib/InterlockedOr.resources.32.test
@@ -219,6 +219,9 @@ DescriptorSets:
 ...
 #--- end
 
+# Bug: https://github.com/llvm/llvm-project/issues/221370
+# XFAIL: Clang && Vulkan
+
 # RUN: split-file %s %t
 # RUN: %dxc_target -T cs_6_5 -Fo %t.o %t/source.hlsl
 # RUN: %offloader %t/pipeline.yaml %t.o


### PR DESCRIPTION
These issues have been fixed and closed, so their XFAILs can be removed:
- https://github.com/llvm/llvm-project/issues/186154
- https://github.com/llvm/llvm-project/issues/218034
- https://github.com/llvm/llvm-project/issues/194930