### PR TITLE
Migrate AMD machine to frequent build

### DIFF
--- a/.github/workflows/pr-matrix.yaml
+++ b/.github/workflows/pr-matrix.yaml
@@ -19,7 +19,14 @@ jobs:
     permissions:
       contents: read
       actions: read
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable-default-tests') }}
+    # The label-gated AMD cells below also consume the frequent builds, so
+    # resolve when any of them can run, not only for the default cells.
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'disable-default-tests')
+      || contains(github.event.pull_request.labels.*.name, 'test-all')
+      || contains(github.event.pull_request.labels.*.name, 'test-lavapipe')
+      || contains(github.event.pull_request.labels.*.name, 'test-dx-all')
+      || contains(github.event.pull_request.labels.*.name, 'test-vk-all')
     uses: ./.github/workflows/resolve-frequent-builds.yaml
 
   # Consumes prebuilt LLVM/DXC rather than compiling them per cell, so these
@@ -80,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-amd, windows-nvidia, windows-qc]
+        SKU: [windows-nvidia, windows-qc]
         TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk, check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
         exclude:
           - { SKU: windows-nvidia, TestTarget: check-hlsl-d3d12 }
@@ -97,6 +104,28 @@ jobs:
       SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
+  Exec-Tests-Extra-AMD:
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+    if: contains( github.event.pull_request.labels.*.name, 'test-all')
+    needs: Resolve-Frequent-Builds
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-vk, check-hlsl-clang-d3d12, check-hlsl-clang-vk, check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
+
+    uses: ./.github/workflows/test-callable.yaml
+    with:
+      OS: windows
+      Arch: x64
+      SKU: windows-amd
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      LlvmRunId: ${{ needs.Resolve-Frequent-Builds.outputs.LlvmRunId }}
+      DxcRunId: ${{ needs.Resolve-Frequent-Builds.outputs.DxcRunId }}
+
   Exec-Tests-Extra-Lavapipe:
     permissions:
       contents: read
@@ -108,8 +137,8 @@ jobs:
       fail-fast: false
       matrix:
         # Lavapipe is only installed on the AMD (x64) and QC (arm64) workers.
-        # See docs/CI.md.
-        SKU: [windows-amd, windows-qc]
+        # See docs/CI.md. AMD runs in Exec-Tests-Extra-Lavapipe-AMD below.
+        SKU: [windows-qc]
         TestTarget: [check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
 
     uses: ./.github/workflows/build-and-test-callable.yaml
@@ -121,6 +150,30 @@ jobs:
       SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
+  Exec-Tests-Extra-Lavapipe-AMD:
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'test-lavapipe')
+      && !contains(github.event.pull_request.labels.*.name, 'test-all')
+    needs: Resolve-Frequent-Builds
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
+
+    uses: ./.github/workflows/test-callable.yaml
+    with:
+      OS: windows
+      Arch: x64
+      SKU: windows-amd
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      LlvmRunId: ${{ needs.Resolve-Frequent-Builds.outputs.LlvmRunId }}
+      DxcRunId: ${{ needs.Resolve-Frequent-Builds.outputs.DxcRunId }}
+
   Exec-Tests-Extra-DX-All:
     permissions:
       contents: read
@@ -131,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-amd, windows-qc]
+        SKU: [windows-qc]
         TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
 
     uses: ./.github/workflows/build-and-test-callable.yaml
@@ -143,6 +196,30 @@ jobs:
       SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
 
+  Exec-Tests-Extra-DX-All-AMD:
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'test-dx-all')
+      && !contains(github.event.pull_request.labels.*.name, 'test-all')
+    needs: Resolve-Frequent-Builds
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-d3d12, check-hlsl-clang-d3d12]
+
+    uses: ./.github/workflows/test-callable.yaml
+    with:
+      OS: windows
+      Arch: x64
+      SKU: windows-amd
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      LlvmRunId: ${{ needs.Resolve-Frequent-Builds.outputs.LlvmRunId }}
+      DxcRunId: ${{ needs.Resolve-Frequent-Builds.outputs.DxcRunId }}
+
   Exec-Tests-Extra-VK-All:
     permissions:
       contents: read
@@ -153,7 +230,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SKU: [windows-amd, windows-nvidia, windows-qc]
+        SKU: [windows-nvidia, windows-qc]
         TestTarget: [check-hlsl-vk, check-hlsl-clang-vk, check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
         exclude:
           - { SKU: windows-nvidia, TestTarget: check-hlsl-vk-lavapipe }
@@ -167,6 +244,30 @@ jobs:
       OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
       SplitBuild: true
       LLVM-ExtraCMakeArgs: -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DOFFLOADTEST_USE_CLANG_TIDY=ON
+
+  Exec-Tests-Extra-VK-All-AMD:
+    permissions:
+      contents: read
+      checks: write
+      actions: read
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'test-vk-all')
+      && !contains(github.event.pull_request.labels.*.name, 'test-all')
+    needs: Resolve-Frequent-Builds
+    strategy:
+      fail-fast: false
+      matrix:
+        TestTarget: [check-hlsl-vk, check-hlsl-clang-vk, check-hlsl-vk-lavapipe, check-hlsl-clang-vk-lavapipe]
+
+    uses: ./.github/workflows/test-callable.yaml
+    with:
+      OS: windows
+      Arch: x64
+      SKU: windows-amd
+      TestTarget: ${{ matrix.TestTarget }}
+      OffloadTest-branch: ${{ github.event.pull_request.head.sha }}
+      LlvmRunId: ${{ needs.Resolve-Frequent-Builds.outputs.LlvmRunId }}
+      DxcRunId: ${{ needs.Resolve-Frequent-Builds.outputs.DxcRunId }}
 
   Exec-Tests-MacOS:
     permissions:

--- a/docs/frequent-builder.md
+++ b/docs/frequent-builder.md
@@ -15,10 +15,13 @@ such as `(windows-intel, check-hlsl-d3d12)`. Each cell shows as one check on
 the PR.
 
 Migration is incremental. Today `pr-matrix.yaml` routes its default x64
-cells (`Exec-Tests-Windows`: `windows-intel` and `windows-nvidia`) this way;
-the warp, `test-all` and macOS cells still build their own toolchain via
-`build-and-test-callable.yaml` with `SplitBuild: true`. So "PRs never build
-LLVM or DXC" below describes the end state, not the current one.
+cells (`Exec-Tests-Windows`: `windows-intel` and `windows-nvidia`) this way,
+plus the `windows-amd` cells of the label-gated jobs (`Exec-Tests-Extra-AMD`
+and the `-DX-All-AMD`, `-VK-All-AMD` and `-Lavapipe-AMD` jobs); the warp,
+arm64, remaining `windows-nvidia` label-gated and macOS cells still build
+their own toolchain via `build-and-test-callable.yaml` with
+`SplitBuild: true`. So "PRs never build LLVM or DXC" below describes the end
+state, not the current one.
 
 The two are separate for **failure isolation**: with a single builder, a
 broken LLVM `main` also withholds the DXC artifact, and vice versa. Split,


### PR DESCRIPTION
Like https://github.com/llvm/offload-test-suite/pull/1436, this PR migrates the existing AMD SKU workflows over to the frequent build path.

QC is still on the legacy path since we dont have the frequent builder building Arm64 binaries yet. Since AMD was coupled with QC on special labelled runs, we need to split AMD out of QC and make 4 new job definitions for AMD specifically.

Assisted by: Github Copilot
Addresses: https://github.com/llvm/offload-test-suite/issues/1388